### PR TITLE
fix(py): normalize accelerated ITK-Wasm downsampling output

### DIFF
--- a/py/ngff_zarr/methods/_itkwasm.py
+++ b/py/ngff_zarr/methods/_itkwasm.py
@@ -75,7 +75,10 @@ def _itkwasm_blur_and_downsample(
         msg = f"Unknown smoothing method: {smoothing}"
         raise ValueError(msg)
 
-    data = downsampled.data
+    # Accelerator backends such as cuCIM may return a CuPy array.  The dask
+    # graph built by this module is NumPy-backed, so normalize the block before
+    # NumPy operations and dask block assembly consume it.
+    data = itkwasm.array_like_to_numpy_array(downsampled.data)
     if needs_float_workaround:
         if np.issubdtype(original_dtype, np.unsignedinteger):
             data = np.clip(np.rint(data), 0, np.iinfo(original_dtype).max)
@@ -105,7 +108,7 @@ def _itkwasm_chunk_bin_shrink(
         return None
 
     downsampled = downsample_bin_shrink(image, shrink_factors=shrink_factors)
-    return downsampled.data
+    return itkwasm.array_like_to_numpy_array(downsampled.data)
 
 
 def _itkwasm_chunk_bin_shrink_nd(

--- a/py/test/test_issue_577.py
+++ b/py/test/test_issue_577.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Regression tests for GH #577.
+
+Issue: https://github.com/fideus-labs/ngff-zarr/issues/577
+
+Accelerated itkwasm backends such as cuCIM can return CuPy arrays.  The
+downsampling dask graph is NumPy-backed, so each backend result must be moved
+to host memory before NumPy operations or dask block assembly consume it.
+"""
+
+from types import SimpleNamespace
+
+import itkwasm
+import itkwasm_downsample
+import numpy as np
+from ngff_zarr.methods._itkwasm import (
+    _itkwasm_blur_and_downsample,
+    _itkwasm_chunk_bin_shrink,
+)
+
+
+def test_itkwasm_gaussian_normalizes_accelerator_output(monkeypatch):
+    accelerator_data = object()
+    host_data = np.full((4, 4), 2.4, dtype=np.float32)
+    normalized = []
+
+    def fake_downsample(*args, **kwargs):
+        return SimpleNamespace(data=accelerator_data)
+
+    def fake_to_numpy(data):
+        normalized.append(data)
+        return host_data
+
+    monkeypatch.setattr(itkwasm_downsample, "downsample", fake_downsample)
+    monkeypatch.setattr(itkwasm, "array_like_to_numpy_array", fake_to_numpy)
+
+    result = _itkwasm_blur_and_downsample(
+        np.full((8, 8), 2, dtype=np.uint8),
+        shrink_factors=[2, 2],
+        kernel_radius=[0, 0],
+        smoothing="gaussian",
+    )
+
+    assert normalized == [accelerator_data]
+    assert result.dtype == np.uint8
+    np.testing.assert_array_equal(result, np.full((4, 4), 2, dtype=np.uint8))
+
+
+def test_itkwasm_bin_shrink_normalizes_accelerator_output(monkeypatch):
+    accelerator_data = object()
+    host_data = np.arange(16, dtype=np.uint8).reshape((4, 4))
+    normalized = []
+
+    def fake_downsample(*args, **kwargs):
+        return SimpleNamespace(data=accelerator_data)
+
+    def fake_to_numpy(data):
+        normalized.append(data)
+        return host_data
+
+    monkeypatch.setattr(itkwasm_downsample, "downsample_bin_shrink", fake_downsample)
+    monkeypatch.setattr(itkwasm, "array_like_to_numpy_array", fake_to_numpy)
+
+    result = _itkwasm_chunk_bin_shrink(
+        np.ones((8, 8), dtype=np.uint8),
+        shrink_factors=[2, 2],
+    )
+
+    assert normalized == [accelerator_data]
+    assert result is host_data


### PR DESCRIPTION
## Summary

- normalize ITK-Wasm backend results to NumPy before NumPy operations and
  Dask block assembly consume them
- add regression coverage for opaque accelerator-backed Gaussian and
  bin-shrink results

## Context

Installing the documented cuCIM backend currently exposes two failures:

1. cuCIM 0.2.0 calls the WASI bin-shrink pipeline with
   `information_only=True`, which traps in current WASI releases. This is an
   upstream ITK-Wasm defect.
2. Once that upstream call is isolated, cuCIM returns CuPy arrays to a
   NumPy-backed Dask graph. Dask refuses the implicit CuPy-to-NumPy conversion.

This PR addresses the second failure at the boundary owned by ngff-zarr. The
WASM trap is addressed separately in an upstream ITK-Wasm PR:
https://github.com/InsightSoftwareConsortium/ITK-Wasm/pull/1545

Related to #577. The issue should remain open until the corresponding upstream
fix is released.

## Validation

- `pixi run --as-is test`: **719 passed, 3 skipped**
- issue #577 and related issue #488 tests: **11 passed**
- file-scoped pre-commit hooks: **passed**
- real NVIDIA GPU reproduction with the upstream metadata-only defect isolated:
  Gaussian and bin-shrink both produced `(1, 1, 8, 32, 32)` `uint8` NumPy
  output

Repository-wide lint currently reformats and then fails on unrelated RFC-5
files already present on `upstream/main`; none of those changes are included in
this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved downsampling reliability by consistently converting accelerated results to NumPy arrays before further processing.
  * Prevented errors caused by accelerator-backed array types during image operations.
* **Tests**
  * Added regression coverage for accelerated downsampling and bin-shrink workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->