### PR TITLE
fix(ci): prevent contributor names from breaking release notes

### DIFF
--- a/.github/scripts/extract-changelog.sh
+++ b/.github/scripts/extract-changelog.sh
@@ -146,7 +146,7 @@ append_contributors() {
     printf "We appreciate the contributions from:\n\n"
     for name in "${contributor_lines[@]}"; do
         if [ -n "$name" ]; then
-            printf "- %s\n" "$name"
+            printf -- "- %s\n" "$name"
         fi
     done
 
@@ -172,7 +172,7 @@ append_contributors() {
         printf "\n## 🌟 Congratulations\n\n"
         printf "Congratulations to our new contributors:\n\n"
         for name in "${new_contributors[@]}"; do
-            printf "- %s\n" "$name"
+            printf -- "- %s\n" "$name"
         done
     fi
 }


### PR DESCRIPTION
## Summary
- Safeguard contributor bullet output in release notes against names that start with dashes

## Details
A recent workflow run failed because the release note generation script used plain `printf` for bullet lines, which treats names beginning with `-` as options. This update adds `printf --` when printing contributor and new-contributor bullets, ensuring the generated release notes are robust regardless of contributor name formatting and preventing the `printf: invalid option` failure seen during release note generation.