### PR TITLE
fix: reject RFC-4 orientation on non-spatial axes and duplicate anatomical axes

### DIFF
--- a/py/ngff_zarr/rfc4_validation.py
+++ b/py/ngff_zarr/rfc4_validation.py
@@ -23,6 +23,37 @@ def load_rfc4_orientation_schema() -> dict:
     return json.loads(schema)
 
 
+# Each RFC 4 value maps to a stable key for the anatomical axis it lies on, so the
+# two antonyms of a pair (e.g. "left-to-right" / "right-to-left") collapse to one
+# key. Used to enforce "one direction per anatomical axis" (mutual exclusion).
+_ANATOMICAL_AXIS_OF: dict[str, str] = {
+    "left-to-right": "left-right",
+    "right-to-left": "left-right",
+    "anterior-to-posterior": "anterior-posterior",
+    "posterior-to-anterior": "anterior-posterior",
+    "inferior-to-superior": "inferior-superior",
+    "superior-to-inferior": "inferior-superior",
+    "dorsal-to-ventral": "dorsal-ventral",
+    "ventral-to-dorsal": "dorsal-ventral",
+    "dorsal-to-palmar": "dorsal-palmar",
+    "palmar-to-dorsal": "dorsal-palmar",
+    "dorsal-to-plantar": "dorsal-plantar",
+    "plantar-to-dorsal": "dorsal-plantar",
+    "rostral-to-caudal": "rostral-caudal",
+    "caudal-to-rostral": "rostral-caudal",
+    "cranial-to-caudal": "cranial-caudal",
+    "caudal-to-cranial": "cranial-caudal",
+    "proximal-to-distal": "proximal-distal",
+    "distal-to-proximal": "proximal-distal",
+    "superficial-to-deep": "superficial-deep",
+    "deep-to-superficial": "superficial-deep",
+    "apical-to-basal": "apical-basal",
+    "basal-to-apical": "apical-basal",
+    "apex-to-base": "apex-base",
+    "base-to-apex": "apex-base",
+}
+
+
 def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
     """
     Validate RFC 4 anatomical orientation metadata against the JSON schema.
@@ -39,10 +70,11 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
     jsonschema.ValidationError
         If the orientation metadata is invalid
     ValueError
-        If orientation is inconsistently defined across spatial axes. The two
-        messages carry stable marker substrings -- ``"same type"`` for a
-        mixed-``type`` failure and ``"all spatial axes"`` for the all-or-none
-        completeness failure -- that
+        If orientation is inconsistently or illegally defined. The messages carry
+        stable marker substrings -- ``"same type"`` (mixed ``type``),
+        ``"all spatial axes"`` (all-or-none completeness), ``"non-space axes"``
+        (orientation on a non-spatial axis) and ``"same anatomical axis"`` (two
+        axes on one antonym pair) -- that
         :func:`ngff_zarr.structural_validation.validate_axis_orientation` reads
         to map each failure onto its :class:`SpecRule`. These markers are a
         load-bearing contract pinned by a message-stability test
@@ -63,6 +95,7 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
     orientation_type = None
     spatial_axes_with_orientation = []
     spatial_axes_without_orientation = []
+    spatial_orientation_values: list[tuple[str, str]] = []
 
     # Valid anatomical orientation values (from the schema)
     valid_orientation_values = {
@@ -116,11 +149,14 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
                         f"Invalid orientation value '{orientation_value}' for axis '{axis['name']}'. "
                         f"Valid values are: {sorted(valid_orientation_values)}"
                     )
+                spatial_orientation_values.append((axis["name"], orientation_value))
             else:
                 spatial_axes_without_orientation.append(axis["name"])
 
-    # RFC 4 requirement: if orientation is defined for one spatial axis,
-    # it must be defined for all spatial axes
+    # RFC 4 requirement: if orientation is defined for one spatial axis, it must
+    # be defined for all spatial axes. Checked before the rules below to keep the
+    # canonical SpecRule precedence (completeness is declared before the non-space
+    # and unique-axis rules).
     if has_orientation and spatial_axes_without_orientation:
         raise ValueError(
             f"RFC 4 requires that if orientation is defined for one spatial axis, "
@@ -128,6 +164,36 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
             f"Axes with orientation: {spatial_axes_with_orientation}, "
             f"axes without orientation: {spatial_axes_without_orientation}"
         )
+
+    # RFC 4 requirement: orientation is only allowed on spatial axes. (Checked
+    # over all axes, independently of has_orientation, so a stray orientation on
+    # a time/channel axis is caught even when no spatial axis carries one.)
+    non_space_with_orientation = [
+        axis["name"]
+        for axis in axes
+        if isinstance(axis, dict)
+        and axis.get("type") != "space"
+        and "orientation" in axis
+    ]
+    if non_space_with_orientation:
+        raise ValueError(
+            f"RFC 4 orientation is only allowed on spatial axes; found orientation "
+            f"on non-space axes: {non_space_with_orientation}"
+        )
+
+    # RFC 4 requirement: at most one direction per anatomical axis -- the two
+    # antonyms of a pair are mutually exclusive across the spatial axes. A list of
+    # (name, value) entries (not a name-keyed map) keeps every entry, so a
+    # repeated axis name cannot mask a collision.
+    anatomical_axis_seen: dict[str, str] = {}
+    for name, value in spatial_orientation_values:
+        axis_key = _ANATOMICAL_AXIS_OF[value]
+        if axis_key in anatomical_axis_seen:
+            raise ValueError(
+                f"Axes '{anatomical_axis_seen[axis_key]}' and '{name}' describe the "
+                f"same anatomical axis; RFC 4 allows only one direction per axis."
+            )
+        anatomical_axis_seen[axis_key] = name
 
     # If no orientation metadata found, nothing to validate
     if not has_orientation:
@@ -168,6 +234,6 @@ def has_rfc4_orientation_metadata(axes: list[dict[str, Any]]) -> bool:
             and "orientation" in axis
         ):
             # Orientation value has to be non-empty for it to count as valid orientation metadata
-            if axis['orientation']:
+            if axis["orientation"]:
                 return True
     return False

--- a/py/ngff_zarr/structural_validation.py
+++ b/py/ngff_zarr/structural_validation.py
@@ -52,6 +52,12 @@ violation, in canonical spec-MUST order.
 #   axis-orientation-completeness
 #       if any spatial axis has orientation, all spatial axes do
 #       e.g. multiscales[0].axes
+#   axis-orientation-on-non-space
+#       orientation is declared only on spatial axes (never time/channel)
+#       e.g. multiscales[0].axes
+#   axis-orientation-unique-axis
+#       at most one direction per anatomical axis (antonyms are exclusive)
+#       e.g. multiscales[0].axes
 #   zarr-format
 #       a v0.5 entry implies a Zarr v3 store (a leaked zarr_format must be 3)
 #       e.g. multiscales[0]
@@ -93,6 +99,8 @@ class SpecRule(str, Enum):
     OMERO_CHANNEL_COLOR_FORMAT = "omero-channel-color-format"
     AXIS_ORIENTATION_CONSISTENT_TYPE = "axis-orientation-consistent-type"
     AXIS_ORIENTATION_COMPLETENESS = "axis-orientation-completeness"
+    AXIS_ORIENTATION_ON_NON_SPACE = "axis-orientation-on-non-space"
+    AXIS_ORIENTATION_UNIQUE_AXIS = "axis-orientation-unique-axis"
     ZARR_FORMAT = "zarr-format"
     OME_NAMESPACE = "ome-namespace"
     PLATE_ROW_INDEX_CONSISTENCY = "plate-row-index-consistency"
@@ -530,10 +538,13 @@ def validate_axis_orientation(metadata: Metadata) -> None:
     ------
     ValidationError
         With :attr:`SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE` when the spatial
-        axes' orientations do not all share one ``type``, or
+        axes' orientations do not all share one ``type``,
         :attr:`SpecRule.AXIS_ORIENTATION_COMPLETENESS` when orientation is defined
-        for some but not all spatial axes; location ``multiscales[0].axes``. The
-        original RFC 4 message text is preserved.
+        for some but not all spatial axes,
+        :attr:`SpecRule.AXIS_ORIENTATION_ON_NON_SPACE` when orientation is declared
+        on a non-spatial axis, or :attr:`SpecRule.AXIS_ORIENTATION_UNIQUE_AXIS`
+        when two spatial axes describe the same anatomical axis; location
+        ``multiscales[0].axes``. The original RFC 4 message text is preserved.
     jsonschema.exceptions.ValidationError
         Propagated unchanged when an orientation value is outside the RFC 4
         vocabulary -- a schema-level concern with no dedicated structural rule.
@@ -544,25 +555,36 @@ def validate_axis_orientation(metadata: Metadata) -> None:
     )
 
     axes_dicts = [_axis_to_validation_dict(axis) for axis in metadata.axes]
-    if not has_rfc4_orientation_metadata(axes_dicts):
+    # A stray orientation on a non-spatial axis carries no spatial-axis
+    # orientation, so has_rfc4_orientation_metadata alone would skip it; check for
+    # any declared orientation so the non-space rule is reachable.
+    non_space_orientation = any(
+        isinstance(axis_dict, dict)
+        and axis_dict.get("type") != "space"
+        and "orientation" in axis_dict
+        for axis_dict in axes_dicts
+    )
+    if not has_rfc4_orientation_metadata(axes_dicts) and not non_space_orientation:
         return
     try:
         validate_rfc4_orientation(axes_dicts)
     except ValueError as exc:
-        # validate_rfc4_orientation raises exactly two ValueErrors: a spatial
-        # orientation "same type" mismatch and the all-or-none completeness
-        # failure. jsonschema's ValidationError (raised for an out-of-vocabulary
+        # validate_rfc4_orientation raises four mappable ValueErrors: a spatial
+        # orientation "same type" mismatch, the all-or-none completeness failure,
+        # orientation on "non-space axes", and two axes on the "same anatomical
+        # axis". jsonschema's ValidationError (raised for an out-of-vocabulary
         # orientation value) is not a ValueError, so it -- like ImportError when
         # jsonschema is absent -- propagates untouched; no structural rule covers
         # those schema-level concerns.
         #
-        # The "same type" / "all spatial axes" substrings below are a
-        # load-bearing contract with validate_rfc4_orientation's message text:
-        # an unrecognized ValueError falls through to the bare ``raise`` and is
-        # surfaced as a plain ValueError rather than a ValidationError. The
-        # message-stability test test_rfc4_orientation_messages_carry_mapping_markers
-        # pins both markers so editing that wording fails CI loudly instead of
-        # silently breaking this mapping.
+        # The marker substrings below ("same type", "all spatial axes",
+        # "non-space axes", "same anatomical axis") are a load-bearing contract
+        # with validate_rfc4_orientation's message text: an unrecognized
+        # ValueError falls through to the bare ``raise`` and is surfaced as a
+        # plain ValueError rather than a ValidationError. The message-stability
+        # test test_rfc4_orientation_messages_carry_mapping_markers pins the
+        # markers so editing that wording fails CI loudly instead of silently
+        # breaking this mapping.
         message = str(exc)
         if "same type" in message:
             raise ValidationError(
@@ -573,6 +595,18 @@ def validate_axis_orientation(metadata: Metadata) -> None:
         if "all spatial axes" in message:
             raise ValidationError(
                 SpecRule.AXIS_ORIENTATION_COMPLETENESS,
+                message,
+                "multiscales[0].axes",
+            ) from exc
+        if "non-space axes" in message:
+            raise ValidationError(
+                SpecRule.AXIS_ORIENTATION_ON_NON_SPACE,
+                message,
+                "multiscales[0].axes",
+            ) from exc
+        if "same anatomical axis" in message:
+            raise ValidationError(
+                SpecRule.AXIS_ORIENTATION_UNIQUE_AXIS,
                 message,
                 "multiscales[0].axes",
             ) from exc

--- a/py/test/test_rfc4_validation.py
+++ b/py/test/test_rfc4_validation.py
@@ -239,6 +239,131 @@ def test_validate_rfc4_orientation_invalid_value():
         validate_rfc4_orientation(axes_invalid)
 
 
+def test_validate_rfc4_orientation_on_non_space_axis():
+    """RFC 4 orientation is rejected on a non-spatial (time/channel) axis."""
+    pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
+
+    axes_bad = [
+        {
+            "name": "t",
+            "type": "time",
+            "unit": "second",
+            "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
+        },
+        {
+            "name": "z",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
+        },
+        {
+            "name": "y",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
+        },
+        {
+            "name": "x",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "right-to-left"},
+        },
+    ]
+
+    with pytest.raises(ValueError, match="non-space axes"):
+        validate_rfc4_orientation(axes_bad)
+
+
+def test_validate_rfc4_orientation_on_non_space_axis_empty_dict():
+    """An empty orientation object on a non-spatial axis is still rejected.
+
+    The presence of the ``orientation`` key -- not a truthy value -- is what
+    RFC 4 forbids on a non-spatial axis, so ``{}`` must not slip through."""
+    pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
+
+    axes_bad = [
+        {"name": "t", "type": "time", "unit": "second", "orientation": {}},
+        {
+            "name": "z",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
+        },
+        {
+            "name": "y",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
+        },
+        {
+            "name": "x",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "right-to-left"},
+        },
+    ]
+
+    with pytest.raises(ValueError, match="non-space axes"):
+        validate_rfc4_orientation(axes_bad)
+
+
+def test_validate_rfc4_orientation_duplicate_anatomical_axis():
+    """Two spatial axes describing the same anatomical axis are rejected."""
+    pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
+
+    # z and x both lie on the left-right axis (mutually exclusive antonyms).
+    axes_dup = [
+        {
+            "name": "z",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "left-to-right"},
+        },
+        {
+            "name": "y",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
+        },
+        {
+            "name": "x",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "right-to-left"},
+        },
+    ]
+
+    with pytest.raises(ValueError, match="same anatomical axis"):
+        validate_rfc4_orientation(axes_dup)
+
+
+def test_validate_rfc4_orientation_duplicate_anatomical_axis_same_name():
+    """Two spatial entries that reuse one axis name still collide.
+
+    Malformed metadata can repeat a name. A name-keyed map would overwrite the
+    first entry and let the pair slip through, so the check keeps every entry.
+    """
+    pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
+
+    axes_dup = [
+        {
+            "name": "x",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "left-to-right"},
+        },
+        {
+            "name": "x",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": "right-to-left"},
+        },
+    ]
+
+    with pytest.raises(ValueError, match="same anatomical axis"):
+        validate_rfc4_orientation(axes_dup)
+
+
 def test_from_ngff_zarr_with_rfc4_validation():
     """Test from_ngff_zarr with RFC 4 validation enabled."""
     pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")

--- a/py/test/test_structural_validation_orientation.py
+++ b/py/test/test_structural_validation_orientation.py
@@ -133,16 +133,57 @@ def test_axis_orientation_incomplete():
     )
 
 
+def test_axis_orientation_on_non_space_axis():
+    # Orientation is (illegally) declared on the non-spatial "t" axis. The
+    # spatial axes carry it too, so the RFC 4 check is actually reached.
+    metadata = _metadata_with_axes(
+        [
+            Axis(
+                name="t",
+                type="time",
+                orientation=_orientation_dict("inferior-to-superior"),
+            ),
+            Axis(name="z", type="space", orientation=_orientation_dict(_LPS_VALUES[0])),
+            Axis(name="y", type="space", orientation=_orientation_dict(_LPS_VALUES[1])),
+            Axis(name="x", type="space", orientation=_orientation_dict(_LPS_VALUES[2])),
+        ]
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_axis_orientation(metadata)
+    assert exc_info.value.rule == SpecRule.AXIS_ORIENTATION_ON_NON_SPACE
+    assert exc_info.value.location == "multiscales[0].axes"
+
+
+def test_axis_orientation_duplicate_anatomical_axis():
+    # "z" and "x" both lie on the left-right anatomical axis (mutually exclusive).
+    metadata = _metadata_with_axes(
+        [
+            Axis(
+                name="z", type="space", orientation=_orientation_dict("left-to-right")
+            ),
+            Axis(name="y", type="space", orientation=_orientation_dict(_LPS_VALUES[1])),
+            Axis(
+                name="x", type="space", orientation=_orientation_dict("right-to-left")
+            ),
+        ]
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_axis_orientation(metadata)
+    assert exc_info.value.rule == SpecRule.AXIS_ORIENTATION_UNIQUE_AXIS
+    assert exc_info.value.location == "multiscales[0].axes"
+
+
 def test_rfc4_orientation_messages_carry_mapping_markers():
     """Pin the substrings :func:`validate_axis_orientation` maps onto rules.
 
-    The wrapper distinguishes the two RFC 4 orientation failures by searching
+    The wrapper distinguishes the RFC 4 orientation failures by searching
     :func:`~ngff_zarr.rfc4_validation.validate_rfc4_orientation`'s message text
-    for ``"same type"`` and ``"all spatial axes"``. Those markers are a
-    load-bearing contract: if the wording is edited away, the wrapper silently
-    falls through to a bare ``ValueError`` instead of raising the mapped
-    :class:`ValidationError`. Asserting the markers here makes such an edit fail
-    CI loudly at the source rather than silently break the mapping.
+    for ``"same type"``, ``"all spatial axes"``, ``"non-space axes"`` and
+    ``"same anatomical axis"``. Those markers are a load-bearing contract: if the
+    wording is edited away, the wrapper silently falls through to a bare
+    ``ValueError`` instead of raising the mapped :class:`ValidationError`.
+    Asserting the markers here makes such an edit fail CI loudly at the source
+    rather than silently break the mapping.
     """
     from ngff_zarr.rfc4_validation import validate_rfc4_orientation
 
@@ -179,5 +220,37 @@ def test_rfc4_orientation_messages_carry_mapping_markers():
                     },
                 },
                 {"name": "x", "type": "space"},
+            ]
+        )
+
+    # Orientation on a non-spatial axis -> the on-non-space marker.
+    with pytest.raises(ValueError, match="non-space axes"):
+        validate_rfc4_orientation(
+            [
+                {
+                    "name": "t",
+                    "type": "time",
+                    "orientation": {
+                        "type": "anatomical",
+                        "value": "inferior-to-superior",
+                    },
+                },
+            ]
+        )
+
+    # Two spatial axes on one anatomical axis -> the unique-axis marker.
+    with pytest.raises(ValueError, match="same anatomical axis"):
+        validate_rfc4_orientation(
+            [
+                {
+                    "name": "y",
+                    "type": "space",
+                    "orientation": {"type": "anatomical", "value": "left-to-right"},
+                },
+                {
+                    "name": "x",
+                    "type": "space",
+                    "orientation": {"type": "anatomical", "value": "right-to-left"},
+                },
             ]
         )

--- a/py/test/test_structural_validation_parity.py
+++ b/py/test/test_structural_validation_parity.py
@@ -53,6 +53,8 @@ CANONICAL_SPEC_RULE_IDS = [
     "omero-channel-color-format",
     "axis-orientation-consistent-type",
     "axis-orientation-completeness",
+    "axis-orientation-on-non-space",
+    "axis-orientation-unique-axis",
     "zarr-format",
     "ome-namespace",
     "plate-row-index-consistency",

--- a/ts/src/utils/rfc4_validation.ts
+++ b/ts/src/utils/rfc4_validation.ts
@@ -38,6 +38,38 @@ const VALID_ORIENTATION_VALUES = new Set([
 ]);
 
 /**
+ * Each RFC 4 value maps to a stable key for the anatomical axis it lies on, so
+ * the two antonyms of a pair (e.g. "left-to-right" / "right-to-left") collapse to
+ * one key. Used to enforce "one direction per anatomical axis" (mutual exclusion).
+ */
+const ANATOMICAL_AXIS_OF: Record<string, string> = {
+  "left-to-right": "left-right",
+  "right-to-left": "left-right",
+  "anterior-to-posterior": "anterior-posterior",
+  "posterior-to-anterior": "anterior-posterior",
+  "inferior-to-superior": "inferior-superior",
+  "superior-to-inferior": "inferior-superior",
+  "dorsal-to-ventral": "dorsal-ventral",
+  "ventral-to-dorsal": "dorsal-ventral",
+  "dorsal-to-palmar": "dorsal-palmar",
+  "palmar-to-dorsal": "dorsal-palmar",
+  "dorsal-to-plantar": "dorsal-plantar",
+  "plantar-to-dorsal": "dorsal-plantar",
+  "rostral-to-caudal": "rostral-caudal",
+  "caudal-to-rostral": "rostral-caudal",
+  "cranial-to-caudal": "cranial-caudal",
+  "caudal-to-cranial": "cranial-caudal",
+  "proximal-to-distal": "proximal-distal",
+  "distal-to-proximal": "proximal-distal",
+  "superficial-to-deep": "superficial-deep",
+  "deep-to-superficial": "superficial-deep",
+  "apical-to-basal": "apical-basal",
+  "basal-to-apical": "apical-basal",
+  "apex-to-base": "apex-base",
+  "base-to-apex": "apex-base",
+};
+
+/**
  * Check if the axes contain RFC 4 anatomical orientation metadata.
  *
  * @param axes - List of axis metadata objects
@@ -79,12 +111,12 @@ function isNonEmptyOrientation(orientation: unknown): boolean {
 /**
  * Validate RFC 4 anatomical orientation metadata.
  *
- * The two inconsistency errors carry stable marker substrings -- `same type`
- * for a mixed-`type` failure and `all spatial axes` for the all-or-none
- * completeness failure -- that `validateAxisOrientation` reads to map each
- * failure onto its `SpecRule`. These markers are a load-bearing contract
- * pinned by a message-stability test (see
- * `structural_validation_orientation_test.ts`) so the mapping cannot silently
+ * The errors carry stable marker substrings -- `same type` (mixed `type`),
+ * `all spatial axes` (all-or-none completeness), `non-space axes` (orientation on
+ * a non-spatial axis) and `same anatomical axis` (two axes on one antonym pair) --
+ * that `validateAxisOrientation` reads to map each failure onto its `SpecRule`.
+ * These markers are a load-bearing contract pinned by a message-stability test
+ * (see `structural_validation_orientation_test.ts`) so the mapping cannot silently
  * break if the wording is later edited.
  *
  * @param axes - List of axis metadata dictionaries to validate
@@ -97,6 +129,7 @@ export function validateRfc4Orientation(
   let orientationType: string | null = null;
   const spatialAxesWithOrientation: string[] = [];
   const spatialAxesWithoutOrientation: string[] = [];
+  const spatialOrientationValues: Array<[string, string]> = [];
 
   for (const axis of axes) {
     if (typeof axis === "object" && axis !== null && axis.type === "space") {
@@ -133,6 +166,7 @@ export function validateRfc4Orientation(
                 }`,
             );
           }
+          spatialOrientationValues.push([axisName, orientationValue]);
         }
       } else {
         spatialAxesWithoutOrientation.push(axisName);
@@ -140,8 +174,10 @@ export function validateRfc4Orientation(
     }
   }
 
-  // RFC 4 requirement: if orientation is defined for one spatial axis,
-  // it must be defined for all spatial axes
+  // RFC 4 requirement: if orientation is defined for one spatial axis, it must
+  // be defined for all spatial axes. Checked before the rules below to keep the
+  // canonical SpecRule precedence (completeness is declared before the non-space
+  // and unique-axis rules).
   if (hasOrientation && spatialAxesWithoutOrientation.length > 0) {
     throw new Error(
       `RFC 4 requires that if orientation is defined for one spatial axis, ` +
@@ -151,5 +187,42 @@ export function validateRfc4Orientation(
         `axes without orientation: ` +
         `${formatNameList(spatialAxesWithoutOrientation)}`,
     );
+  }
+
+  // RFC 4 requirement: orientation is only allowed on spatial axes. (Checked
+  // over all axes, independently of hasOrientation, so a stray orientation on a
+  // time/channel axis is caught even when no spatial axis carries one.)
+  const nonSpaceWithOrientation: string[] = [];
+  for (const axis of axes) {
+    if (
+      typeof axis === "object" &&
+      axis !== null &&
+      axis.type !== "space" &&
+      "orientation" in axis
+    ) {
+      nonSpaceWithOrientation.push(String(axis.name));
+    }
+  }
+  if (nonSpaceWithOrientation.length > 0) {
+    throw new Error(
+      `RFC 4 orientation is only allowed on spatial axes; found orientation ` +
+        `on non-space axes: ${formatNameList(nonSpaceWithOrientation)}`,
+    );
+  }
+
+  // RFC 4 requirement: at most one direction per anatomical axis -- the two
+  // antonyms of a pair are mutually exclusive across the spatial axes. An ordered
+  // list of [name, value] entries (not a name-keyed map) keeps every entry, so a
+  // repeated axis name cannot mask a collision.
+  const anatomicalAxisSeen: Record<string, string> = {};
+  for (const [name, value] of spatialOrientationValues) {
+    const axisKey = ANATOMICAL_AXIS_OF[value];
+    if (axisKey in anatomicalAxisSeen) {
+      throw new Error(
+        `Axes '${anatomicalAxisSeen[axisKey]}' and '${name}' describe the ` +
+          `same anatomical axis; RFC 4 allows only one direction per axis.`,
+      );
+    }
+    anatomicalAxisSeen[axisKey] = name;
   }
 }

--- a/ts/src/utils/structural_validation.ts
+++ b/ts/src/utils/structural_validation.ts
@@ -66,6 +66,10 @@ export const SpecRule = {
   AxisOrientationConsistentType: "axis-orientation-consistent-type",
   /** If any spatial axis declares an orientation, all spatial axes do. */
   AxisOrientationCompleteness: "axis-orientation-completeness",
+  /** Orientation is declared only on spatial axes (never time/channel). */
+  AxisOrientationOnNonSpace: "axis-orientation-on-non-space",
+  /** At most one direction per anatomical axis (antonyms are exclusive). */
+  AxisOrientationUniqueAxis: "axis-orientation-unique-axis",
   /** A v0.5 entry implies a Zarr v3 store: a leaked `zarr_format` must be 3. */
   ZarrFormat: "zarr-format",
   /** A v0.5 entry must not retain a group-level `ome`/`multiscales` wrapper. */
@@ -588,9 +592,12 @@ function axisToValidationRecord(axis: Axis): Record<string, unknown> {
  *
  * @param metadata - The parsed multiscales metadata to validate.
  * @throws {ValidationError} With {@link SpecRule.AxisOrientationConsistentType}
- * when the spatial axes' orientations do not all share one `type`, or
+ * when the spatial axes' orientations do not all share one `type`,
  * {@link SpecRule.AxisOrientationCompleteness} when orientation is defined for
- * some but not all spatial axes; location `multiscales[0].axes`. The original
+ * some but not all spatial axes, {@link SpecRule.AxisOrientationOnNonSpace} when
+ * orientation is declared on a non-spatial axis, or
+ * {@link SpecRule.AxisOrientationUniqueAxis} when two spatial axes describe the
+ * same anatomical axis; location `multiscales[0].axes`. The original
  * RFC 4 message text is preserved. Any other failure from
  * {@link validateRfc4Orientation} -- e.g. an orientation value outside the
  * RFC 4 vocabulary, a schema-level concern with no dedicated structural rule
@@ -598,24 +605,36 @@ function axisToValidationRecord(axis: Axis): Record<string, unknown> {
  */
 export function validateAxisOrientation(metadata: Metadata): void {
   const axesRecords = metadata.axes.map(axisToValidationRecord);
-  if (!hasRfc4OrientationMetadata(axesRecords)) {
+  // A stray orientation on a non-spatial axis carries no spatial-axis
+  // orientation, so hasRfc4OrientationMetadata alone would skip it; check for any
+  // declared orientation so the non-space rule is reachable.
+  const nonSpaceOrientation = axesRecords.some(
+    (axisRecord) =>
+      typeof axisRecord === "object" &&
+      axisRecord !== null &&
+      axisRecord.type !== "space" &&
+      "orientation" in axisRecord,
+  );
+  if (!hasRfc4OrientationMetadata(axesRecords) && !nonSpaceOrientation) {
     return;
   }
   try {
     validateRfc4Orientation(axesRecords);
   } catch (error) {
-    // validateRfc4Orientation throws exactly two messages this rule maps: a
-    // spatial-orientation "same type" mismatch and the all-or-none completeness
-    // failure. An out-of-vocabulary orientation value -- a schema-level concern
-    // with no dedicated structural rule -- carries neither marker and so
-    // propagates unchanged, matching the package's Python implementation.
+    // validateRfc4Orientation throws four messages this rule maps: a
+    // spatial-orientation "same type" mismatch, the all-or-none completeness
+    // failure, orientation on "non-space axes", and two axes on the "same
+    // anatomical axis". An out-of-vocabulary orientation value -- a schema-level
+    // concern with no dedicated structural rule -- carries none of these markers
+    // and so propagates unchanged, matching the package's Python implementation.
     //
-    // The "same type" / "all spatial axes" substrings below are a load-bearing
-    // contract with validateRfc4Orientation's message text: an unrecognized
-    // error falls through to the final `throw` and surfaces as a plain Error
-    // rather than a ValidationError. The message-stability test in
-    // structural_validation_orientation_test.ts pins both markers so editing
-    // that wording fails CI loudly instead of silently breaking this mapping.
+    // The marker substrings below ("same type", "all spatial axes", "non-space
+    // axes", "same anatomical axis") are a load-bearing contract with
+    // validateRfc4Orientation's message text: an unrecognized error falls
+    // through to the final `throw` and surfaces as a plain Error rather than a
+    // ValidationError. The message-stability test in
+    // structural_validation_orientation_test.ts pins the markers so editing that
+    // wording fails CI loudly instead of silently breaking this mapping.
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes("same type")) {
       throw new ValidationError(
@@ -627,6 +646,20 @@ export function validateAxisOrientation(metadata: Metadata): void {
     if (message.includes("all spatial axes")) {
       throw new ValidationError(
         SpecRule.AxisOrientationCompleteness,
+        message,
+        "multiscales[0].axes",
+      );
+    }
+    if (message.includes("non-space axes")) {
+      throw new ValidationError(
+        SpecRule.AxisOrientationOnNonSpace,
+        message,
+        "multiscales[0].axes",
+      );
+    }
+    if (message.includes("same anatomical axis")) {
+      throw new ValidationError(
+        SpecRule.AxisOrientationUniqueAxis,
         message,
         "multiscales[0].axes",
       );

--- a/ts/test/structural_validation_orientation_test.ts
+++ b/ts/test/structural_validation_orientation_test.ts
@@ -195,5 +195,65 @@ Deno.test(
       Error,
       "all spatial axes",
     );
+
+    // Orientation on a non-spatial axis -> the on-non-space marker.
+    assertThrows(
+      () =>
+        validateRfc4Orientation([
+          {
+            name: "t",
+            type: "time",
+            orientation: { type: "anatomical", value: "inferior-to-superior" },
+          },
+        ]),
+      Error,
+      "non-space axes",
+    );
+
+    // Two spatial axes on one anatomical axis -> the unique-axis marker.
+    assertThrows(
+      () =>
+        validateRfc4Orientation([
+          {
+            name: "y",
+            type: "space",
+            orientation: { type: "anatomical", value: "left-to-right" },
+          },
+          {
+            name: "x",
+            type: "space",
+            orientation: { type: "anatomical", value: "right-to-left" },
+          },
+        ]),
+      Error,
+      "same anatomical axis",
+    );
+  },
+);
+
+Deno.test(
+  "validateRfc4Orientation - same-name spatial entries still collide",
+  () => {
+    // Malformed metadata can repeat an axis name. A name-keyed map would
+    // overwrite the first entry and let the opposing pair slip through, so the
+    // check keeps every [name, value] entry. Mirrors the Python
+    // test_validate_rfc4_orientation_duplicate_anatomical_axis_same_name.
+    assertThrows(
+      () =>
+        validateRfc4Orientation([
+          {
+            name: "x",
+            type: "space",
+            orientation: { type: "anatomical", value: "left-to-right" },
+          },
+          {
+            name: "x",
+            type: "space",
+            orientation: { type: "anatomical", value: "right-to-left" },
+          },
+        ]),
+      Error,
+      "same anatomical axis",
+    );
   },
 );

--- a/ts/test/structural_validation_parity_test.ts
+++ b/ts/test/structural_validation_parity_test.ts
@@ -69,6 +69,8 @@ const CANONICAL_SPEC_RULE_IDS: string[] = [
   "omero-channel-color-format",
   "axis-orientation-consistent-type",
   "axis-orientation-completeness",
+  "axis-orientation-on-non-space",
+  "axis-orientation-unique-axis",
   "zarr-format",
   "ome-namespace",
   "plate-row-index-consistency",


### PR DESCRIPTION
## Problem

`validate_rfc4_orientation` accepts two malformed inputs that RFC-4 forbids:

1. **Orientation on a non-spatial axis** — RFC-4 orientation is only defined for `space` axes, yet an orientation declared on a `time`/`channel` axis was silently accepted.
2. **Duplicate anatomical axis** — RFC-4 directions are mutually exclusive (one per antonym pair), yet two spatial axes on the same axis (e.g. `left-to-right` and `right-to-left`) were silently accepted.

## Fix

Two checks added to `validate_rfc4_orientation`, surfaced through the existing `SpecRule` channel as `axis-orientation-on-non-space` and `axis-orientation-unique-axis`. Well-formed metadata is unaffected; only these two malformed shapes are now rejected.

## Tests

- unit tests for both new rules, at the function level and via the `validate_axis_orientation` → `SpecRule` mapping;
- the message-marker stability test updated with the two new markers.

All RFC-4 orientation tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened RFC 4 axis-orientation validation by rejecting any `orientation` on non-space axes (including `orientation: {}`).
  * Added enforcement to prevent multiple spatial axes from resolving to the same anatomical axis, avoiding conflicting/duplicate direction metadata.
  * Validation now reports dedicated rule identifiers for these cases (Python + TypeScript).

* **Tests**
  * Expanded unit and message-mapping tests to cover non-space rejection, empty-orientation rejection, and duplicate anatomical-axis (including same-name collision) failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->