### PR TITLE
feat(py,ts): write an image and its transformation into one store

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ A lean and kind
 - [Sharded Zarr] stores
 - Optional writing via zarr-python 2, zarr-python 3, [tensorstore] or zarrita (TypeScript)
 - [Anatomical orientation metadata](./rfc4.md) (RFC-4)
+- [Coordinate systems and transformations](./rfc5.md) (RFC-5)
 - **OME-Zarr Zip (.ozx) file support** for single-file OME-Zarr datasets (RFC-9)
 - **High Content Screening (HCS) support** for plate and well data
 - **TIFF/OME-TIFF support** with automatic metadata extraction and multi-series conversion
@@ -47,6 +48,7 @@ python.md
 typescript.md
 cli.md
 mcp.md
+rfc5.md
 hcs.md
 tiff.md
 lif.md

--- a/docs/python.md
+++ b/docs/python.md
@@ -188,7 +188,7 @@ field = nz.NgffImage(
 )
 
 multiscales = nz.to_multiscales(field)
-nz.to_ngff_zarr("displacement.ome.zarr", multiscales, version="0.6")
+nz.to_ome_zarr("displacement.ome.zarr", multiscales, version="0.6")
 ```
 
 The axis type round-trips through reading and writing. It can also be set after

--- a/docs/python.md
+++ b/docs/python.md
@@ -200,6 +200,10 @@ transformations (`ngff_zarr.v06.zarr_metadata.Displacements` and `Coordinates`)
 that reference such a field from a registered image. Like the other v0.6
 transforms, they round-trip through reading and writing.
 
+See [RFC-5: Coordinate Systems and Transformations](./rfc5.md) for the full
+transformation model, including how to write an image and its transformation
+(an affine, or a displacement/coordinate field) into a single store.
+
 ## Read an OME-Zarr
 
 To read an OME-Zarr file, use [`from_ngff_zarr`], which returns the

--- a/docs/rfc5.md
+++ b/docs/rfc5.md
@@ -1,0 +1,269 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+# RFC-5: Coordinate Systems and Transformations
+
+[RFC-5] extends OME-NGFF with named **coordinate systems** and a richer set of
+**coordinate transformations** — identity, scale, translation, rotation,
+affine, transformation sequences, and array-backed *displacement* and
+*coordinate* fields. This is the OME-Zarr v0.6 data model. `ngff-zarr` reads and
+writes it in both the Python and TypeScript packages.
+
+## Overview
+
+In v0.4/v0.5 each dataset carries only a scale and translation. RFC-5 (v0.6)
+generalizes this: a multiscales document declares one or more
+`coordinateSystems` (the intrinsic pixel system plus any output systems), and
+maps between them with `coordinateTransformations`. Transformations may live on
+a dataset (the per-scale scale/translation) or at the top level of the
+multiscales (an affine, a displacement field, a sequence, ...), mapping the
+image into another coordinate system.
+
+Two of these transformations reference their parameters as an array stored in
+the Zarr hierarchy rather than inline:
+
+- **`displacements`** — a vector field added to each coordinate.
+- **`coordinates`** — a vector field of absolute output coordinates.
+
+The field is itself an ordinary OME-Zarr image, so it can be written into the
+**same store** as the image it transforms. That end-to-end pattern is the focus
+of the [Write an image and its transformation into one store](#write-an-image-and-its-transformation-into-one-store)
+section below.
+
+## Displacement and coordinate fields
+
+A displacement (or coordinate) field is a multiscale image whose
+vector-component axis, in the channel position, carries `type="displacement"`
+(or `type="coordinate"`) instead of `type="channel"`. Like a channel/component
+axis it is `discrete` — it indexes vector components rather than a continuous
+coordinate. Set the type with the `axes_types` argument of `NgffImage`, mapping
+a dimension name to its axis type:
+
+```python
+import dask.array as da
+import numpy as np
+import ngff_zarr as nz
+
+# A 2-component displacement field over a yx image: the "c" dimension holds the
+# (y, x) displacement vector, one component per output spatial axis.
+data = da.from_array(np.zeros((2, 256, 256), dtype=np.float32))
+field = nz.NgffImage(
+    data=data,
+    dims=("c", "y", "x"),
+    scale={"c": 1.0, "y": 1.0, "x": 1.0},
+    translation={"c": 0.0, "y": 0.0, "x": 0.0},
+    axes_types={"c": "displacement"},
+)
+
+multiscales = nz.to_multiscales(field, scale_factors=[])
+nz.to_ngff_zarr("displacement.ome.zarr", multiscales, version="0.6")
+```
+
+The axis type round-trips through reading and writing. It can also be set after
+the fact by editing the metadata directly, for example
+`multiscales.metadata.intrinsic_coordinate_system.axes[0].type = "displacement"`.
+
+## Transformations
+
+The transformation data classes live in `ngff_zarr.v06.zarr_metadata`:
+
+| Class | `type` | Parameters |
+| --- | --- | --- |
+| `Identity` | `identity` | — |
+| `Scale` | `scale` | `scale: list[float]` |
+| `Translation` | `translation` | `translation: list[float]` |
+| `Rotation` | `rotation` | `rotation: list[list[float]]` |
+| `Affine` | `affine` | `affine: list[list[float]]` |
+| `Displacements` | `displacements` | `path: str`, `interpolation: str` |
+| `Coordinates` | `coordinates` | `path: str`, `interpolation: str` |
+| `TransformSequence` | `sequence` | `transformations: list[Transform]` |
+
+Every transform has an `input` and `output`, each a
+`CoordinateSystemIdentifier` naming a coordinate system (`name=`) or referencing
+a dataset (`path=`). `Displacements`/`Coordinates` additionally carry a `path`
+pointing at the field array within the store.
+
+Inline transforms (affine, rotation, scale, ...) are stored directly in the
+multiscales metadata, so a single `to_ngff_zarr` call writes both the image
+pixel data and the transformation:
+
+```python
+import numpy as np
+import ngff_zarr as nz
+from ngff_zarr.v06.zarr_metadata import (
+    Affine,
+    Axis,
+    CoordinateSystem,
+    CoordinateSystemIdentifier,
+)
+
+array = np.random.random((64, 64, 64)).astype(np.float32)
+image = nz.to_ngff_image(array, dims=["z", "y", "x"])
+multiscales = nz.to_multiscales(image, scale_factors=[])
+
+# An affine that maps the intrinsic pixel system to an "output" system.
+output_cs = CoordinateSystem(
+    name="output",
+    axes=[Axis(name=d, type="space") for d in ("z", "y", "x")],
+)
+affine = Affine(
+    affine=[
+        [1.0, 0.0, 0.0, 5.0],
+        [0.0, 1.0, 0.0, 10.0],
+        [0.0, 0.0, 1.0, 15.0],
+    ],
+    input=CoordinateSystemIdentifier(
+        name=multiscales.metadata.intrinsic_coordinate_system.name
+    ),
+    output=CoordinateSystemIdentifier(name=output_cs.name),
+    name="to_output",
+)
+multiscales.metadata.coordinateSystems.append(output_cs)
+multiscales.metadata.coordinateTransformations = [affine]
+
+nz.to_ngff_zarr("affine.ome.zarr", multiscales, version="0.6")
+```
+
+## Write an image and its transformation into one store
+
+A `displacements` or `coordinates` transform points at a field array by `path`.
+To keep the image and the field it references together, write the field as an
+OME-Zarr image into a subgroup of the same store, then reference it from the
+image's transform.
+
+Because the store metadata is consolidated after the last write, **write the
+field subgroup first, then the image at the store root with `overwrite=False`**.
+The final write consolidates metadata for the whole store, so the field is
+discoverable under its `path`.
+
+```python
+import dask.array as da
+import numpy as np
+import ngff_zarr as nz
+from ngff_zarr.v06.zarr_metadata import (
+    Axis,
+    CoordinateSystem,
+    CoordinateSystemIdentifier,
+    Displacements,
+)
+
+store = "warped.ome.zarr"
+field_path = "displacement_field"
+
+# The primary image.
+image = nz.to_ngff_image(
+    np.random.random((256, 256)).astype(np.float32), dims=["y", "x"]
+)
+multiscales = nz.to_multiscales(image, scale_factors=[])
+
+# The displacement field, an image with a displacement component axis.
+field = nz.NgffImage(
+    data=da.from_array(np.zeros((2, 256, 256), dtype=np.float32)),
+    dims=("c", "y", "x"),
+    scale={"c": 1.0, "y": 1.0, "x": 1.0},
+    translation={"c": 0.0, "y": 0.0, "x": 0.0},
+    axes_types={"c": "displacement"},
+)
+field_multiscales = nz.to_multiscales(field, scale_factors=[])
+
+# A displacements transform whose `path` resolves to the field subgroup.
+output_cs = CoordinateSystem(
+    name="output",
+    axes=[Axis(name="y", type="space"), Axis(name="x", type="space")],
+)
+transform = Displacements(path=field_path, interpolation="linear")
+transform.input = CoordinateSystemIdentifier(
+    name=multiscales.metadata.intrinsic_coordinate_system.name
+)
+transform.output = CoordinateSystemIdentifier(name=output_cs.name)
+transform.name = "warp"
+multiscales.metadata.coordinateSystems.append(output_cs)
+multiscales.metadata.coordinateTransformations = [transform]
+
+# Write the field subgroup first, then the image at the store root.
+nz.to_ngff_zarr(f"{store}/{field_path}", field_multiscales, version="0.6")
+nz.to_ngff_zarr(store, multiscales, version="0.6", overwrite=False)
+```
+
+Reading back resolves both the image and the field from the one store:
+
+```python
+imported = nz.from_ngff_zarr(store)
+transform = imported.metadata.coordinateTransformations[0]
+assert transform.path == field_path
+
+field = nz.from_ngff_zarr(f"{store}/{transform.path}")
+axes = field.metadata.intrinsic_coordinate_system.axes
+assert [a.type for a in axes] == ["displacement", "space", "space"]
+```
+
+Use `Coordinates` instead of `Displacements` (and `axes_types={"c":
+"coordinate"}` on the field) for an absolute coordinate field; the store layout
+is identical.
+
+## TypeScript
+
+The TypeScript package (`@fideus-labs/ngff-zarr`) mirrors the Python API. Field
+axis types are set with the `axesTypes` option, and the same field-first,
+`overwrite: false` ordering writes an image and its field into one store:
+
+```typescript
+import {
+  createAxis,
+  createCoordinateSystem,
+  fromNgffZarr,
+  toMultiscales,
+  toNgffImage,
+  toNgffZarr,
+  type V06Transform,
+} from "@fideus-labs/ngff-zarr";
+
+const store = "warped.ome.zarr";
+const fieldPath = "displacement_field";
+
+const image = await toNgffImage(new Float32Array(256 * 256), {
+  dims: ["y", "x"],
+  shape: [256, 256],
+});
+const multiscales = await toMultiscales(image, { scaleFactors: [] });
+
+const field = await toNgffImage(new Float32Array(2 * 256 * 256), {
+  dims: ["c", "y", "x"],
+  shape: [2, 256, 256],
+  axesTypes: { c: "displacement" },
+});
+const fieldMultiscales = await toMultiscales(field, { scaleFactors: [] });
+
+const intrinsic = multiscales.metadata.coordinateSystems![0];
+const outputCs = createCoordinateSystem("output", [
+  createAxis("y", "space"),
+  createAxis("x", "space"),
+]);
+multiscales.metadata.coordinateSystems!.push(outputCs);
+multiscales.metadata.coordinateTransformations = [{
+  type: "displacements",
+  path: fieldPath,
+  interpolation: "linear",
+  input: { name: intrinsic.name },
+  output: { name: outputCs.name },
+  name: "warp",
+} as V06Transform];
+
+// Write the field subgroup first, then the image at the store root.
+await toNgffZarr(`${store}/${fieldPath}`, fieldMultiscales, { version: "0.6" });
+await toNgffZarr(store, multiscales, { version: "0.6", overwrite: false });
+
+const imported = await fromNgffZarr(store, { version: "0.6" });
+const transform = imported.metadata.coordinateTransformations![0];
+const field2 = await fromNgffZarr(`${store}/${(transform as { path: string }).path}`, {
+  version: "0.6",
+});
+```
+
+## Compatibility
+
+The v0.6 data model requires a Zarr v3 store, so writing `version="0.6"` needs
+zarr-python >= 3.0.0b1. Reading v0.1–v0.5 stores is unchanged; on read, older
+metadata is converted into the v0.6 data model (a single `intrinsic` coordinate
+system with per-dataset scale/translation sequences).
+
+[RFC-5]: https://ngff.openmicroscopy.org/rfc/5/index.html

--- a/docs/rfc5.md
+++ b/docs/rfc5.md
@@ -55,7 +55,7 @@ field = nz.NgffImage(
 )
 
 multiscales = nz.to_multiscales(field, scale_factors=[])
-nz.to_ngff_zarr("displacement.ome.zarr", multiscales, version="0.6")
+nz.to_ome_zarr("displacement.ome.zarr", multiscales, version="0.6")
 ```
 
 The axis type round-trips through reading and writing. It can also be set after
@@ -83,7 +83,7 @@ a dataset (`path=`). `Displacements`/`Coordinates` additionally carry a `path`
 pointing at the field array within the store.
 
 Inline transforms (affine, rotation, scale, ...) are stored directly in the
-multiscales metadata, so a single `to_ngff_zarr` call writes both the image
+multiscales metadata, so a single `to_ome_zarr` call writes both the image
 pixel data and the transformation:
 
 ```python
@@ -120,7 +120,7 @@ affine = Affine(
 multiscales.metadata.coordinateSystems.append(output_cs)
 multiscales.metadata.coordinateTransformations = [affine]
 
-nz.to_ngff_zarr("affine.ome.zarr", multiscales, version="0.6")
+nz.to_ome_zarr("affine.ome.zarr", multiscales, version="0.6")
 ```
 
 ## Write an image and its transformation into one store
@@ -180,18 +180,18 @@ multiscales.metadata.coordinateSystems.append(output_cs)
 multiscales.metadata.coordinateTransformations = [transform]
 
 # Write the field subgroup first, then the image at the store root.
-nz.to_ngff_zarr(f"{store}/{field_path}", field_multiscales, version="0.6")
-nz.to_ngff_zarr(store, multiscales, version="0.6", overwrite=False)
+nz.to_ome_zarr(f"{store}/{field_path}", field_multiscales, version="0.6")
+nz.to_ome_zarr(store, multiscales, version="0.6", overwrite=False)
 ```
 
 Reading back resolves both the image and the field from the one store:
 
 ```python
-imported = nz.from_ngff_zarr(store)
+imported = nz.from_ome_zarr(store)
 transform = imported.metadata.coordinateTransformations[0]
 assert transform.path == field_path
 
-field = nz.from_ngff_zarr(f"{store}/{transform.path}")
+field = nz.from_ome_zarr(f"{store}/{transform.path}")
 axes = field.metadata.intrinsic_coordinate_system.axes
 assert [a.type for a in axes] == ["displacement", "space", "space"]
 ```
@@ -210,10 +210,10 @@ axis types are set with the `axesTypes` option, and the same field-first,
 import {
   createAxis,
   createCoordinateSystem,
-  fromNgffZarr,
+  fromOmeZarr,
   toMultiscales,
   toNgffImage,
-  toNgffZarr,
+  toOmeZarr,
   type V06Transform,
 } from "@fideus-labs/ngff-zarr";
 
@@ -249,12 +249,12 @@ multiscales.metadata.coordinateTransformations = [{
 } as V06Transform];
 
 // Write the field subgroup first, then the image at the store root.
-await toNgffZarr(`${store}/${fieldPath}`, fieldMultiscales, { version: "0.6" });
-await toNgffZarr(store, multiscales, { version: "0.6", overwrite: false });
+await toOmeZarr(`${store}/${fieldPath}`, fieldMultiscales, { version: "0.6" });
+await toOmeZarr(store, multiscales, { version: "0.6", overwrite: false });
 
-const imported = await fromNgffZarr(store, { version: "0.6" });
+const imported = await fromOmeZarr(store, { version: "0.6" });
 const transform = imported.metadata.coordinateTransformations![0];
-const field2 = await fromNgffZarr(`${store}/${(transform as { path: string }).path}`, {
+const field2 = await fromOmeZarr(`${store}/${(transform as { path: string }).path}`, {
   version: "0.6",
 });
 ```

--- a/docs/spec_features.md
+++ b/docs/spec_features.md
@@ -62,7 +62,8 @@ implementation details.
   allowing for scalable data management.
 - **RFC-4**: [Anatomical orientation support](./rfc4.md), allowing images to
   include metadata about their anatomical orientation.
-- **RFC-5**: Coordinate systems and transformations for OME-Zarr v0.6.
+- **RFC-5**: [Coordinate systems and transformations](./rfc5.md) for OME-Zarr
+  v0.6, including affine transforms and displacement/coordinate fields.
 - **RFC-9**: [OME-Zarr Zip (.ozx) format support](https://ngff.openmicroscopy.org/rfc/9/index.html),
   enabling single-file distribution of OME-Zarr datasets.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -234,6 +234,10 @@ transformations (the `Displacements` and `Coordinates` types) that reference suc
 a field from a registered image. Like the other v0.6 transforms, they round-trip
 through reading and writing.
 
+See [RFC-5: Coordinate Systems and Transformations](./rfc5.md) for the full
+transformation model, including how to write an image and its transformation
+(an affine, or a displacement/coordinate field) into a single store.
+
 ## 🌍 Platform Support
 
 ### Deno

--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -348,9 +348,11 @@ def from_ome_zarr(
 
     if version.startswith("0.6"):
         from .v06.zarr_metadata import Metadata
+
         # TODO: Restore validation for v0.6
         metadata_obj, images = Metadata._from_zarr_attrs(
-            root_attrs, store, validate=False)
+            root_attrs, store, validate=False, subpath=subpath
+        )
         method, method_type, method_metadata = _extract_method_metadata(
             root_attrs['ome']['multiscales'][0])
 

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -16,6 +16,7 @@ from .._zarr_types import StoreLike
 from abc import ABC
 
 if TYPE_CHECKING:
+    from ..ngff_image import NgffImage
     from ..v05.zarr_metadata import Metadata as Metadata_v05
     from ..v04.zarr_metadata import Metadata as Metadata_v04
 
@@ -333,8 +334,16 @@ class Metadata:
         root_attrs: dict,
         store: StoreLike,
         validate: bool = False,
+        subpath: str | None = None,
         ) -> tuple["Metadata", list["NgffImage"]]:
-        """Create Metadata instance from ome-zarr metadata dictionary."""
+        """Create Metadata instance from ome-zarr metadata dictionary.
+
+        When the multiscales group is nested inside the store (e.g. a
+        displacement field written next to its image), ``subpath`` locates the
+        group so dataset arrays resolve against the right prefix. Dataset
+        paths in the returned metadata stay relative to the group.
+        """
+        import posixpath
         import sys
         import dask.array
         from ..validate import validate as validate_ngff
@@ -382,7 +391,10 @@ class Metadata:
         images = []
         datasets = []
         for index, dataset in enumerate(root_attrs["datasets"]):
-            data = dask.array.from_zarr(store, component=dataset["path"])
+            dataset_path = dataset["path"]
+            if subpath:
+                dataset_path = posixpath.join(subpath, dataset_path)
+            data = dask.array.from_zarr(store, component=dataset_path)
             # Convert endianness to native if needed
             if (sys.byteorder == "little" and data.dtype.byteorder == ">") or (
                 sys.byteorder == "big" and data.dtype.byteorder == "<"

--- a/py/test/test_coordinate_transformations.py
+++ b/py/test/test_coordinate_transformations.py
@@ -115,3 +115,47 @@ def test_transform_serialization(transform):
         assert imported_transforms[0].type == transform.type
         assert imported_transforms[0].input == CoordinateSystemIdentifier(name=input_cs.name)
         assert imported_transforms[0].output == CoordinateSystemIdentifier(name=output_cs.name)
+
+
+@requires_zarr_v3
+def test_affine_image_single_store_roundtrip():
+    """An image and its affine transform live in one store; values round-trip.
+
+    The affine parameters are inline metadata, so a single ``to_ngff_zarr``
+    call writes both the image pixel data and the transformation.
+    """
+    array = rng.random(size=(8, 8, 8), dtype=np.float32)
+    input_image = nz.to_ngff_image(
+        array,
+        dims=["z", "y", "x"],
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        )
+    multiscales = nz.to_multiscales(input_image, scale_factors=[])
+
+    output_cs = CoordinateSystem(
+        name="output",
+        axes=[
+            Axis(name="z", type="space"),
+            Axis(name="y", type="space"),
+            Axis(name="x", type="space"),
+        ]
+    )
+    transform = affine_transform()
+    input_cs = multiscales.metadata.intrinsic_coordinate_system
+    transform.input = CoordinateSystemIdentifier(name=input_cs.name)
+    transform.output = CoordinateSystemIdentifier(name=output_cs.name)
+    transform.name = "to_output"
+
+    multiscales.metadata.coordinateSystems.append(output_cs)
+    multiscales.metadata.coordinateTransformations = [transform]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        nz.to_ngff_zarr(tmpdir, multiscales, version="0.6")
+
+        imported = nz.from_ngff_zarr(tmpdir)
+        np.testing.assert_array_equal(np.asarray(imported.images[0].data), array)
+
+        imported_transforms = imported.metadata.coordinateTransformations
+        assert len(imported_transforms) == 1
+        assert imported_transforms[0].type == "affine"
+        assert imported_transforms[0].affine == affine_transform().affine

--- a/py/test/test_coordinate_transformations.py
+++ b/py/test/test_coordinate_transformations.py
@@ -121,7 +121,7 @@ def test_transform_serialization(transform):
 def test_affine_image_single_store_roundtrip():
     """An image and its affine transform live in one store; values round-trip.
 
-    The affine parameters are inline metadata, so a single ``to_ngff_zarr``
+    The affine parameters are inline metadata, so a single ``to_ome_zarr``
     call writes both the image pixel data and the transformation.
     """
     array = rng.random(size=(8, 8, 8), dtype=np.float32)
@@ -150,9 +150,9 @@ def test_affine_image_single_store_roundtrip():
     multiscales.metadata.coordinateTransformations = [transform]
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        nz.to_ngff_zarr(tmpdir, multiscales, version="0.6")
+        nz.to_ome_zarr(tmpdir, multiscales, version="0.6")
 
-        imported = nz.from_ngff_zarr(tmpdir)
+        imported = nz.from_ome_zarr(tmpdir)
         np.testing.assert_array_equal(np.asarray(imported.images[0].data), array)
 
         imported_transforms = imported.metadata.coordinateTransformations

--- a/py/test/test_displacement_field.py
+++ b/py/test/test_displacement_field.py
@@ -134,6 +134,85 @@ def test_field_transform_roundtrip(transform_type):
     assert out[0].interpolation == "linear"
 
 
+@requires_zarr_v3
+@pytest.mark.parametrize("transform_type", ["displacements", "coordinates"])
+def test_image_and_field_in_single_store(transform_type):
+    """An image and the field its transform references share one store.
+
+    The field, itself an OME-Zarr image, is written first into a subgroup.
+    The image is then written at the store root with ``overwrite=False`` so
+    the final metadata consolidation covers both groups. The transform
+    ``path`` then resolves to the field within the same store.
+
+    The store root uses a ``.ome.zarr`` suffix so reading the field through
+    ``store.ome.zarr/<path>`` goes via the HCS-style sub-path split, which
+    exercises the v0.6 reader resolving dataset arrays against the sub-path.
+    """
+    from ngff_zarr.v06.zarr_metadata import (
+        Axis,
+        Coordinates,
+        CoordinateSystem,
+        CoordinateSystemIdentifier,
+        Displacements,
+    )
+
+    rng = np.random.default_rng(20260707)
+    image_data = rng.random((4, 5), dtype=np.float32)
+    image = NgffImage(
+        data=da.from_array(image_data, chunks=(4, 5)),
+        dims=("y", "x"),
+        scale={"y": 1.0, "x": 1.0},
+        translation={"y": 0.0, "x": 0.0},
+    )
+    multiscales = to_multiscales(image, scale_factors=[])
+
+    axis_type = "displacement" if transform_type == "displacements" else "coordinate"
+    field_data = rng.random((2, 4, 5), dtype=np.float32)
+    field = NgffImage(
+        data=da.from_array(field_data, chunks=(2, 4, 5)),
+        dims=("c", "y", "x"),
+        scale={"c": 1.0, "y": 1.0, "x": 1.0},
+        translation={"c": 0.0, "y": 0.0, "x": 0.0},
+        axes_types={"c": axis_type},
+    )
+    field_multiscales = to_multiscales(field, scale_factors=[])
+
+    field_path = f"{transform_type}_field"
+    cls = Displacements if transform_type == "displacements" else Coordinates
+    transform = cls(path=field_path, interpolation="linear")
+    output_cs = CoordinateSystem(
+        name="output",
+        axes=[Axis(name="y", type="space"), Axis(name="x", type="space")],
+    )
+    transform.input = CoordinateSystemIdentifier(
+        name=multiscales.metadata.intrinsic_coordinate_system.name
+    )
+    transform.output = CoordinateSystemIdentifier(name=output_cs.name)
+    transform.name = "warp"
+    multiscales.metadata.coordinateSystems.append(output_cs)
+    multiscales.metadata.coordinateTransformations = [transform]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = f"{tmpdir}/image.ome.zarr"
+        nz.to_ngff_zarr(f"{store}/{field_path}", field_multiscales, version="0.6")
+        nz.to_ngff_zarr(store, multiscales, version="0.6", overwrite=False)
+
+        imported = nz.from_ngff_zarr(store)
+        np.testing.assert_array_equal(np.asarray(imported.images[0].data), image_data)
+        transforms = imported.metadata.coordinateTransformations
+        assert len(transforms) == 1
+        assert transforms[0].type == transform_type
+        assert transforms[0].path == field_path
+
+        imported_field = nz.from_ngff_zarr(f"{store}/{transforms[0].path}")
+        axes = imported_field.metadata.intrinsic_coordinate_system.axes
+        assert [a.type for a in axes] == [axis_type, "space", "space"]
+        assert axes[0].discrete is True
+        np.testing.assert_array_equal(
+            np.asarray(imported_field.images[0].data), field_data
+        )
+
+
 def test_axes_types_unknown_dim_raises():
     """An axes_types entry naming a missing dimension is rejected."""
     with pytest.raises(ValueError):

--- a/py/test/test_displacement_field.py
+++ b/py/test/test_displacement_field.py
@@ -194,17 +194,17 @@ def test_image_and_field_in_single_store(transform_type):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         store = f"{tmpdir}/image.ome.zarr"
-        nz.to_ngff_zarr(f"{store}/{field_path}", field_multiscales, version="0.6")
-        nz.to_ngff_zarr(store, multiscales, version="0.6", overwrite=False)
+        nz.to_ome_zarr(f"{store}/{field_path}", field_multiscales, version="0.6")
+        nz.to_ome_zarr(store, multiscales, version="0.6", overwrite=False)
 
-        imported = nz.from_ngff_zarr(store)
+        imported = nz.from_ome_zarr(store)
         np.testing.assert_array_equal(np.asarray(imported.images[0].data), image_data)
         transforms = imported.metadata.coordinateTransformations
         assert len(transforms) == 1
         assert transforms[0].type == transform_type
         assert transforms[0].path == field_path
 
-        imported_field = nz.from_ngff_zarr(f"{store}/{transforms[0].path}")
+        imported_field = nz.from_ome_zarr(f"{store}/{transforms[0].path}")
         axes = imported_field.metadata.intrinsic_coordinate_system.axes
         assert [a.type for a in axes] == [axis_type, "space", "space"]
         assert axes[0].discrete is True

--- a/ts/src/io/to_ngff_image.ts
+++ b/ts/src/io/to_ngff_image.ts
@@ -121,8 +121,9 @@ export async function toNgffImage(
     codecs: defaultCodecs("float32"),
   });
 
-  // Write data to zarr array
-  await zarrSet(zarrArray, [], {
+  // Write data to zarr array; a null selection targets the full array (an
+  // empty selection list writes nothing).
+  await zarrSet(zarrArray, null, {
     data: typedData as Float32Array,
     shape,
     stride: calculateStride(shape),

--- a/ts/test/displacement_field_test.ts
+++ b/ts/test/displacement_field_test.ts
@@ -196,7 +196,10 @@ for (const transformType of ["displacements", "coordinates"] as const) {
           overwrite: false,
         });
 
-        const imported = await fromOmeZarr(tmpDir, { version: "0.6" });
+        const imported = await fromOmeZarr(tmpDir, {
+          version: "0.6",
+          validate: true,
+        });
         const transforms = imported.metadata.coordinateTransformations!;
         assertEquals(transforms.length, 1);
         assertEquals(transforms[0].type, transformType);
@@ -209,6 +212,7 @@ for (const transformType of ["displacements", "coordinates"] as const) {
 
         const importedField = await fromOmeZarr(`${tmpDir}/${importedPath}`, {
           version: "0.6",
+          validate: true,
         });
         const fieldAxes = importedField.metadata.coordinateSystems![0].axes;
         assertEquals(fieldAxes.map((a) => a.type), [

--- a/ts/test/displacement_field_test.ts
+++ b/ts/test/displacement_field_test.ts
@@ -12,6 +12,7 @@
  */
 
 import { assertEquals, assertRejects } from "@std/assert";
+import * as zarr from "zarrita";
 import {
   toMultiscales,
   toNgffImage,
@@ -128,6 +129,99 @@ for (const transformType of ["displacements", "coordinates"] as const) {
         (out[0] as Displacements | Coordinates).interpolation,
         "linear",
       );
+    },
+  );
+}
+
+for (const transformType of ["displacements", "coordinates"] as const) {
+  Deno.test(
+    `an image and its ${transformType} field share a single store`,
+    async () => {
+      // The field, itself an OME-Zarr image, is written first into a
+      // subgroup; the image is then written at the store root so the
+      // transform `path` resolves within the same store.
+      const axisType = transformType === "displacements"
+        ? "displacement"
+        : "coordinate";
+      const fieldPath = `${transformType}_field`;
+
+      const imageData = new Float32Array(4 * 5);
+      for (let i = 0; i < imageData.length; i++) imageData[i] = i / 10;
+      const image = await toNgffImage(imageData, {
+        dims: ["y", "x"],
+        shape: [4, 5],
+        scale: { y: 1, x: 1 },
+        translation: { y: 0, x: 0 },
+      });
+      const multiscales = await toMultiscales(image, { scaleFactors: [] });
+
+      const fieldData = new Float32Array(2 * 4 * 5);
+      for (let i = 0; i < fieldData.length; i++) fieldData[i] = i / 100;
+      const field = await toNgffImage(fieldData, {
+        dims: ["c", "y", "x"],
+        shape: [2, 4, 5],
+        scale: { c: 1, y: 1, x: 1 },
+        translation: { c: 0, y: 0, x: 0 },
+        axesTypes: { c: axisType },
+      });
+      const fieldMultiscales = await toMultiscales(field, {
+        scaleFactors: [],
+      });
+
+      const intrinsic = multiscales.metadata.coordinateSystems![0];
+      const outputCs = createCoordinateSystem("output", [
+        createAxis("y", "space"),
+        createAxis("x", "space"),
+      ]);
+      const transform = {
+        type: transformType,
+        path: fieldPath,
+        interpolation: "linear",
+        input: { name: intrinsic.name },
+        output: { name: outputCs.name },
+        name: "warp",
+      } as V06Transform;
+      multiscales.metadata.coordinateSystems!.push(outputCs);
+      multiscales.metadata.coordinateTransformations = [transform];
+
+      const tmpDir = await Deno.makeTempDir();
+      try {
+        await toNgffZarr(`${tmpDir}/${fieldPath}`, fieldMultiscales, {
+          version: "0.6",
+        });
+        await toNgffZarr(tmpDir, multiscales, {
+          version: "0.6",
+          overwrite: false,
+        });
+
+        const imported = await fromNgffZarr(tmpDir, { version: "0.6" });
+        const transforms = imported.metadata.coordinateTransformations!;
+        assertEquals(transforms.length, 1);
+        assertEquals(transforms[0].type, transformType);
+        const importedPath =
+          (transforms[0] as Displacements | Coordinates).path;
+        assertEquals(importedPath, fieldPath);
+
+        const importedImage = await zarr.get(imported.images[0].data);
+        assertEquals(importedImage.data as Float32Array, imageData);
+
+        const importedField = await fromNgffZarr(`${tmpDir}/${importedPath}`, {
+          version: "0.6",
+        });
+        const fieldAxes = importedField.metadata.coordinateSystems![0].axes;
+        assertEquals(fieldAxes.map((a) => a.type), [
+          axisType,
+          "space",
+          "space",
+        ]);
+        assertEquals(fieldAxes[0].discrete, true);
+        const importedFieldChunk = await zarr.get(
+          importedField.images[0].data,
+        );
+        assertEquals(importedFieldChunk.data as Float32Array, fieldData);
+      } finally {
+        await Deno.remove(tmpDir, { recursive: true });
+      }
     },
   );
 }

--- a/ts/test/displacement_field_test.ts
+++ b/ts/test/displacement_field_test.ts
@@ -23,7 +23,9 @@ import {
   createCoordinateSystem,
   type Displacements,
   fromNgffZarr,
+  fromOmeZarr,
   toNgffZarr,
+  toOmeZarr,
   type V06Transform,
 } from "../src/mod.ts";
 import type { MemoryStore } from "../src/io/from_ngff_zarr.ts";
@@ -186,15 +188,15 @@ for (const transformType of ["displacements", "coordinates"] as const) {
 
       const tmpDir = await Deno.makeTempDir();
       try {
-        await toNgffZarr(`${tmpDir}/${fieldPath}`, fieldMultiscales, {
+        await toOmeZarr(`${tmpDir}/${fieldPath}`, fieldMultiscales, {
           version: "0.6",
         });
-        await toNgffZarr(tmpDir, multiscales, {
+        await toOmeZarr(tmpDir, multiscales, {
           version: "0.6",
           overwrite: false,
         });
 
-        const imported = await fromNgffZarr(tmpDir, { version: "0.6" });
+        const imported = await fromOmeZarr(tmpDir, { version: "0.6" });
         const transforms = imported.metadata.coordinateTransformations!;
         assertEquals(transforms.length, 1);
         assertEquals(transforms[0].type, transformType);
@@ -205,7 +207,7 @@ for (const transformType of ["displacements", "coordinates"] as const) {
         const importedImage = await zarr.get(imported.images[0].data);
         assertEquals(importedImage.data as Float32Array, imageData);
 
-        const importedField = await fromNgffZarr(`${tmpDir}/${importedPath}`, {
+        const importedField = await fromOmeZarr(`${tmpDir}/${importedPath}`, {
           version: "0.6",
         });
         const fieldAxes = importedField.metadata.coordinateSystems![0].axes;


### PR DESCRIPTION
Closes #586.

Adds tests and documentation for writing an image together with an associated
transformation (affine, displacement/coordinate field) into a **single**
OME-Zarr v0.6 store with `to_ome_zarr`.

## What was missing

The v0.6 metadata model already carries `Affine`, `Displacements`, and
`Coordinates` transforms, but nothing demonstrated (or tested) writing an image
and the array a transform references into one store. The existing tests
round-tripped metadata only — e.g. a `Displacements(path="displacement_field")`
whose `path` was a dangling reference to an array that was never written.

## Changes

**Tests**
- `test_image_and_field_in_single_store` (Python & TypeScript, parametrized over
  displacements/coordinates): writes an image plus its field into one store,
  reads both back, and asserts the transform `path` resolves to real field data.
- `test_affine_image_single_store_roundtrip` (Python): an inline affine and the
  image pixel data written in a single `to_ngff_zarr` call, with the affine
  matrix verified on read-back.

**Fixes surfaced by the tests**
- v0.6 reader: `Metadata._from_zarr_attrs` now honors a `subpath` when resolving
  dataset arrays. Previously the subpath was ignored, so reading a field nested
  in the store returned the wrong array (matching the v0.4/v0.5 readers, which
  already join the subpath).
- TypeScript `toNgffImage`: pass a `null` selection to `zarrSet`. An empty
  selection list wrote nothing, leaving arrays zero-filled.

**Documentation**
- New `docs/rfc5.md` page (modeled on `docs/rfc4.md`) covering the RFC-5
  coordinate systems and transformations model, with the end-to-end single-store
  image + field pattern in Python and TypeScript. Registered in the docs
  toctree, with cross-references from `spec_features.md`, `python.md`, and
  `typescript.md`.

## Write pattern

There is no single call that writes both the image and the field. The working
pattern (documented and tested): write the field into a subgroup first, then the
image at the store root with `overwrite=False`, so the final metadata
consolidation covers both groups and the transform `path` resolves within the
store. If a convenience helper that manages this ordering is desired, happy to
follow up.

## Testing

- Python: full suite passes (728 passed, 3 skipped).
- TypeScript: full suite passes (455 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation / New Features**
  * Added RFC-5 documentation for OME-Zarr v0.6 coordinate systems and transformations, including affine transforms and displacement/coordinate fields.
  * Updated the docs navigation and cross-references, with guidance for representing transformations in metadata.

* **Bug Fixes**
  * Fixed v0.6 loading so nested image subpaths are resolved correctly.
  * Adjusted TypeScript array-writing behavior to reliably populate full arrays.

* **Tests**
  * Added integration round-trip coverage for writing an image and its transformation (single-store affine and displacement/coordinate fields).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->