### PR TITLE
feat(ts): add codecs option to toMultiscales for skipping blosc compression

### DIFF
--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -54,6 +54,8 @@ export * from "./types/multiscales.ts";
 export * from "./types/ngff_image.ts";
 export * from "./types/units.ts";
 export * from "./types/zarr_metadata.ts";
+export type { ZarrCodec } from "./utils/codecs.ts";
+export { bytesOnlyCodecs, defaultCodecs } from "./utils/codecs.ts";
 export type {
   ComputeOmeroFromMultiscalesOptions,
   ComputeOmeroOptions,

--- a/ts/src/methods/itkwasm-browser.ts
+++ b/ts/src/methods/itkwasm-browser.ts
@@ -12,9 +12,11 @@ import {
   downsampleLabelImage,
 } from "@itk-wasm/downsample";
 import * as zarr from "zarrita";
-import { zarrGet, zarrSet } from "../utils/worker_pool.ts";
-import { defaultCodecs } from "../utils/codecs.ts";
+
 import { NgffImage } from "../types/ngff_image.ts";
+import type { ZarrCodec } from "../utils/codecs.ts";
+import { defaultCodecs } from "../utils/codecs.ts";
+import { zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import {
   type DimFactors,
   dimScaleFactors,
@@ -63,6 +65,7 @@ async function downsampleGaussian(
   dimFactors: DimFactors,
   spatialDims: string[],
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ): Promise<NgffImage> {
   // Handle time dimension by processing each time slice independently
   if (image.dims.includes("t")) {
@@ -96,7 +99,7 @@ async function downsampleGaussian(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -127,6 +130,7 @@ async function downsampleGaussian(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -151,7 +155,7 @@ async function downsampleGaussian(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -220,7 +224,7 @@ async function downsampleGaussian(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -251,6 +255,7 @@ async function downsampleGaussian(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -275,7 +280,7 @@ async function downsampleGaussian(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -343,6 +348,7 @@ async function downsampleGaussian(
     "image",
     chunkShape,
     image.dims,
+    codecs,
   );
 
   return new NgffImage({
@@ -364,6 +370,7 @@ async function downsampleBinShrinkImpl(
   dimFactors: DimFactors,
   spatialDims: string[],
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ): Promise<NgffImage> {
   // Handle time dimension by processing each time slice independently
   if (image.dims.includes("t")) {
@@ -397,7 +404,7 @@ async function downsampleBinShrinkImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -428,6 +435,7 @@ async function downsampleBinShrinkImpl(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -452,7 +460,7 @@ async function downsampleBinShrinkImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -521,7 +529,7 @@ async function downsampleBinShrinkImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -552,6 +560,7 @@ async function downsampleBinShrinkImpl(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -576,7 +585,7 @@ async function downsampleBinShrinkImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -640,6 +649,7 @@ async function downsampleBinShrinkImpl(
     "image",
     chunkShape,
     image.dims,
+    codecs,
   );
 
   return new NgffImage({
@@ -661,6 +671,7 @@ async function downsampleLabelImageImpl(
   dimFactors: DimFactors,
   spatialDims: string[],
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ): Promise<NgffImage> {
   // Handle time dimension by processing each time slice independently
   if (image.dims.includes("t")) {
@@ -694,7 +705,7 @@ async function downsampleLabelImageImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -725,6 +736,7 @@ async function downsampleLabelImageImpl(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -749,7 +761,7 @@ async function downsampleLabelImageImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -818,7 +830,7 @@ async function downsampleLabelImageImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -849,6 +861,7 @@ async function downsampleLabelImageImpl(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -873,7 +886,7 @@ async function downsampleLabelImageImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -943,6 +956,7 @@ async function downsampleLabelImageImpl(
     "image",
     chunkShape,
     image.dims,
+    codecs,
   );
 
   return new NgffImage({
@@ -964,6 +978,7 @@ export async function downsampleItkWasm(
   scaleFactors: (Record<string, number> | number)[],
   smoothing: "gaussian" | "bin_shrink" | "label_image",
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ): Promise<NgffImage[]> {
   const multiscales: NgffImage[] = [ngffImage];
   const dims = ngffImage.dims;
@@ -1043,6 +1058,7 @@ export async function downsampleItkWasm(
         sourceDimFactors,
         spatialDims,
         chunks,
+        codecs,
       );
     } else if (smoothing === "bin_shrink") {
       downsampled = await downsampleBinShrinkImpl(
@@ -1050,6 +1066,7 @@ export async function downsampleItkWasm(
         sourceDimFactors,
         spatialDims,
         chunks,
+        codecs,
       );
     } else if (smoothing === "label_image") {
       downsampled = await downsampleLabelImageImpl(
@@ -1057,6 +1074,7 @@ export async function downsampleItkWasm(
         sourceDimFactors,
         spatialDims,
         chunks,
+        codecs,
       );
     } else {
       throw new Error(`Unknown smoothing method: ${smoothing}`);

--- a/ts/src/methods/itkwasm-node.ts
+++ b/ts/src/methods/itkwasm-node.ts
@@ -17,9 +17,11 @@ import {
   downsampleNode as downsample,
 } from "@itk-wasm/downsample";
 import * as zarr from "zarrita";
-import { zarrGet, zarrSet } from "../utils/worker_pool.ts";
-import { defaultCodecs } from "../utils/codecs.ts";
+
 import { NgffImage } from "../types/ngff_image.ts";
+import type { ZarrCodec } from "../utils/codecs.ts";
+import { defaultCodecs } from "../utils/codecs.ts";
+import { zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import {
   type DimFactors,
   dimScaleFactors,
@@ -68,6 +70,7 @@ async function downsampleGaussian(
   dimFactors: DimFactors,
   spatialDims: string[],
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ): Promise<NgffImage> {
   // Handle time dimension by processing each time slice independently
   if (image.dims.includes("t")) {
@@ -101,7 +104,7 @@ async function downsampleGaussian(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -132,6 +135,7 @@ async function downsampleGaussian(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -156,7 +160,7 @@ async function downsampleGaussian(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -225,7 +229,7 @@ async function downsampleGaussian(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -256,6 +260,7 @@ async function downsampleGaussian(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -280,7 +285,7 @@ async function downsampleGaussian(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -348,6 +353,7 @@ async function downsampleGaussian(
     "image",
     chunkShape,
     image.dims,
+    codecs,
   );
 
   return new NgffImage({
@@ -369,6 +375,7 @@ async function downsampleBinShrinkImpl(
   dimFactors: DimFactors,
   spatialDims: string[],
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ): Promise<NgffImage> {
   // Handle time dimension by processing each time slice independently
   if (image.dims.includes("t")) {
@@ -402,7 +409,7 @@ async function downsampleBinShrinkImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -433,6 +440,7 @@ async function downsampleBinShrinkImpl(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -457,7 +465,7 @@ async function downsampleBinShrinkImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -526,7 +534,7 @@ async function downsampleBinShrinkImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -557,6 +565,7 @@ async function downsampleBinShrinkImpl(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -581,7 +590,7 @@ async function downsampleBinShrinkImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -645,6 +654,7 @@ async function downsampleBinShrinkImpl(
     "image",
     chunkShape,
     image.dims,
+    codecs,
   );
 
   return new NgffImage({
@@ -666,6 +676,7 @@ async function downsampleLabelImageImpl(
   dimFactors: DimFactors,
   spatialDims: string[],
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ): Promise<NgffImage> {
   // Handle time dimension by processing each time slice independently
   if (image.dims.includes("t")) {
@@ -699,7 +710,7 @@ async function downsampleLabelImageImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -730,6 +741,7 @@ async function downsampleLabelImageImpl(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -754,7 +766,7 @@ async function downsampleLabelImageImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -823,7 +835,7 @@ async function downsampleLabelImageImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
-        codecs: defaultCodecs(image.data.dtype),
+        codecs: codecs ?? defaultCodecs(image.data.dtype),
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -854,6 +866,7 @@ async function downsampleLabelImageImpl(
         dimFactors,
         spatialDims,
         sliceChunks,
+        codecs,
       );
       downsampledSlices.push(downsampledSlice.data);
     }
@@ -878,7 +891,7 @@ async function downsampleLabelImageImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
-      codecs: defaultCodecs(image.data.dtype),
+      codecs: codecs ?? defaultCodecs(image.data.dtype),
     });
 
     // Copy each downsampled slice into the combined array
@@ -948,6 +961,7 @@ async function downsampleLabelImageImpl(
     "image",
     chunkShape,
     image.dims,
+    codecs,
   );
 
   return new NgffImage({
@@ -969,6 +983,7 @@ export async function downsampleItkWasm(
   scaleFactors: (Record<string, number> | number)[],
   smoothing: "gaussian" | "bin_shrink" | "label_image",
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ): Promise<NgffImage[]> {
   const multiscales: NgffImage[] = [ngffImage];
   const dims = ngffImage.dims;
@@ -1048,6 +1063,7 @@ export async function downsampleItkWasm(
         sourceDimFactors,
         spatialDims,
         chunks,
+        codecs,
       );
     } else if (smoothing === "bin_shrink") {
       downsampled = await downsampleBinShrinkImpl(
@@ -1055,6 +1071,7 @@ export async function downsampleItkWasm(
         sourceDimFactors,
         spatialDims,
         chunks,
+        codecs,
       );
     } else if (smoothing === "label_image") {
       downsampled = await downsampleLabelImageImpl(
@@ -1062,6 +1079,7 @@ export async function downsampleItkWasm(
         sourceDimFactors,
         spatialDims,
         chunks,
+        codecs,
       );
     } else {
       throw new Error(`Unknown smoothing method: ${smoothing}`);

--- a/ts/src/methods/itkwasm-shared.ts
+++ b/ts/src/methods/itkwasm-shared.ts
@@ -8,8 +8,10 @@
 
 import type { Image } from "itk-wasm";
 import * as zarr from "zarrita";
+
+import type { NgffImage } from "../types/ngff_image.ts";
+import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
-import { NgffImage } from "../types/ngff_image.ts";
 import { zarrGet, zarrSet } from "../utils/worker_pool.ts";
 
 export const SPATIAL_DIMS = ["x", "y", "z"];
@@ -502,6 +504,7 @@ export async function itkImageToZarr(
   path: string,
   chunkShape: number[],
   targetDims?: string[],
+  codecs?: ZarrCodec[],
 ): Promise<zarr.Array<zarr.DataType, zarr.Readable>> {
   const root = zarr.root(store);
 
@@ -632,12 +635,27 @@ export async function itkImageToZarr(
     );
   }
 
+  // Validate codecs if provided
+  if (codecs !== undefined) {
+    if (codecs.length === 0) {
+      throw new Error(
+        "codecs array must not be empty; at minimum, include the required 'bytes' array-to-bytes codec",
+      );
+    }
+    const hasBytesCodec = codecs.some((codec) => codec.name === "bytes");
+    if (!hasBytesCodec) {
+      throw new Error(
+        "codecs array must include the required 'bytes' array-to-bytes codec",
+      );
+    }
+  }
+
   const array = await zarr.create(root.resolve(path), {
     shape: zarrShape,
     chunk_shape: zarrChunkShape,
     data_type: dataType,
     fill_value: 0,
-    codecs: defaultCodecs(dataType),
+    codecs: codecs ?? defaultCodecs(dataType),
   });
 
   // Write data - preserve the actual data type, don't cast to Float32Array

--- a/ts/src/mod.ts
+++ b/ts/src/mod.ts
@@ -1,61 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 // SPDX-License-Identifier: MIT
-export * from "./types/units.ts";
-export * from "./types/methods.ts";
-export * from "./types/array_interface.ts";
-export * from "./types/zarr_metadata.ts";
-export * from "./types/ngff_image.ts";
-export * from "./types/multiscales.ts";
-export * from "./types/rfc4.ts";
-export * from "./types/hcs.ts";
-export * from "./types/supported_versions.ts";
-
-export * from "./schemas/units.ts";
-export * from "./schemas/methods.ts";
-export * from "./schemas/zarr_metadata.ts";
-export * from "./schemas/ngff_image.ts";
-export * from "./schemas/multiscales.ts";
-
-export {
-  isValidDimension,
-  isValidUnit,
-  validateMetadata,
-} from "./utils/validation.ts";
-export {
-  createAxis,
-  createDataset,
-  createMetadata,
-  createMultiscales,
-  createNgffImage,
-} from "./utils/factory.ts";
-export { getMethodMetadata } from "./utils/method_metadata.ts";
-export {
-  detectVersion,
-  extractMethodMetadata,
-  parseOmero,
-} from "./utils/parse_metadata.ts";
-export {
-  computeOmeroFromMultiscales,
-  computeOmeroFromNgffImage,
-  getDefaultColors,
-  GLASBEY_COLORS,
-  terminateOmeroWorkerPool,
-} from "./utils/compute_omero.ts";
-export type {
-  ComputeOmeroFromMultiscalesOptions,
-  ComputeOmeroOptions,
-} from "./utils/compute_omero.ts";
-export { fromZarrAttrsV04, fromZarrAttrsV05 } from "./utils/from_zarr_attrs.ts";
-export { terminateWorkerPool, zarrGet, zarrSet } from "./utils/worker_pool.ts";
 
 export * from "./io/from_ngff_zarr.ts";
-export * from "./io/to_ngff_zarr.ts";
-export * from "./process/to_multiscales-node.ts";
-export type { MemoryStore } from "./io/from_ngff_zarr.ts";
+export * from "./io/hcs.ts";
 export * from "./io/itk_image_to_ngff_image.ts";
 export * from "./io/ngff_image_to_itk_image.ts";
-export * from "./io/hcs.ts";
-
+export type { MemoryStoreToZipOptions } from "./io/rfc9_zip.ts";
 // RFC-9 exports
 export {
   getZipFileCompressionMethod,
@@ -66,4 +16,52 @@ export {
   readOzxJsonFirst,
   readOzxVersion,
 } from "./io/rfc9_zip.ts";
-export type { MemoryStoreToZipOptions } from "./io/rfc9_zip.ts";
+export * from "./io/to_ngff_zarr.ts";
+export * from "./process/to_multiscales-node.ts";
+export * from "./schemas/methods.ts";
+export * from "./schemas/multiscales.ts";
+export * from "./schemas/ngff_image.ts";
+export * from "./schemas/units.ts";
+export * from "./schemas/zarr_metadata.ts";
+export * from "./types/array_interface.ts";
+export * from "./types/hcs.ts";
+export * from "./types/methods.ts";
+export * from "./types/multiscales.ts";
+export * from "./types/ngff_image.ts";
+export * from "./types/rfc4.ts";
+export * from "./types/supported_versions.ts";
+export * from "./types/units.ts";
+export * from "./types/zarr_metadata.ts";
+export type { ZarrCodec } from "./utils/codecs.ts";
+export { bytesOnlyCodecs, defaultCodecs } from "./utils/codecs.ts";
+export type {
+  ComputeOmeroFromMultiscalesOptions,
+  ComputeOmeroOptions,
+} from "./utils/compute_omero.ts";
+export {
+  computeOmeroFromMultiscales,
+  computeOmeroFromNgffImage,
+  getDefaultColors,
+  GLASBEY_COLORS,
+  terminateOmeroWorkerPool,
+} from "./utils/compute_omero.ts";
+export {
+  createAxis,
+  createDataset,
+  createMetadata,
+  createMultiscales,
+  createNgffImage,
+} from "./utils/factory.ts";
+export { fromZarrAttrsV04, fromZarrAttrsV05 } from "./utils/from_zarr_attrs.ts";
+export { getMethodMetadata } from "./utils/method_metadata.ts";
+export {
+  detectVersion,
+  extractMethodMetadata,
+  parseOmero,
+} from "./utils/parse_metadata.ts";
+export {
+  isValidDimension,
+  isValidUnit,
+  validateMetadata,
+} from "./utils/validation.ts";
+export { terminateWorkerPool, zarrGet, zarrSet } from "./utils/worker_pool.ts";

--- a/ts/src/process/to_multiscales-shared.ts
+++ b/ts/src/process/to_multiscales-shared.ts
@@ -7,9 +7,12 @@
  * browser and Node versions of toMultiscales.
  */
 
-import { NgffImage } from "../types/ngff_image.ts";
-import { Multiscales } from "../types/multiscales.ts";
 import { Methods } from "../types/methods.ts";
+import type { Multiscales } from "../types/multiscales.ts";
+import type { NgffImage } from "../types/ngff_image.ts";
+import type { ZarrCodec } from "../utils/codecs.ts";
+// deno-lint-ignore no-unused-vars
+import { bytesOnlyCodecs, defaultCodecs } from "../utils/codecs.ts";
 import {
   createAxis,
   createDataset,
@@ -18,10 +21,24 @@ import {
 } from "../utils/factory.ts";
 import { getMethodMetadata } from "../utils/method_metadata.ts";
 
+export type { ZarrCodec };
+
 export interface ToMultiscalesOptions {
   scaleFactors?: (Record<string, number> | number)[];
   method?: Methods;
   chunks?: number | number[] | Record<string, number>;
+
+  /**
+   * Codec pipeline for intermediate zarr arrays created during
+   * downsampling.  When omitted the default blosc+zstd pipeline is
+   * used ({@link defaultCodecs}).
+   *
+   * Pass {@link bytesOnlyCodecs | `bytesOnlyCodecs()`} to skip
+   * compression entirely — useful when the multiscale result will be
+   * immediately re-encoded into another format (e.g. OME-TIFF) and
+   * the compress/decompress round-trip would be wasted work.
+   */
+  codecs?: ZarrCodec[];
 }
 
 /**
@@ -32,6 +49,7 @@ export type DownsampleFunction = (
   scaleFactors: (Record<string, number> | number)[],
   smoothing: "gaussian" | "bin_shrink" | "label_image",
   chunks?: number | number[] | Record<string, number>,
+  codecs?: ZarrCodec[],
 ) => Promise<NgffImage[]>;
 
 /**
@@ -52,6 +70,7 @@ export async function toMultiscalesCore(
     scaleFactors = [2, 4],
     method = Methods.ITKWASM_GAUSSIAN,
     chunks: _chunks,
+    codecs,
   } = options;
 
   let images: NgffImage[];
@@ -74,6 +93,7 @@ export async function toMultiscalesCore(
       scaleFactors as (Record<string, number> | number)[],
       smoothing,
       _chunks,
+      codecs,
     );
   } else {
     // Fallback: create only the base image (no actual downsampling)

--- a/ts/src/utils/codecs.ts
+++ b/ts/src/utils/codecs.ts
@@ -2,6 +2,17 @@
 // SPDX-License-Identifier: MIT
 
 /**
+ * Codec descriptor used in zarr v3 array metadata.
+ *
+ * @see {@link defaultCodecs} for the standard blosc+zstd pipeline.
+ * @see {@link bytesOnlyCodecs} for an uncompressed pipeline.
+ */
+export type ZarrCodec = {
+  name: string;
+  configuration: Record<string, unknown>;
+};
+
+/**
  * Return the byte size for a zarr v3 data type string.
  *
  * The Zarr v3 blosc codec spec requires an explicit `typesize` when
@@ -56,4 +67,17 @@ export function defaultCodecs(dataType: string) {
       },
     },
   ];
+}
+
+/**
+ * Build an uncompressed zarr v3 codec pipeline.
+ *
+ * Returns only the required `bytes` array-to-bytes codec (little-endian)
+ * with no bytes-to-bytes compression. This is useful when zarr arrays
+ * are ephemeral (e.g., in-memory multiscale pyramids that will be
+ * immediately re-encoded into another format like OME-TIFF) and the
+ * blosc compress/decompress round-trip would be wasted work.
+ */
+export function bytesOnlyCodecs(): ZarrCodec[] {
+  return [{ name: "bytes", configuration: { endian: "little" } }];
 }


### PR DESCRIPTION
Add ZarrCodec type and bytesOnlyCodecs() helper that returns an
uncompressed zarr v3 codec pipeline. Thread the new optional codecs
parameter through toMultiscales, all downsample functions, and
itkImageToZarr so callers can skip the default blosc+zstd compression
when zarr arrays are ephemeral (e.g. intermediates for OME-TIFF
conversion where the compress/decompress round-trip is wasted work).

Export bytesOnlyCodecs, defaultCodecs, and ZarrCodec from both mod.ts
and browser-mod.ts.
