### PR TITLE
fix: RFC 4 orientation is optional per axis, null equals absent, type must be anatomical

### DIFF
--- a/docs/validation/parity.md
+++ b/docs/validation/parity.md
@@ -57,14 +57,15 @@ The canonical `SpecRule` set, in evaluation order:
 5. `global-coord-transform-after-per-level`
 6. `dataset-order-highest-to-lowest`
 7. `omero-channel-color-format`
-8. `axis-orientation-consistent-type`
-9. `axis-orientation-completeness`
-10. `zarr-format`
-11. `ome-namespace`
-12. `plate-row-index-consistency`
-13. `well-acquisition-missing`
+8. `axis-orientation-anatomical-type`
+9. `axis-orientation-on-non-space`
+10. `axis-orientation-unique-axis`
+11. `zarr-format`
+12. `ome-namespace`
+13. `plate-row-index-consistency`
+14. `well-acquisition-missing`
 
-Entries 10–11 are the v0.5 namespacing rules; they fire only for v0.5 metadata
+Entries 11–12 are the v0.5 namespacing rules; they fire only for v0.5 metadata
 and are inert for v0.4. Each suite pins this list as a `CANONICAL_SPEC_RULE_IDS`
 literal — byte-identical between the two languages so the tests are
 line-for-line comparable.

--- a/docs/validation/rule-reference.md
+++ b/docs/validation/rule-reference.md
@@ -43,12 +43,13 @@ the `SpecRule` enum declares them and the orchestrators evaluate them.
 | 5  | `global-coord-transform-after-per-level` | images/multiscales | Exactly one `scale` per dataset, and a `translation` must follow — not precede — its `scale`. | v0.4: each dataset defines exactly one scale; a translation follows its scale. | `multiscales[0].datasets[1].coordinateTransformations` |
 | 6  | `dataset-order-highest-to-lowest` | images/multiscales | Datasets ordered finest → coarsest; the spatial scale must not decrease as the level index rises. | v0.4: multiscale datasets ordered from highest to lowest resolution. | `multiscales[0].datasets[2]` |
 | 7  | `omero-channel-color-format` | OMERO | Each OMERO channel `color` is exactly six hexadecimal digits (RGB). | v0.4: OMERO channel color is 6 hex digits. | `multiscales[0].omero.channels[0].color` |
-| 8  | `axis-orientation-consistent-type` | RFC 4 orientation | All spatial-axis anatomical orientations share one `type`. | RFC 4: all spatial-axis orientations share one type. | `multiscales[0].axes` |
-| 9  | `axis-orientation-completeness` | RFC 4 orientation | If any spatial axis declares an orientation, all spatial axes must. | RFC 4: orientation is all-or-none across spatial axes. | `multiscales[0].axes` |
-| 10 | `zarr-format` | images/multiscales (v0.5) | A v0.5 entry implies a Zarr v3 store; a `zarr_format` value that leaked into the entry must be exactly `3`. Inert for v0.4. | v0.5: metadata is backed by a Zarr v3 store (`zarr_format == 3`). | `multiscales[0]` |
-| 11 | `ome-namespace` | images/multiscales (v0.5) | A v0.5 entry must not retain a group-level `ome` or `multiscales` wrapper key — the `ome` namespace wraps the group attributes, not each entry. Inert for v0.4. | v0.5: multiscales live under the top-level `ome` namespace, with `version` hoisted to `ome.version`. | `multiscales[0]` |
-| 12 | `plate-row-index-consistency` | HCS plate | Each well's `path` is `<row>/<column>`, naming declared row/column entries, with `rowIndex`/`columnIndex` equal to those entries' positions. | v0.4: well `rowIndex`/`columnIndex` match the named row/column positions in `plate.rows`/`plate.columns`. | `plate.wells[3]` |
-| 13 | `well-acquisition-missing` | HCS well | When the plate declares more than one acquisition, every well image references one via `acquisition`. | v0.4: with multiple acquisitions, each well image references an acquisition. | `well.images[0].acquisition` |
+| 8  | `axis-orientation-anatomical-type` | RFC 4 orientation | Every declared spatial-axis `orientation` has `type` `anatomical`. | RFC 4: an orientation's `type` is `anatomical`. | `multiscales[0].axes` |
+| 9  | `axis-orientation-on-non-space` | RFC 4 orientation | An `orientation` is declared only on `space` axes, never on a non-spatial axis. | RFC 4: orientation applies to spatial axes only. | `multiscales[0].axes[0]` |
+| 10 | `axis-orientation-unique-axis` | RFC 4 orientation | No two spatial axes declare orientations describing the same anatomical axis. | RFC 4: each spatial axis describes a distinct anatomical axis. | `multiscales[0].axes` |
+| 11 | `zarr-format` | images/multiscales (v0.5) | A v0.5 entry implies a Zarr v3 store; a `zarr_format` value that leaked into the entry must be exactly `3`. Inert for v0.4. | v0.5: metadata is backed by a Zarr v3 store (`zarr_format == 3`). | `multiscales[0]` |
+| 12 | `ome-namespace` | images/multiscales (v0.5) | A v0.5 entry must not retain a group-level `ome` or `multiscales` wrapper key — the `ome` namespace wraps the group attributes, not each entry. Inert for v0.4. | v0.5: multiscales live under the top-level `ome` namespace, with `version` hoisted to `ome.version`. | `multiscales[0]` |
+| 13 | `plate-row-index-consistency` | HCS plate | Each well's `path` is `<row>/<column>`, naming declared row/column entries, with `rowIndex`/`columnIndex` equal to those entries' positions. | v0.4: well `rowIndex`/`columnIndex` match the named row/column positions in `plate.rows`/`plate.columns`. | `plate.wells[3]` |
+| 14 | `well-acquisition-missing` | HCS well | When the plate declares more than one acquisition, every well image references one via `acquisition`. | v0.4: with multiple acquisitions, each well image references an acquisition. | `well.images[0].acquisition` |
 
 ## Evaluation order and orchestrators
 
@@ -56,21 +57,24 @@ The rules are evaluated fail-fast: the first violation raises a
 `ValidationError` and later rules do not run. Three orchestrators dispatch the
 rules:
 
-- **`validate_structural` / `validateStructural`** evaluates rules **1–11** (the
+- **`validate_structural` / `validateStructural`** evaluates rules **1–12** (the
   image/multiscales rules, including the OMERO color check, the RFC 4
   orientation checks, and the two v0.5 namespacing rules). Rules 3 and 5 each
   have two internal enforcement points that share a single identifier — axis
   class-ordering then spatial-name ordering for `axis-order`; per-dataset
   scale-count then transform-ordering for
-  `global-coord-transform-after-per-level`. The v0.5 namespacing rules (10 and
-  11) run last and are inert for v0.4 input, so for a v0.4 metadata the observed
-  evaluation order is a 10-step sequence over identifiers 1–9.
-- **`validate_plate` / `validatePlate`** evaluates rule **12**
+  `global-coord-transform-after-per-level`. The v0.5 namespacing rules (11 and
+  12) run last and are inert for v0.4 input. The orientation rules
+  `axis-orientation-on-non-space` (9) and `axis-orientation-unique-axis` (10)
+  fire only for specific orientation shapes, so the linear fail-fast cascade for
+  a v0.4 metadata is a 10-step sequence ending at
+  `axis-orientation-anatomical-type` (identifiers 1–8).
+- **`validate_plate` / `validatePlate`** evaluates rule **13**
   (`plate-row-index-consistency`).
-- **`validate_well` / `validateWell`** evaluates rule **13**
+- **`validate_well` / `validateWell`** evaluates rule **14**
   (`well-acquisition-missing`), in the context of its parent plate.
 
-The two HCS rules (12 and 13) are deliberately absent from the image
+The two HCS rules (13 and 14) are deliberately absent from the image
 orchestrator's order; they operate on separate metadata objects. The exact
 fail-fast sequence is locked by the parity tests described in [[parity]].
 
@@ -80,8 +84,8 @@ fail-fast sequence is locked by the parity tests described in [[parity]].
   `scale-length-mismatch`, `global-coord-transform-after-per-level`,
   `dataset-order-highest-to-lowest`.
 - **OMERO** — `omero-channel-color-format`.
-- **RFC 4 orientation** — `axis-orientation-consistent-type`,
-  `axis-orientation-completeness`.
+- **RFC 4 orientation** — `axis-orientation-anatomical-type`,
+  `axis-orientation-on-non-space`, `axis-orientation-unique-axis`.
 - **v0.5 namespacing** — `zarr-format`, `ome-namespace` (inert for v0.4).
 - **HCS plate / well** — `plate-row-index-consistency`,
   `well-acquisition-missing`.

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -1301,17 +1301,38 @@ def _upgrade_main(argv: list[str] | None = None) -> None:
         )
 
 
+def _conformance_main(argv: list[str] | None = None) -> None:
+    """Handle the ``ngff-zarr conformance`` subcommand.
+
+    Prints one canonical JSON RFC 4 verdict (rfc4_valid, axes, violations,
+    warnings) per input, for a tool-agnostic conformance driver to diff against
+    its manifest.
+    """
+    import json
+
+    from .rfc4_conformance import conformance_report
+
+    if argv is None:
+        argv = sys.argv[1:]
+    if len(argv) != 1:
+        print("usage: ngff-zarr conformance <input>", file=sys.stderr)
+        raise SystemExit(2)
+    print(json.dumps(conformance_report(argv[0]), indent=2))
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``ngff-zarr`` command.
 
-    Dispatches to the ``upgrade`` subcommand when the first token is
-    ``"upgrade"``; otherwise runs the flat conversion command unchanged so
+    Dispatches to the ``upgrade`` or ``conformance`` subcommand when the first
+    token matches; otherwise runs the flat conversion command unchanged so
     existing invocations behave exactly as before.
     """
     if argv is None:
         argv = sys.argv[1:]
     if argv and argv[0] == "upgrade":
         return _upgrade_main(argv[1:])
+    if argv and argv[0] == "conformance":
+        return _conformance_main(argv[1:])
     return _convert_main(argv)
 
 

--- a/py/ngff_zarr/rfc4_conformance.py
+++ b/py/ngff_zarr/rfc4_conformance.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""RFC 4 conformance output for the ``ngff-zarr`` CLI.
+
+``ngff-zarr conformance <input>`` prints one JSON verdict per input -- the shape
+a tool-agnostic conformance driver feeds against its manifest to check that an
+implementation follows RFC 4:
+
+    {"input": ..., "format": "ome-zarr", "rfc4_valid": bool,
+     "axes": {name: value}, "violations": [code, ...], "warnings": [code, ...]}
+
+It reuses :func:`~ngff_zarr.rfc4_validation.validate_rfc4_orientation` (no rule is
+reimplemented) and reads the *raw* axes, so malformed metadata is still
+classifiable -- the high-level reader would reject it before it could be reported.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from .rfc4_validation import validate_rfc4_orientation
+
+# Metadata files that may hold the multiscales, most specific first.
+_METADATA_NAMES = ("zarr.json", ".zattrs")
+
+
+class _UnreadableInput(Exception):
+    """The input is not a readable OME-Zarr carrying an axes list.
+
+    Holds the conformance ``code`` to surface as the verdict violation, so an
+    unreadable or non-OME-Zarr input is reported as invalid rather than silently
+    treated as an empty (and therefore "valid") axes list.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _axes_from_metadata(meta: Any) -> list[dict[str, Any]]:
+    """Pull ``multiscales[0].axes`` out of a v2 ``.zattrs`` or v3 ``zarr.json`` blob."""
+    if not isinstance(meta, dict):
+        raise _UnreadableInput("input-not-ome-zarr", "metadata is not a JSON object")
+    attributes = meta.get("attributes", meta)
+    ome = attributes.get("ome", attributes) if isinstance(attributes, dict) else {}
+    try:
+        axes = ome["multiscales"][0]["axes"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise _UnreadableInput(
+            "input-not-ome-zarr", "metadata has no multiscales[0].axes"
+        ) from exc
+    if not isinstance(axes, list):
+        raise _UnreadableInput(
+            "input-not-ome-zarr", "multiscales[0].axes is not a list"
+        )
+    return axes
+
+
+def _load_json(raw: bytes | str, source: str) -> Any:
+    """Parse metadata JSON, classifying a decode failure as an unreadable input."""
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise _UnreadableInput(
+            "input-unreadable", f"{source} is not valid JSON"
+        ) from exc
+
+
+def _read_axes(path: str) -> list[dict[str, Any]]:
+    """Read the raw axis dicts from an OME-Zarr directory or ``.zip``.
+
+    Raises :class:`_UnreadableInput` when no readable OME-Zarr metadata carrying
+    an axes list is found, so the caller can emit an invalid verdict instead of
+    an empty axes list.
+    """
+    source = Path(path)
+    if source.suffix == ".zip":
+        try:
+            archive = zipfile.ZipFile(source)
+        except (FileNotFoundError, OSError, zipfile.BadZipFile) as exc:
+            raise _UnreadableInput(
+                "input-unreadable", f"{path} is not a readable zip archive"
+            ) from exc
+        with archive:
+            for name in sorted(archive.namelist(), key=lambda n: n.count("/")):
+                if name.endswith(_METADATA_NAMES):
+                    return _axes_from_metadata(_load_json(archive.read(name), name))
+        raise _UnreadableInput(
+            "input-not-ome-zarr", f"{path} has no zarr.json or .zattrs"
+        )
+    for name in _METADATA_NAMES:
+        candidate = source / name
+        if candidate.is_file():
+            with candidate.open(encoding="utf-8") as metadata_file:
+                return _axes_from_metadata(_load_json(metadata_file.read(), name))
+    raise _UnreadableInput("input-not-ome-zarr", f"{path} has no zarr.json or .zattrs")
+
+
+def _violation_code(exc: ValueError) -> str:
+    """Map a ``validate_rfc4_orientation`` ValueError onto its SpecRule code.
+
+    Uses the same stable message markers the structural validator relies on."""
+    message = str(exc)
+    if "non-space axes" in message:
+        return "axis-orientation-on-non-space"
+    if "same anatomical axis" in message:
+        return "axis-orientation-unique-axis"
+    if "same type" in message:
+        return "axis-orientation-consistent-type"
+    if "all spatial axes" in message:
+        return "axis-orientation-completeness"
+    return "orientation-invalid"
+
+
+def conformance_report(path: str) -> dict[str, Any]:
+    """Build the canonical conformance verdict for one OME-Zarr input.
+
+    An unreadable or non-OME-Zarr input yields an invalid verdict carrying the
+    read-failure code, never ``rfc4_valid: true`` with empty axes.
+    """
+    try:
+        axes = _read_axes(path)
+    except _UnreadableInput as exc:
+        return {
+            "input": path,
+            "format": "ome-zarr",
+            "rfc4_valid": False,
+            "axes": {},
+            "violations": [exc.code],
+            "warnings": [],
+        }
+
+    # Built defensively from the raw axes: a malformed axis (missing name,
+    # non-dict orientation) is skipped here rather than crashing the verdict --
+    # validate_rfc4_orientation below still reports it as a violation.
+    orientations = {
+        axis["name"]: axis["orientation"]["value"]
+        for axis in axes
+        if isinstance(axis, dict)
+        and isinstance(axis.get("name"), str)
+        and isinstance(axis.get("orientation"), dict)
+        and axis["orientation"].get("value")
+    }
+
+    violations: list[str] = []
+    try:
+        validate_rfc4_orientation(axes)
+    except ValueError as exc:
+        violations.append(_violation_code(exc))
+    except Exception:
+        violations.append("orientation-schema-invalid")
+
+    return {
+        "input": path,
+        "format": "ome-zarr",
+        "rfc4_valid": not violations,
+        "axes": orientations,
+        "violations": violations,
+        "warnings": [],
+    }

--- a/py/ngff_zarr/rfc4_conformance.py
+++ b/py/ngff_zarr/rfc4_conformance.py
@@ -9,9 +9,13 @@ implementation follows RFC 4:
     {"input": ..., "format": "ome-zarr", "rfc4_valid": bool,
      "axes": {name: value}, "violations": [code, ...], "warnings": [code, ...]}
 
-It reuses :func:`~ngff_zarr.rfc4_validation.validate_rfc4_orientation` (no rule is
-reimplemented) and reads the *raw* axes, so malformed metadata is still
-classifiable -- the high-level reader would reject it before it could be reported.
+It reads the *raw* axes, so malformed metadata is still classifiable -- the
+high-level reader would reject it before it could be reported. Findings are
+reported with the conformance contract's code names: RFC 4 defines no error codes,
+and the package's own :class:`~ngff_zarr.structural_validation.SpecRule`
+identifiers are a different vocabulary, so the classification here is deliberately
+expressed in the contract's terms while applying the same RFC 4 rules as
+:func:`~ngff_zarr.rfc4_validation.validate_rfc4_orientation`.
 """
 
 from __future__ import annotations
@@ -21,7 +25,7 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
-from .rfc4_validation import validate_rfc4_orientation
+from .rfc4_validation import _ANATOMICAL_AXIS_OF
 
 # Metadata files that may hold the multiscales, most specific first.
 _METADATA_NAMES = ("zarr.json", ".zattrs")
@@ -99,20 +103,60 @@ def _read_axes(path: str) -> list[dict[str, Any]]:
     raise _UnreadableInput("input-not-ome-zarr", f"{path} has no zarr.json or .zattrs")
 
 
-def _violation_code(exc: ValueError) -> str:
-    """Map a ``validate_rfc4_orientation`` ValueError onto its SpecRule code.
+def _classify(axes: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    """Classify RFC 4 findings using the conformance contract's code vocabulary.
 
-    Uses the same stable message markers the structural validator relies on."""
-    message = str(exc)
-    if "non-space axes" in message:
-        return "axis-orientation-on-non-space"
-    if "same anatomical axis" in message:
-        return "axis-orientation-unique-axis"
-    if "same type" in message:
-        return "axis-orientation-consistent-type"
-    if "all spatial axes" in message:
-        return "axis-orientation-completeness"
-    return "orientation-invalid"
+    RFC 4 defines no error codes, so the names below belong to the conformance
+    contract rather than to the specification. The rules applied are the RFC's:
+
+    - ``orientation`` MUST only be used on spatial axes;
+    - an ``orientation`` object MUST carry a ``type`` (only ``"anatomical"`` is
+      defined) and a ``value`` drawn from the controlled vocabulary;
+    - a set of axes MUST only carry one direction of each antonym pair.
+
+    Orientation is optional per spatial axis, and an absent orientation is
+    equivalent to an explicit ``null`` -- neither is a violation -- but a writer
+    SHOULD omit the field rather than serialize ``null``, which is reported as a
+    warning. A code may repeat, once per offending axis.
+    """
+    violations: list[str] = []
+    warnings: list[str] = []
+    seen_anatomical_axis: dict[str, str] = {}
+
+    for axis in axes:
+        if not isinstance(axis, dict):
+            continue
+        orientation = axis.get("orientation")
+
+        # An explicit null is equivalent to an absent field (undefined), but
+        # RFC 4 says writers SHOULD omit it instead.
+        if "orientation" in axis and orientation is None:
+            warnings.append("null-orientation")
+            continue
+        if not isinstance(orientation, dict) or not orientation:
+            continue
+
+        if axis.get("type") != "space":
+            violations.append("orientation-on-non-space")
+            continue
+        if orientation.get("type") != "anatomical":
+            violations.append("bad-type")
+            continue
+        value = orientation.get("value")
+        if value is None:
+            violations.append("missing-value")
+            continue
+        if value not in _ANATOMICAL_AXIS_OF:
+            violations.append("bad-value")
+            continue
+
+        axis_key = _ANATOMICAL_AXIS_OF[value]
+        if axis_key in seen_anatomical_axis:
+            violations.append("duplicate-anatomical-axis")
+        else:
+            seen_anatomical_axis[axis_key] = str(axis.get("name"))
+
+    return violations, warnings
 
 
 def conformance_report(path: str) -> dict[str, Any]:
@@ -134,8 +178,8 @@ def conformance_report(path: str) -> dict[str, Any]:
         }
 
     # Built defensively from the raw axes: a malformed axis (missing name,
-    # non-dict orientation) is skipped here rather than crashing the verdict --
-    # validate_rfc4_orientation below still reports it as a violation.
+    # non-dict orientation) is skipped in this display map rather than crashing
+    # the verdict; _classify below still reports any rule it violates.
     orientations = {
         axis["name"]: axis["orientation"]["value"]
         for axis in axes
@@ -145,13 +189,7 @@ def conformance_report(path: str) -> dict[str, Any]:
         and axis["orientation"].get("value")
     }
 
-    violations: list[str] = []
-    try:
-        validate_rfc4_orientation(axes)
-    except ValueError as exc:
-        violations.append(_violation_code(exc))
-    except Exception:
-        violations.append("orientation-schema-invalid")
+    violations, warnings = _classify(axes)
 
     return {
         "input": path,
@@ -159,5 +197,5 @@ def conformance_report(path: str) -> dict[str, Any]:
         "rfc4_valid": not violations,
         "axes": orientations,
         "violations": violations,
-        "warnings": [],
+        "warnings": warnings,
     }

--- a/py/ngff_zarr/rfc4_validation.py
+++ b/py/ngff_zarr/rfc4_validation.py
@@ -70,16 +70,23 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
     jsonschema.ValidationError
         If the orientation metadata is invalid
     ValueError
-        If orientation is inconsistently or illegally defined. The messages carry
-        stable marker substrings -- ``"same type"`` (mixed ``type``),
-        ``"all spatial axes"`` (all-or-none completeness), ``"non-space axes"``
-        (orientation on a non-spatial axis) and ``"same anatomical axis"`` (two
-        axes on one antonym pair) -- that
+        If orientation is illegally defined. The messages carry stable marker
+        substrings -- ``"must be anatomical"`` (``type`` other than the single
+        value the vocabulary defines), ``"non-space axes"`` (orientation on a
+        non-spatial axis) and ``"same anatomical axis"`` (two axes on one antonym
+        pair) -- that
         :func:`ngff_zarr.structural_validation.validate_axis_orientation` reads
         to map each failure onto its :class:`SpecRule`. These markers are a
         load-bearing contract pinned by a message-stability test
         (``test_rfc4_orientation_messages_carry_mapping_markers``) so the
         mapping cannot silently break if the wording is later edited.
+
+    Notes
+    -----
+    RFC 4 makes ``orientation`` optional per spatial axis: an image may orient
+    only some of its spatial axes, and an absent orientation is equivalent to an
+    explicit ``null`` (the axis orientation is undefined). No all-or-none
+    completeness rule is enforced.
     """
     try:
         from jsonschema import Draft202012Validator
@@ -90,11 +97,9 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
             "install the ngff-zarr[validate] extra"
         )
 
-    # Check if any spatial axes have orientation defined
+    # RFC 4: orientation is optional per spatial axis. Collect the (name, value)
+    # of every spatial axis that carries a real orientation object.
     has_orientation = False
-    orientation_type = None
-    spatial_axes_with_orientation = []
-    spatial_axes_without_orientation = []
     spatial_orientation_values: list[tuple[str, str]] = []
 
     # Valid anatomical orientation values (from the schema)
@@ -127,53 +132,51 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
 
     for axis in axes:
         if isinstance(axis, dict) and axis.get("type") == "space":
-            if "orientation" in axis:
-                has_orientation = True
-                spatial_axes_with_orientation.append(axis["name"])
+            orientation = axis.get("orientation")
+            # RFC 4: an absent orientation, an explicit null, and an empty object
+            # are equivalent -- the axis orientation is undefined. Orientation is
+            # optional per spatial axis, so a partially oriented image is valid.
+            # Any other value is a real orientation to validate; a non-dict value
+            # is malformed and is left for the JSON Schema check below to reject.
+            if orientation is None or orientation == {}:
+                continue
+            has_orientation = True
 
-                # Check that all orientations have the same type
-                if orientation_type is None:
-                    orientation_type = axis["orientation"].get("type")
-                elif axis["orientation"].get("type") != orientation_type:
-                    raise ValueError(
-                        f"All spatial axis orientations must have the same type. "
-                        f"Found types: {orientation_type} and {axis['orientation'].get('type')}"
-                    )
+            # RFC 4: the orientation type is restricted to the single value the
+            # controlled vocabulary defines, "anatomical". A non-object orientation
+            # cannot carry that type, so it fails the same check.
+            orientation_type = (
+                orientation.get("type") if isinstance(orientation, dict) else None
+            )
+            if orientation_type != "anatomical":
+                raise ValueError(
+                    f"RFC 4 orientation type must be anatomical; axis "
+                    f"'{axis['name']}' has type '{orientation_type}'."
+                )
 
-                # Check that the orientation value is valid
-                orientation_value = axis["orientation"].get("value")
-                if orientation_value not in valid_orientation_values:
-                    from jsonschema import ValidationError
+            # Check that the orientation value is in the controlled vocabulary
+            orientation_value = orientation.get("value")
+            if orientation_value not in valid_orientation_values:
+                from jsonschema import ValidationError
 
-                    raise ValidationError(
-                        f"Invalid orientation value '{orientation_value}' for axis '{axis['name']}'. "
-                        f"Valid values are: {sorted(valid_orientation_values)}"
-                    )
-                spatial_orientation_values.append((axis["name"], orientation_value))
-            else:
-                spatial_axes_without_orientation.append(axis["name"])
+                raise ValidationError(
+                    f"Invalid orientation value '{orientation_value}' for axis '{axis['name']}'. "
+                    f"Valid values are: {sorted(valid_orientation_values)}"
+                )
+            spatial_orientation_values.append((axis["name"], orientation_value))
 
-    # RFC 4 requirement: if orientation is defined for one spatial axis, it must
-    # be defined for all spatial axes. Checked before the rules below to keep the
-    # canonical SpecRule precedence (completeness is declared before the non-space
-    # and unique-axis rules).
-    if has_orientation and spatial_axes_without_orientation:
-        raise ValueError(
-            f"RFC 4 requires that if orientation is defined for one spatial axis, "
-            f"it must be defined for all spatial axes. "
-            f"Axes with orientation: {spatial_axes_with_orientation}, "
-            f"axes without orientation: {spatial_axes_without_orientation}"
-        )
-
-    # RFC 4 requirement: orientation is only allowed on spatial axes. (Checked
-    # over all axes, independently of has_orientation, so a stray orientation on
-    # a time/channel axis is caught even when no spatial axis carries one.)
+    # RFC 4 requirement: orientation is only allowed on spatial axes. Only a real
+    # orientation counts as "used"; a null or empty orientation is undefined, so
+    # it is not a violation on a non-spatial axis. Any other non-null value is a
+    # use of orientation. Checked over all axes so a stray orientation is caught
+    # even when no spatial axis carries one.
     non_space_with_orientation = [
         axis["name"]
         for axis in axes
         if isinstance(axis, dict)
         and axis.get("type") != "space"
-        and "orientation" in axis
+        and axis.get("orientation") is not None
+        and axis.get("orientation") != {}
     ]
     if non_space_with_orientation:
         raise ValueError(

--- a/py/ngff_zarr/structural_validation.py
+++ b/py/ngff_zarr/structural_validation.py
@@ -46,11 +46,8 @@ violation, in canonical spec-MUST order.
 #   omero-channel-color-format
 #       each OMERO channel color is exactly 6 hex digits
 #       e.g. multiscales[0].omero.channels[0].color
-#   axis-orientation-consistent-type
-#       all spatial-axis RFC 4 orientations share one type
-#       e.g. multiscales[0].axes
-#   axis-orientation-completeness
-#       if any spatial axis has orientation, all spatial axes do
+#   axis-orientation-anatomical-type
+#       each RFC 4 orientation type is "anatomical" (the only value defined)
 #       e.g. multiscales[0].axes
 #   axis-orientation-on-non-space
 #       orientation is declared only on spatial axes (never time/channel)
@@ -97,8 +94,7 @@ class SpecRule(str, Enum):
     GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL = "global-coord-transform-after-per-level"
     DATASET_ORDER_HIGHEST_TO_LOWEST = "dataset-order-highest-to-lowest"
     OMERO_CHANNEL_COLOR_FORMAT = "omero-channel-color-format"
-    AXIS_ORIENTATION_CONSISTENT_TYPE = "axis-orientation-consistent-type"
-    AXIS_ORIENTATION_COMPLETENESS = "axis-orientation-completeness"
+    AXIS_ORIENTATION_ANATOMICAL_TYPE = "axis-orientation-anatomical-type"
     AXIS_ORIENTATION_ON_NON_SPACE = "axis-orientation-on-non-space"
     AXIS_ORIENTATION_UNIQUE_AXIS = "axis-orientation-unique-axis"
     ZARR_FORMAT = "zarr-format"
@@ -506,6 +502,11 @@ def _axis_to_validation_dict(axis: Axis) -> dict[str, Any]:
     orientation = axis.orientation
     if orientation is not None:
         if isinstance(orientation, dict):
+            # An empty orientation object is undefined under RFC 4, exactly like
+            # an absent one, so it must not be rendered as a populated
+            # {type, value} dict -- that would read back as a real orientation.
+            if not orientation:
+                return axis_dict
             orientation_type = orientation.get("type")
             orientation_value = orientation.get("value")
         else:
@@ -537,10 +538,8 @@ def validate_axis_orientation(metadata: Metadata) -> None:
     Raises
     ------
     ValidationError
-        With :attr:`SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE` when the spatial
-        axes' orientations do not all share one ``type``,
-        :attr:`SpecRule.AXIS_ORIENTATION_COMPLETENESS` when orientation is defined
-        for some but not all spatial axes,
+        With :attr:`SpecRule.AXIS_ORIENTATION_ANATOMICAL_TYPE` when an orientation
+        ``type`` is not ``"anatomical"``,
         :attr:`SpecRule.AXIS_ORIENTATION_ON_NON_SPACE` when orientation is declared
         on a non-spatial axis, or :attr:`SpecRule.AXIS_ORIENTATION_UNIQUE_AXIS`
         when two spatial axes describe the same anatomical axis; location
@@ -557,11 +556,13 @@ def validate_axis_orientation(metadata: Metadata) -> None:
     axes_dicts = [_axis_to_validation_dict(axis) for axis in metadata.axes]
     # A stray orientation on a non-spatial axis carries no spatial-axis
     # orientation, so has_rfc4_orientation_metadata alone would skip it; check for
-    # any declared orientation so the non-space rule is reachable.
+    # any real (non-empty) orientation so the non-space rule is reachable. A null
+    # or empty orientation is undefined under RFC 4 and so is not a violation.
     non_space_orientation = any(
         isinstance(axis_dict, dict)
         and axis_dict.get("type") != "space"
-        and "orientation" in axis_dict
+        and isinstance(axis_dict.get("orientation"), dict)
+        and axis_dict.get("orientation")
         for axis_dict in axes_dicts
     )
     if not has_rfc4_orientation_metadata(axes_dicts) and not non_space_orientation:
@@ -569,16 +570,16 @@ def validate_axis_orientation(metadata: Metadata) -> None:
     try:
         validate_rfc4_orientation(axes_dicts)
     except ValueError as exc:
-        # validate_rfc4_orientation raises four mappable ValueErrors: a spatial
-        # orientation "same type" mismatch, the all-or-none completeness failure,
-        # orientation on "non-space axes", and two axes on the "same anatomical
-        # axis". jsonschema's ValidationError (raised for an out-of-vocabulary
-        # orientation value) is not a ValueError, so it -- like ImportError when
-        # jsonschema is absent -- propagates untouched; no structural rule covers
-        # those schema-level concerns.
+        # validate_rfc4_orientation raises three mappable ValueErrors: an
+        # orientation type that is not "anatomical", orientation on "non-space
+        # axes", and two axes on the "same anatomical axis". jsonschema's
+        # ValidationError (raised for an out-of-vocabulary orientation value) is
+        # not a ValueError, so it -- like ImportError when jsonschema is absent --
+        # propagates untouched; no structural rule covers those schema-level
+        # concerns.
         #
-        # The marker substrings below ("same type", "all spatial axes",
-        # "non-space axes", "same anatomical axis") are a load-bearing contract
+        # The marker substrings below ("must be anatomical", "non-space axes",
+        # "same anatomical axis") are a load-bearing contract
         # with validate_rfc4_orientation's message text: an unrecognized
         # ValueError falls through to the bare ``raise`` and is surfaced as a
         # plain ValueError rather than a ValidationError. The message-stability
@@ -586,15 +587,9 @@ def validate_axis_orientation(metadata: Metadata) -> None:
         # markers so editing that wording fails CI loudly instead of silently
         # breaking this mapping.
         message = str(exc)
-        if "same type" in message:
+        if "must be anatomical" in message:
             raise ValidationError(
-                SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE,
-                message,
-                "multiscales[0].axes",
-            ) from exc
-        if "all spatial axes" in message:
-            raise ValidationError(
-                SpecRule.AXIS_ORIENTATION_COMPLETENESS,
+                SpecRule.AXIS_ORIENTATION_ANATOMICAL_TYPE,
                 message,
                 "multiscales[0].axes",
             ) from exc

--- a/py/test/test_cli_conformance.py
+++ b/py/test/test_cli_conformance.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for the ``ngff-zarr conformance`` RFC 4 verdict output."""
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from ngff_zarr.cli import main
+from ngff_zarr.rfc4_conformance import conformance_report
+
+Axis = dict[str, Any]
+
+
+def _write_zarr(tmp_path: Path, axes: list[Axis]) -> str:
+    """Write a minimal v3 ``zarr.json`` carrying the given axes; return its path."""
+    metadata = {"attributes": {"ome": {"multiscales": [{"axes": axes}]}}}
+    (tmp_path / "zarr.json").write_text(json.dumps(metadata))
+    return str(tmp_path)
+
+
+def _write_zattrs(tmp_path: Path, axes: list[Axis]) -> str:
+    """Write a minimal v2 ``.zattrs`` carrying the given axes; return its dir path."""
+    metadata = {"multiscales": [{"axes": axes}]}
+    (tmp_path / ".zattrs").write_text(json.dumps(metadata))
+    return str(tmp_path)
+
+
+def _write_zarr_zip(tmp_path: Path, axes: list[Axis]) -> str:
+    """Pack a minimal v3 ``zarr.json`` into a ``.zip``; return the archive path."""
+    metadata = {"attributes": {"ome": {"multiscales": [{"axes": axes}]}}}
+    archive = tmp_path / "image.ome.zarr.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("zarr.json", json.dumps(metadata))
+    return str(archive)
+
+
+def _space(name: str, value: str) -> Axis:
+    return {
+        "name": name,
+        "type": "space",
+        "orientation": {"type": "anatomical", "value": value},
+    }
+
+
+_LPS = (
+    _space("z", "inferior-to-superior"),
+    _space("y", "anterior-to-posterior"),
+    _space("x", "right-to-left"),
+)
+
+
+def test_conformance_report_valid(tmp_path):
+    path = _write_zarr(
+        tmp_path,
+        [
+            _space("z", "inferior-to-superior"),
+            _space("y", "anterior-to-posterior"),
+            _space("x", "right-to-left"),
+        ],
+    )
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is True
+    assert report["violations"] == []
+    assert report["axes"] == {
+        "z": "inferior-to-superior",
+        "y": "anterior-to-posterior",
+        "x": "right-to-left",
+    }
+
+
+def test_conformance_report_orientation_on_non_space(tmp_path):
+    path = _write_zarr(
+        tmp_path,
+        [
+            {
+                "name": "t",
+                "type": "time",
+                "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
+            },
+            _space("z", "inferior-to-superior"),
+            _space("y", "anterior-to-posterior"),
+            _space("x", "right-to-left"),
+        ],
+    )
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is False
+    assert "axis-orientation-on-non-space" in report["violations"]
+
+
+def test_conformance_report_duplicate_anatomical_axis(tmp_path):
+    path = _write_zarr(
+        tmp_path,
+        [
+            _space("z", "left-to-right"),
+            _space("y", "anterior-to-posterior"),
+            _space("x", "right-to-left"),
+        ],
+    )
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is False
+    assert "axis-orientation-unique-axis" in report["violations"]
+
+
+def test_conformance_report_out_of_vocabulary(tmp_path):
+    path = _write_zarr(
+        tmp_path,
+        [
+            _space("z", "LPS"),
+            _space("y", "anterior-to-posterior"),
+            _space("x", "right-to-left"),
+        ],
+    )
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is False
+    assert report["violations"] == ["orientation-schema-invalid"]
+
+
+def test_conformance_report_reads_v2_zattrs(tmp_path):
+    """A v2 ``.zattrs`` layout (no ``attributes``/``ome`` wrapper) is read too."""
+    path = _write_zattrs(tmp_path, list(_LPS))
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is True
+    assert report["axes"] == {
+        "z": "inferior-to-superior",
+        "y": "anterior-to-posterior",
+        "x": "right-to-left",
+    }
+
+
+def test_conformance_report_reads_zip(tmp_path):
+    """An OME-Zarr packed as ``.zip`` is read from its archived metadata."""
+    path = _write_zarr_zip(tmp_path, list(_LPS))
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is True
+    assert report["axes"]["x"] == "right-to-left"
+
+
+def test_conformance_report_empty_dir_is_invalid(tmp_path):
+    """A directory without OME-Zarr metadata is invalid, not vacuously valid."""
+    report = conformance_report(str(tmp_path))
+    assert report["rfc4_valid"] is False
+    assert report["violations"] == ["input-not-ome-zarr"]
+    assert report["axes"] == {}
+
+
+def test_conformance_report_zip_without_metadata_is_invalid(tmp_path):
+    """A ``.zip`` carrying no root metadata is classified invalid, not valid."""
+    archive = tmp_path / "empty.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("not-metadata.txt", "nothing here")
+    report = conformance_report(str(archive))
+    assert report["rfc4_valid"] is False
+    assert report["violations"] == ["input-not-ome-zarr"]
+
+
+def test_conformance_report_non_list_axes_is_invalid(tmp_path):
+    """``axes`` present but not a list is a read failure, not empty-and-valid."""
+    metadata = {"attributes": {"ome": {"multiscales": [{"axes": "oops"}]}}}
+    (tmp_path / "zarr.json").write_text(json.dumps(metadata))
+    report = conformance_report(str(tmp_path))
+    assert report["rfc4_valid"] is False
+    assert report["violations"] == ["input-not-ome-zarr"]
+
+
+def test_conformance_report_malformed_json_is_invalid(tmp_path):
+    """Unparsable metadata is reported as unreadable, never as valid."""
+    (tmp_path / "zarr.json").write_text("{ this is not json")
+    report = conformance_report(str(tmp_path))
+    assert report["rfc4_valid"] is False
+    assert report["violations"] == ["input-unreadable"]
+
+
+def test_conformance_report_axis_missing_name_does_not_crash(tmp_path):
+    """A raw axis without a name yields a verdict instead of crashing the CLI."""
+    metadata = {
+        "attributes": {
+            "ome": {
+                "multiscales": [
+                    {
+                        "axes": [
+                            {
+                                "type": "space",
+                                "orientation": {
+                                    "type": "anatomical",
+                                    "value": "left-to-right",
+                                },
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+    (tmp_path / "zarr.json").write_text(json.dumps(metadata))
+    report = conformance_report(str(tmp_path))
+    assert report["format"] == "ome-zarr"
+    assert report["rfc4_valid"] is False
+    # The unnamed axis is dropped from the display map but is still surfaced as a
+    # violation by validate_rfc4_orientation, classified per the conformance
+    # contract as a schema-level failure.
+    assert report["axes"] == {}
+    assert report["violations"] == ["orientation-schema-invalid"]
+
+
+def test_conformance_cli_prints_json(tmp_path, monkeypatch, capsys):
+    path = _write_zarr(
+        tmp_path,
+        [
+            _space("z", "inferior-to-superior"),
+            _space("y", "anterior-to-posterior"),
+            _space("x", "right-to-left"),
+        ],
+    )
+    monkeypatch.setattr("sys.argv", ["ngff-zarr", "conformance", path])
+    main()
+    report = json.loads(capsys.readouterr().out)
+    assert report["rfc4_valid"] is True
+    assert report["format"] == "ome-zarr"

--- a/py/test/test_cli_conformance.py
+++ b/py/test/test_cli_conformance.py
@@ -86,7 +86,7 @@ def test_conformance_report_orientation_on_non_space(tmp_path):
     )
     report = conformance_report(path)
     assert report["rfc4_valid"] is False
-    assert "axis-orientation-on-non-space" in report["violations"]
+    assert "orientation-on-non-space" in report["violations"]
 
 
 def test_conformance_report_duplicate_anatomical_axis(tmp_path):
@@ -100,7 +100,7 @@ def test_conformance_report_duplicate_anatomical_axis(tmp_path):
     )
     report = conformance_report(path)
     assert report["rfc4_valid"] is False
-    assert "axis-orientation-unique-axis" in report["violations"]
+    assert "duplicate-anatomical-axis" in report["violations"]
 
 
 def test_conformance_report_out_of_vocabulary(tmp_path):
@@ -114,7 +114,7 @@ def test_conformance_report_out_of_vocabulary(tmp_path):
     )
     report = conformance_report(path)
     assert report["rfc4_valid"] is False
-    assert report["violations"] == ["orientation-schema-invalid"]
+    assert report["violations"] == ["bad-value"]
 
 
 def test_conformance_report_reads_v2_zattrs(tmp_path):
@@ -196,12 +196,81 @@ def test_conformance_report_axis_missing_name_does_not_crash(tmp_path):
     (tmp_path / "zarr.json").write_text(json.dumps(metadata))
     report = conformance_report(str(tmp_path))
     assert report["format"] == "ome-zarr"
-    assert report["rfc4_valid"] is False
-    # The unnamed axis is dropped from the display map but is still surfaced as a
-    # violation by validate_rfc4_orientation, classified per the conformance
-    # contract as a schema-level failure.
+    # A missing axis name is an OME-Zarr concern, not an RFC 4 orientation rule,
+    # so the verdict is still emitted: the unnamed axis is simply dropped from the
+    # display map rather than crashing the command.
     assert report["axes"] == {}
-    assert report["violations"] == ["orientation-schema-invalid"]
+    assert report["rfc4_valid"] is True
+    assert report["violations"] == []
+
+
+def test_conformance_report_partial_orientation_is_valid(tmp_path):
+    """RFC 4 makes orientation optional per spatial axis, so partial is valid."""
+    path = _write_zarr(
+        tmp_path,
+        [
+            _space("z", "distal-to-proximal"),
+            _space("y", "dorsal-to-plantar"),
+            {"name": "x", "type": "space"},
+        ],
+    )
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is True
+    assert report["violations"] == []
+    assert report["axes"] == {"z": "distal-to-proximal", "y": "dorsal-to-plantar"}
+
+
+def test_conformance_report_null_orientation_is_valid_with_warning(tmp_path):
+    """An explicit null equals an absent field; writers SHOULD omit it instead."""
+    path = _write_zarr(
+        tmp_path,
+        [
+            {"name": "z", "type": "space", "orientation": None},
+            _space("y", "anterior-to-posterior"),
+            _space("x", "right-to-left"),
+        ],
+    )
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is True
+    assert report["violations"] == []
+    assert report["warnings"] == ["null-orientation"]
+
+
+def test_conformance_report_bad_type(tmp_path):
+    """RFC 4 defines a single orientation type, "anatomical"."""
+    path = _write_zarr(
+        tmp_path,
+        [
+            {
+                "name": "z",
+                "type": "space",
+                "orientation": {
+                    "type": "geographical",
+                    "value": "inferior-to-superior",
+                },
+            },
+            _space("y", "anterior-to-posterior"),
+            _space("x", "right-to-left"),
+        ],
+    )
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is False
+    assert report["violations"] == ["bad-type"]
+
+
+def test_conformance_report_missing_value(tmp_path):
+    """An orientation object MUST carry a value."""
+    path = _write_zarr(
+        tmp_path,
+        [
+            {"name": "z", "type": "space", "orientation": {"type": "anatomical"}},
+            _space("y", "anterior-to-posterior"),
+            _space("x", "right-to-left"),
+        ],
+    )
+    report = conformance_report(path)
+    assert report["rfc4_valid"] is False
+    assert report["violations"] == ["missing-value"]
 
 
 def test_conformance_cli_prints_json(tmp_path, monkeypatch, capsys):

--- a/py/test/test_rfc4_validation.py
+++ b/py/test/test_rfc4_validation.py
@@ -149,9 +149,15 @@ def test_validate_rfc4_orientation_mixed_types():
     validate_rfc4_orientation(axes_mixed)
 
 
-def test_validate_rfc4_orientation_incomplete():
-    """Test RFC 4 validation fails when orientation is incomplete."""
-    # Missing orientation for one spatial axis
+def test_validate_rfc4_orientation_partial_is_valid():
+    """RFC 4 makes orientation optional per spatial axis, so partial is valid.
+
+    The specification states no all-or-none completeness requirement: an image may
+    orient only some of its spatial axes and leave the rest undefined.
+    """
+    pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
+
+    # Orientation is defined for two spatial axes and left undefined on the third.
     axes_incomplete = [
         {
             "name": "x",
@@ -173,15 +179,15 @@ def test_validate_rfc4_orientation_incomplete():
         },
     ]
 
-    with pytest.raises(
-        ValueError, match="RFC 4 requires that if orientation is defined"
-    ):
-        validate_rfc4_orientation(axes_incomplete)
+    # Should not raise: an unoriented spatial axis is simply undefined.
+    validate_rfc4_orientation(axes_incomplete)
 
 
-def test_validate_rfc4_orientation_inconsistent_types():
-    """Test RFC 4 validation fails with inconsistent orientation types."""
-    # Different orientation types
+def test_validate_rfc4_orientation_non_anatomical_type():
+    """RFC 4 defines a single orientation type, so any other type is rejected."""
+    pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
+
+    # The "y" axis declares a type the RFC 4 vocabulary does not define.
     axes_inconsistent = [
         {
             "name": "x",
@@ -203,10 +209,44 @@ def test_validate_rfc4_orientation_inconsistent_types():
         },
     ]
 
-    with pytest.raises(
-        ValueError, match="All spatial axis orientations must have the same type"
-    ):
+    with pytest.raises(ValueError, match="must be anatomical"):
         validate_rfc4_orientation(axes_inconsistent)
+
+
+def test_validate_rfc4_orientation_non_object_is_rejected():
+    """A non-object orientation is malformed, not undefined.
+
+    Only an absent field, ``null`` and an empty object are undefined. Any other
+    non-null value (string, list, number) is a real -- but malformed -- use of
+    orientation and must fail: on a spatial axis via the type check, on a
+    non-spatial axis via the spatial-only rule.
+    """
+    pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
+
+    with pytest.raises(ValueError, match="must be anatomical"):
+        validate_rfc4_orientation(
+            [
+                {
+                    "name": "x",
+                    "type": "space",
+                    "unit": "micrometer",
+                    "orientation": "nope",
+                }
+            ]
+        )
+
+    with pytest.raises(ValueError, match="non-space axes"):
+        validate_rfc4_orientation(
+            [
+                {"name": "t", "type": "time", "orientation": "nope"},
+                {
+                    "name": "x",
+                    "type": "space",
+                    "unit": "micrometer",
+                    "orientation": {"type": "anatomical", "value": "right-to-left"},
+                },
+            ]
+        )
 
 
 def test_validate_rfc4_orientation_invalid_value():
@@ -274,11 +314,12 @@ def test_validate_rfc4_orientation_on_non_space_axis():
         validate_rfc4_orientation(axes_bad)
 
 
-def test_validate_rfc4_orientation_on_non_space_axis_empty_dict():
-    """An empty orientation object on a non-spatial axis is still rejected.
+def test_validate_rfc4_orientation_empty_dict_on_non_space_is_undefined():
+    """An empty orientation object on a non-spatial axis is not a violation.
 
-    The presence of the ``orientation`` key -- not a truthy value -- is what
-    RFC 4 forbids on a non-spatial axis, so ``{}`` must not slip through."""
+    RFC 4 treats an absent orientation and an explicit ``null`` as equivalent --
+    the orientation is simply undefined -- so an empty object is likewise not a
+    use of orientation on that axis."""
     pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
 
     axes_bad = [
@@ -303,8 +344,8 @@ def test_validate_rfc4_orientation_on_non_space_axis_empty_dict():
         },
     ]
 
-    with pytest.raises(ValueError, match="non-space axes"):
-        validate_rfc4_orientation(axes_bad)
+    # Should not raise: an empty orientation is undefined, not a use of it.
+    validate_rfc4_orientation(axes_bad)
 
 
 def test_validate_rfc4_orientation_duplicate_anatomical_axis():
@@ -456,7 +497,8 @@ def test_from_ngff_zarr_with_rfc4_validation_invalid():
                 "name": "z",
                 "type": "space",
                 "unit": "micrometer",
-                # Missing orientation - this should cause validation to fail
+                # Out-of-vocabulary value - this should cause validation to fail
+                "orientation": {"type": "anatomical", "value": "not-a-direction"},
             },
         ],
         "datasets": [
@@ -471,10 +513,8 @@ def test_from_ngff_zarr_with_rfc4_validation_invalid():
 
     root.attrs["multiscales"] = [multiscales_metadata]
 
-    # Should fail with incomplete orientation
-    with pytest.raises(
-        ValueError, match="RFC 4 requires that if orientation is defined"
-    ):
+    # Should fail on the out-of-vocabulary orientation value
+    with pytest.raises(ValidationError, match="Invalid orientation value"):
         from_ngff_zarr(store, validate=True)
 
 

--- a/py/test/test_structural_validation_orientation.py
+++ b/py/test/test_structural_validation_orientation.py
@@ -14,9 +14,10 @@ Coverage:
 * a fully specified, consistent orientation passes for *both* stored shapes -- a
   raw ``dict`` (image read path) and an
   :class:`~ngff_zarr.rfc4.AnatomicalOrientation` dataclass (write path);
-* mixed orientation ``type`` -> :attr:`SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE`;
-* orientation on some but not all spatial axes ->
-  :attr:`SpecRule.AXIS_ORIENTATION_COMPLETENESS`.
+* a non-anatomical orientation ``type`` ->
+  :attr:`SpecRule.AXIS_ORIENTATION_ANATOMICAL_TYPE`;
+* orientation on only some spatial axes -> accepted (RFC 4 makes orientation
+  optional per axis).
 
 Each failing case asserts the expected :class:`SpecRule` and the
 ``multiscales[0].axes`` location.
@@ -92,7 +93,7 @@ def test_axis_orientation_valid_consistent(shape):
     validate_axis_orientation(metadata)
 
 
-def test_axis_orientation_inconsistent_type():
+def test_axis_orientation_non_anatomical_type():
     # The "y" axis declares a different orientation type than its siblings.
     metadata = _metadata_with_axes(
         [
@@ -107,12 +108,41 @@ def test_axis_orientation_inconsistent_type():
     )
     with pytest.raises(ValidationError) as exc_info:
         validate_axis_orientation(metadata)
-    assert exc_info.value.rule == SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE
+    assert exc_info.value.rule == SpecRule.AXIS_ORIENTATION_ANATOMICAL_TYPE
     assert exc_info.value.location == "multiscales[0].axes"
 
 
-def test_axis_orientation_incomplete():
-    # Orientation is defined for "z" and "y" but missing on "x".
+def test_axis_orientation_empty_object_is_undefined():
+    """An empty ``orientation`` object is undefined, whatever the axis type.
+
+    Guards the Axis-to-dict rendering: emitting ``{}`` as a populated
+    ``{"type": None, "value": None}`` dict would read back as a real orientation
+    and trip the non-space or anatomical-type rule.
+    """
+    # On a non-spatial axis: not a use of orientation, so not a violation.
+    validate_axis_orientation(
+        _metadata_with_axes(
+            [
+                Axis(name="t", type="time", orientation={}),
+                Axis(name="y", type="space"),
+                Axis(name="x", type="space"),
+            ]
+        )
+    )
+    # On a spatial axis: that axis is simply left undefined.
+    validate_axis_orientation(
+        _metadata_with_axes(
+            [
+                Axis(name="y", type="space", orientation={}),
+                Axis(name="x", type="space"),
+            ]
+        )
+    )
+
+
+def test_axis_orientation_partial_is_accepted():
+    # Orientation is defined for "z" and "y" and left undefined on "x". RFC 4
+    # makes orientation optional per spatial axis, so this is not a violation.
     metadata = _metadata_with_axes(
         [
             Axis(name="z", type="space", orientation=_orientation_dict(_LPS_VALUES[0])),
@@ -120,17 +150,7 @@ def test_axis_orientation_incomplete():
             Axis(name="x", type="space"),
         ]
     )
-    with pytest.raises(ValidationError) as exc_info:
-        validate_axis_orientation(metadata)
-    assert exc_info.value.rule == SpecRule.AXIS_ORIENTATION_COMPLETENESS
-    assert exc_info.value.location == "multiscales[0].axes"
-    # Axis-name lists render Python-style (`['z', 'y']`); the TypeScript port
-    # matches this byte-for-byte via its formatNameList() helper (locks parity).
-    assert exc_info.value.message == (
-        "RFC 4 requires that if orientation is defined for one spatial axis, "
-        "it must be defined for all spatial axes. "
-        "Axes with orientation: ['z', 'y'], axes without orientation: ['x']"
-    )
+    validate_axis_orientation(metadata)
 
 
 def test_axis_orientation_on_non_space_axis():
@@ -178,7 +198,7 @@ def test_rfc4_orientation_messages_carry_mapping_markers():
 
     The wrapper distinguishes the RFC 4 orientation failures by searching
     :func:`~ngff_zarr.rfc4_validation.validate_rfc4_orientation`'s message text
-    for ``"same type"``, ``"all spatial axes"``, ``"non-space axes"`` and
+    for ``"must be anatomical"``, ``"non-space axes"`` and
     ``"same anatomical axis"``. Those markers are a load-bearing contract: if the
     wording is edited away, the wrapper silently falls through to a bare
     ``ValueError`` instead of raising the mapped :class:`ValidationError`.
@@ -187,8 +207,8 @@ def test_rfc4_orientation_messages_carry_mapping_markers():
     """
     from ngff_zarr.rfc4_validation import validate_rfc4_orientation
 
-    # Mixed orientation type -> the marker the consistent-type rule maps.
-    with pytest.raises(ValueError, match="same type"):
+    # A non-anatomical orientation type -> the marker the type rule maps.
+    with pytest.raises(ValueError, match="must be anatomical"):
         validate_rfc4_orientation(
             [
                 {
@@ -204,22 +224,6 @@ def test_rfc4_orientation_messages_carry_mapping_markers():
                     "type": "space",
                     "orientation": {"type": "other", "value": "right-to-left"},
                 },
-            ]
-        )
-
-    # Orientation on some but not all spatial axes -> the completeness marker.
-    with pytest.raises(ValueError, match="all spatial axes"):
-        validate_rfc4_orientation(
-            [
-                {
-                    "name": "y",
-                    "type": "space",
-                    "orientation": {
-                        "type": "anatomical",
-                        "value": "anterior-to-posterior",
-                    },
-                },
-                {"name": "x", "type": "space"},
             ]
         )
 

--- a/py/test/test_structural_validation_parity.py
+++ b/py/test/test_structural_validation_parity.py
@@ -51,8 +51,7 @@ CANONICAL_SPEC_RULE_IDS = [
     "global-coord-transform-after-per-level",
     "dataset-order-highest-to-lowest",
     "omero-channel-color-format",
-    "axis-orientation-consistent-type",
-    "axis-orientation-completeness",
+    "axis-orientation-anatomical-type",
     "axis-orientation-on-non-space",
     "axis-orientation-unique-axis",
     "zarr-format",
@@ -82,7 +81,7 @@ EXPECTED_EVALUATION_ORDER = [
     SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL,  # transform order
     SpecRule.DATASET_ORDER_HIGHEST_TO_LOWEST,
     SpecRule.OMERO_CHANNEL_COLOR_FORMAT,
-    SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE,
+    SpecRule.AXIS_ORIENTATION_ANATOMICAL_TYPE,
 ]
 
 
@@ -108,8 +107,8 @@ def _valid_axes_with_inconsistent_orientation() -> list[Axis]:
 
     Every axis rule passes (channel-then-space class order, ``(z, y, x)``
     spatial suffix, count 4), but the ``y`` axis declares orientation type
-    ``"other"`` while ``z`` and ``x`` declare ``"anatomical"`` -- tripping
-    :attr:`SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE`, the last orchestrator
+    ``"other"`` -- a type RFC 4 does not define -- tripping
+    :attr:`SpecRule.AXIS_ORIENTATION_ANATOMICAL_TYPE`, the last orchestrator
     rule, when every earlier rule is satisfied.
     """
     return [

--- a/ts/src/utils/py_format.ts
+++ b/ts/src/utils/py_format.ts
@@ -12,7 +12,7 @@
  *
  * Mirrors Python's `str(list_of_str)` / f-string rendering: bracketed,
  * single-quoted elements, comma-space separated. Both the structural
- * spatial-axis-order message and the RFC 4 axis-orientation-completeness
+ * spatial-axis-order message and the RFC 4 axis-orientation-on-non-space
  * message interpolate this verbatim, so the two ports stay byte-for-byte
  * identical. Axis names reaching these rules are single-quote-free, so the
  * plain single-quoted element form is exact.

--- a/ts/src/utils/rfc4_validation.ts
+++ b/ts/src/utils/rfc4_validation.ts
@@ -111,13 +111,18 @@ function isNonEmptyOrientation(orientation: unknown): boolean {
 /**
  * Validate RFC 4 anatomical orientation metadata.
  *
- * The errors carry stable marker substrings -- `same type` (mixed `type`),
- * `all spatial axes` (all-or-none completeness), `non-space axes` (orientation on
- * a non-spatial axis) and `same anatomical axis` (two axes on one antonym pair) --
- * that `validateAxisOrientation` reads to map each failure onto its `SpecRule`.
- * These markers are a load-bearing contract pinned by a message-stability test
- * (see `structural_validation_orientation_test.ts`) so the mapping cannot silently
- * break if the wording is later edited.
+ * The errors carry stable marker substrings -- `must be anatomical` (a `type`
+ * other than the single value the vocabulary defines), `non-space axes`
+ * (orientation on a non-spatial axis) and `same anatomical axis` (two axes on one
+ * antonym pair) -- that `validateAxisOrientation` reads to map each failure onto
+ * its `SpecRule`. These markers are a load-bearing contract pinned by a
+ * message-stability test (see `structural_validation_orientation_test.ts`) so the
+ * mapping cannot silently break if the wording is later edited.
+ *
+ * RFC 4 makes `orientation` optional per spatial axis: an image may orient only
+ * some of its spatial axes, and an absent orientation is equivalent to an explicit
+ * `null` (the axis orientation is undefined). No all-or-none completeness rule is
+ * enforced.
  *
  * @param axes - List of axis metadata dictionaries to validate
  * @throws Error if the orientation metadata is invalid or inconsistent
@@ -125,80 +130,58 @@ function isNonEmptyOrientation(orientation: unknown): boolean {
 export function validateRfc4Orientation(
   axes: Array<Record<string, unknown>>,
 ): void {
-  let hasOrientation = false;
-  let orientationType: string | null = null;
-  const spatialAxesWithOrientation: string[] = [];
-  const spatialAxesWithoutOrientation: string[] = [];
   const spatialOrientationValues: Array<[string, string]> = [];
 
   for (const axis of axes) {
     if (typeof axis === "object" && axis !== null && axis.type === "space") {
       const axisName = String(axis.name ?? "unknown");
 
-      if ("orientation" in axis && axis.orientation !== null) {
-        hasOrientation = true;
-        spatialAxesWithOrientation.push(axisName);
-
+      // RFC 4: an absent orientation and an explicit null (or empty object) are
+      // equivalent -- the axis orientation is simply undefined -- so only a real,
+      // non-empty orientation object is validated here. Orientation is optional
+      // per spatial axis, so a partially oriented image is valid.
+      if (isNonEmptyOrientation(axis.orientation)) {
         const orientation = axis.orientation as Record<string, unknown>;
 
-        // Check that all orientations have the same type
-        const currentType = orientation.type as string | undefined;
-        if (orientationType === null) {
-          orientationType = currentType ?? null;
-        } else if (currentType !== orientationType) {
+        // RFC 4: the orientation type is restricted to the single value the
+        // controlled vocabulary defines, "anatomical".
+        const orientationType = orientation.type as string | undefined;
+        if (orientationType !== "anatomical") {
           throw new Error(
-            `All spatial axis orientations must have the same type. ` +
-              `Found types: ${orientationType} and ${currentType}`,
+            `RFC 4 orientation type must be anatomical; axis ` +
+              `'${axisName}' has type '${orientationType}'.`,
           );
         }
 
-        // Validate the orientation value using the schema
+        // RFC 4 requires a value, drawn from the controlled vocabulary.
         const orientationValue = orientation.value as string | undefined;
-        if (orientationValue !== undefined) {
-          const result = AnatomicalOrientationValuesSchema.safeParse(
-            orientationValue,
+        if (
+          orientationValue === undefined ||
+          !AnatomicalOrientationValuesSchema.safeParse(orientationValue).success
+        ) {
+          throw new Error(
+            `Invalid orientation value '${orientationValue}' for axis '${axisName}'. ` +
+              `Valid values are: ${
+                [...VALID_ORIENTATION_VALUES].sort().join(", ")
+              }`,
           );
-          if (!result.success) {
-            throw new Error(
-              `Invalid orientation value '${orientationValue}' for axis '${axisName}'. ` +
-                `Valid values are: ${
-                  [...VALID_ORIENTATION_VALUES].sort().join(", ")
-                }`,
-            );
-          }
-          spatialOrientationValues.push([axisName, orientationValue]);
         }
-      } else {
-        spatialAxesWithoutOrientation.push(axisName);
+        spatialOrientationValues.push([axisName, orientationValue]);
       }
     }
   }
 
-  // RFC 4 requirement: if orientation is defined for one spatial axis, it must
-  // be defined for all spatial axes. Checked before the rules below to keep the
-  // canonical SpecRule precedence (completeness is declared before the non-space
-  // and unique-axis rules).
-  if (hasOrientation && spatialAxesWithoutOrientation.length > 0) {
-    throw new Error(
-      `RFC 4 requires that if orientation is defined for one spatial axis, ` +
-        `it must be defined for all spatial axes. ` +
-        `Axes with orientation: ` +
-        `${formatNameList(spatialAxesWithOrientation)}, ` +
-        `axes without orientation: ` +
-        `${formatNameList(spatialAxesWithoutOrientation)}`,
-    );
-  }
-
-  // RFC 4 requirement: orientation is only allowed on spatial axes. (Checked
-  // over all axes, independently of hasOrientation, so a stray orientation on a
-  // time/channel axis is caught even when no spatial axis carries one.)
+  // RFC 4 requirement: orientation is only allowed on spatial axes. Only a real
+  // (non-empty) orientation object counts as "used"; a null or empty orientation
+  // is undefined, so it is not a violation on a non-spatial axis. Checked over all
+  // axes so a stray orientation is caught even when no spatial axis carries one.
   const nonSpaceWithOrientation: string[] = [];
   for (const axis of axes) {
     if (
       typeof axis === "object" &&
       axis !== null &&
       axis.type !== "space" &&
-      "orientation" in axis
+      isNonEmptyOrientation(axis.orientation)
     ) {
       nonSpaceWithOrientation.push(String(axis.name));
     }

--- a/ts/src/utils/structural_validation.ts
+++ b/ts/src/utils/structural_validation.ts
@@ -62,10 +62,8 @@ export const SpecRule = {
   DatasetOrderHighestToLowest: "dataset-order-highest-to-lowest",
   /** Each OMERO channel color is exactly six hexadecimal digits. */
   OmeroChannelColorFormat: "omero-channel-color-format",
-  /** All spatial-axis RFC 4 orientations share one `type`. */
-  AxisOrientationConsistentType: "axis-orientation-consistent-type",
-  /** If any spatial axis declares an orientation, all spatial axes do. */
-  AxisOrientationCompleteness: "axis-orientation-completeness",
+  /** Each RFC 4 orientation `type` is "anatomical" (the only value defined). */
+  AxisOrientationAnatomicalType: "axis-orientation-anatomical-type",
   /** Orientation is declared only on spatial axes (never time/channel). */
   AxisOrientationOnNonSpace: "axis-orientation-on-non-space",
   /** At most one direction per anatomical axis (antonyms are exclusive). */
@@ -568,7 +566,14 @@ function axisToValidationRecord(axis: Axis): Record<string, unknown> {
     type: axis.type,
   };
   const orientation = axis.orientation;
-  if (orientation !== undefined && orientation !== null) {
+  // An empty orientation object is undefined under RFC 4, exactly like an absent
+  // one, so it must not be rendered as a populated { type, value } object -- that
+  // would read back as a real orientation.
+  if (
+    orientation !== undefined &&
+    orientation !== null &&
+    Object.keys(orientation).length > 0
+  ) {
     record.orientation = {
       type: orientation.type,
       value: orientation.value,
@@ -591,10 +596,9 @@ function axisToValidationRecord(axis: Axis): Record<string, unknown> {
  * is a no-op.
  *
  * @param metadata - The parsed multiscales metadata to validate.
- * @throws {ValidationError} With {@link SpecRule.AxisOrientationConsistentType}
- * when the spatial axes' orientations do not all share one `type`,
- * {@link SpecRule.AxisOrientationCompleteness} when orientation is defined for
- * some but not all spatial axes, {@link SpecRule.AxisOrientationOnNonSpace} when
+ * @throws {ValidationError} With {@link SpecRule.AxisOrientationAnatomicalType}
+ * when an orientation `type` is not `"anatomical"`,
+ * {@link SpecRule.AxisOrientationOnNonSpace} when
  * orientation is declared on a non-spatial axis, or
  * {@link SpecRule.AxisOrientationUniqueAxis} when two spatial axes describe the
  * same anatomical axis; location `multiscales[0].axes`. The original
@@ -607,13 +611,16 @@ export function validateAxisOrientation(metadata: Metadata): void {
   const axesRecords = metadata.axes.map(axisToValidationRecord);
   // A stray orientation on a non-spatial axis carries no spatial-axis
   // orientation, so hasRfc4OrientationMetadata alone would skip it; check for any
-  // declared orientation so the non-space rule is reachable.
+  // real (non-empty) orientation so the non-space rule is reachable. A null or
+  // empty orientation is undefined under RFC 4 and so is not a violation.
   const nonSpaceOrientation = axesRecords.some(
     (axisRecord) =>
       typeof axisRecord === "object" &&
       axisRecord !== null &&
       axisRecord.type !== "space" &&
-      "orientation" in axisRecord,
+      typeof axisRecord.orientation === "object" &&
+      axisRecord.orientation !== null &&
+      Object.keys(axisRecord.orientation as Record<string, unknown>).length > 0,
   );
   if (!hasRfc4OrientationMetadata(axesRecords) && !nonSpaceOrientation) {
     return;
@@ -621,31 +628,24 @@ export function validateAxisOrientation(metadata: Metadata): void {
   try {
     validateRfc4Orientation(axesRecords);
   } catch (error) {
-    // validateRfc4Orientation throws four messages this rule maps: a
-    // spatial-orientation "same type" mismatch, the all-or-none completeness
-    // failure, orientation on "non-space axes", and two axes on the "same
-    // anatomical axis". An out-of-vocabulary orientation value -- a schema-level
-    // concern with no dedicated structural rule -- carries none of these markers
-    // and so propagates unchanged, matching the package's Python implementation.
+    // validateRfc4Orientation throws three messages this rule maps: an
+    // orientation type that is not "anatomical", orientation on "non-space
+    // axes", and two axes on the "same anatomical axis". An out-of-vocabulary
+    // orientation value -- a schema-level concern with no dedicated structural
+    // rule -- carries none of these markers and so propagates unchanged,
+    // matching the package's Python implementation.
     //
-    // The marker substrings below ("same type", "all spatial axes", "non-space
-    // axes", "same anatomical axis") are a load-bearing contract with
+    // The marker substrings below ("must be anatomical", "non-space axes",
+    // "same anatomical axis") are a load-bearing contract with
     // validateRfc4Orientation's message text: an unrecognized error falls
     // through to the final `throw` and surfaces as a plain Error rather than a
     // ValidationError. The message-stability test in
     // structural_validation_orientation_test.ts pins the markers so editing that
     // wording fails CI loudly instead of silently breaking this mapping.
     const message = error instanceof Error ? error.message : String(error);
-    if (message.includes("same type")) {
+    if (message.includes("must be anatomical")) {
       throw new ValidationError(
-        SpecRule.AxisOrientationConsistentType,
-        message,
-        "multiscales[0].axes",
-      );
-    }
-    if (message.includes("all spatial axes")) {
-      throw new ValidationError(
-        SpecRule.AxisOrientationCompleteness,
+        SpecRule.AxisOrientationAnatomicalType,
         message,
         "multiscales[0].axes",
       );

--- a/ts/test/rfc4_validation_test.ts
+++ b/ts/test/rfc4_validation_test.ts
@@ -158,7 +158,8 @@ Deno.test("validateRfc4Orientation - mixed axis types (time/channel) pass", () =
   validateRfc4Orientation(axesMixed);
 });
 
-Deno.test("validateRfc4Orientation - throws on incomplete orientation", () => {
+Deno.test("validateRfc4Orientation - accepts partial orientation", () => {
+  // RFC 4 makes orientation optional per spatial axis: no all-or-none rule.
   const axesIncomplete = [
     {
       name: "x",
@@ -180,14 +181,38 @@ Deno.test("validateRfc4Orientation - throws on incomplete orientation", () => {
     },
   ];
 
+  validateRfc4Orientation(axesIncomplete);
+});
+
+Deno.test("validateRfc4Orientation - rejects a non-object orientation", () => {
+  // Only an absent field, null and an empty object are undefined. Any other
+  // non-null value is a malformed use of orientation and must fail: on a spatial
+  // axis via the type check, on a non-spatial axis via the spatial-only rule.
+  // Mirrors the Python test_validate_rfc4_orientation_non_object_is_rejected.
   assertThrows(
-    () => validateRfc4Orientation(axesIncomplete),
+    () =>
+      validateRfc4Orientation([
+        { name: "x", type: "space", orientation: "nope" },
+      ]),
     Error,
-    "RFC 4 requires that if orientation is defined",
+    "must be anatomical",
+  );
+  assertThrows(
+    () =>
+      validateRfc4Orientation([
+        { name: "t", type: "time", orientation: "nope" },
+        {
+          name: "x",
+          type: "space",
+          orientation: { type: "anatomical", value: "right-to-left" },
+        },
+      ]),
+    Error,
+    "non-space axes",
   );
 });
 
-Deno.test("validateRfc4Orientation - throws on inconsistent orientation types", () => {
+Deno.test("validateRfc4Orientation - throws on a non-anatomical type", () => {
   const axesInconsistent = [
     {
       name: "x",
@@ -212,7 +237,7 @@ Deno.test("validateRfc4Orientation - throws on inconsistent orientation types", 
   assertThrows(
     () => validateRfc4Orientation(axesInconsistent),
     Error,
-    "All spatial axis orientations must have the same type",
+    "must be anatomical",
   );
 });
 
@@ -335,7 +360,8 @@ Deno.test("fromNgffZarr with invalid RFC-4 orientation - throws error", async ()
         name: "z",
         type: "space",
         unit: "micrometer",
-        // Missing orientation - this should cause validation to fail
+        // Out-of-vocabulary value - this should cause validation to fail
+        orientation: { type: "anatomical", value: "not-a-direction" },
       },
     ],
     datasets: [
@@ -350,16 +376,14 @@ Deno.test("fromNgffZarr with invalid RFC-4 orientation - throws error", async ()
 
   const store = await createTestStore(multiscalesMetadata);
 
-  // Should fail with incomplete orientation
+  // Should fail on the out-of-vocabulary orientation value
   let errorThrown = false;
   try {
     await fromNgffZarr(store, { validate: true });
   } catch (error) {
     errorThrown = true;
     assertEquals(
-      (error as Error).message.includes(
-        "RFC 4 requires that if orientation is defined",
-      ),
+      (error as Error).message.includes("Invalid orientation value"),
       true,
     );
   }

--- a/ts/test/structural_validation_orientation_test.ts
+++ b/ts/test/structural_validation_orientation_test.ts
@@ -12,9 +12,10 @@
  * - a fully specified, consistent orientation passes for both the serialized
  *   `{ type, value }` form (the image read path) and the
  *   {@link AnatomicalOrientationValues} enum form (the write path);
- * - mixed orientation `type` -> {@link SpecRule.AxisOrientationConsistentType};
- * - orientation on some but not all spatial axes ->
- *   {@link SpecRule.AxisOrientationCompleteness}.
+ * - a non-anatomical orientation `type` ->
+ *   {@link SpecRule.AxisOrientationAnatomicalType};
+ * - orientation on only some spatial axes -> accepted (RFC 4 makes orientation
+ *   optional per axis).
  *
  * Each failing case asserts the expected {@link SpecRule} and the
  * `multiscales[0].axes` location. The identifiers and location strings are kept
@@ -113,8 +114,8 @@ Deno.test("validateAxisOrientation - accepts a consistent orientation", () => {
   );
 });
 
-Deno.test("validateAxisOrientation - rejects inconsistent orientation types", () => {
-  // The "y" axis declares a different orientation type than its siblings.
+Deno.test("validateAxisOrientation - rejects a non-anatomical type", () => {
+  // The "y" axis declares a type RFC 4 does not define.
   const metadata = metadataWithOrientations([
     { type: "anatomical", value: LPS_VALUES[0] },
     { type: "other", value: LPS_VALUES[1] },
@@ -122,47 +123,63 @@ Deno.test("validateAxisOrientation - rejects inconsistent orientation types", ()
   ]);
   assertRuleViolation(
     () => validateAxisOrientation(metadata),
-    SpecRule.AxisOrientationConsistentType,
+    SpecRule.AxisOrientationAnatomicalType,
     "multiscales[0].axes",
   );
 });
 
-Deno.test("validateAxisOrientation - rejects incomplete orientation", () => {
-  // Orientation is defined for "z" and "y" but missing on "x".
+Deno.test("validateAxisOrientation - an empty orientation object is undefined", () => {
+  // Guards the Axis-to-record rendering: emitting `{}` as a populated
+  // { type, value } object would read back as a real orientation and trip the
+  // non-space or anatomical-type rule.
+  const empty = {} as Axis["orientation"];
+
+  // On a spatial axis: that axis is simply left undefined.
+  validateAxisOrientation(
+    metadataWithOrientations([empty, undefined, undefined]),
+  );
+
+  // On a non-spatial axis: not a use of orientation, so not a violation.
+  const metadata: Metadata = {
+    axes: [
+      { name: "t", type: "time", unit: undefined, orientation: empty },
+      { name: "y", type: "space", unit: undefined },
+      { name: "x", type: "space", unit: undefined },
+    ],
+    datasets: [
+      { path: "0", coordinateTransformations: [createScale([1.0, 1.0, 1.0])] },
+    ],
+    coordinateTransformations: undefined,
+    omero: undefined,
+    name: "image",
+    version: "0.4",
+  };
+  validateAxisOrientation(metadata);
+});
+
+Deno.test("validateAxisOrientation - accepts partial orientation", () => {
+  // Orientation is defined for "z" and "y" and left undefined on "x". RFC 4
+  // makes orientation optional per spatial axis, so this is not a violation.
   const metadata = metadataWithOrientations([
     { type: "anatomical", value: LPS_VALUES[0] },
     { type: "anatomical", value: LPS_VALUES[1] },
     undefined,
   ]);
-  const error = assertThrows(
-    () => validateAxisOrientation(metadata),
-    ValidationError,
-  );
-  assertEquals(error.rule, SpecRule.AxisOrientationCompleteness);
-  assertEquals(error.location, "multiscales[0].axes");
-  // The axis-name lists render Python-style (`['z', 'y']`) so the surfaced
-  // RFC 4 message is byte-for-byte identical to the Python port (locks parity).
-  assertEquals(
-    error.message,
-    "Spec rule [axis-orientation-completeness] violated: RFC 4 requires " +
-      "that if orientation is defined for one spatial axis, it must be " +
-      "defined for all spatial axes. Axes with orientation: ['z', 'y'], " +
-      "axes without orientation: ['x']",
-  );
+  validateAxisOrientation(metadata);
 });
 
 Deno.test(
   "validateRfc4Orientation - messages carry the SpecRule mapping markers",
   () => {
-    // validateAxisOrientation distinguishes the two RFC 4 orientation failures
-    // by searching this function's message text for "same type" and "all
-    // spatial axes". Those markers are a load-bearing contract: editing the
-    // wording away makes the wrapper silently rethrow a plain Error instead of
-    // the mapped ValidationError. Asserting them here fails loudly at the
-    // source. Mirrors the Python
+    // validateAxisOrientation distinguishes the RFC 4 orientation failures by
+    // searching this function's message text for "must be anatomical",
+    // "non-space axes" and "same anatomical axis". Those markers are a
+    // load-bearing contract: editing the wording away makes the wrapper silently
+    // rethrow a plain Error instead of the mapped ValidationError. Asserting them
+    // here fails loudly at the source. Mirrors the Python
     // test_rfc4_orientation_messages_carry_mapping_markers.
 
-    // Mixed orientation type -> the marker the consistent-type rule maps.
+    // A non-anatomical orientation type -> the marker the type rule maps.
     assertThrows(
       () =>
         validateRfc4Orientation([
@@ -178,22 +195,7 @@ Deno.test(
           },
         ]),
       Error,
-      "same type",
-    );
-
-    // Orientation on some but not all spatial axes -> the completeness marker.
-    assertThrows(
-      () =>
-        validateRfc4Orientation([
-          {
-            name: "y",
-            type: "space",
-            orientation: { type: "anatomical", value: "anterior-to-posterior" },
-          },
-          { name: "x", type: "space" },
-        ]),
-      Error,
-      "all spatial axes",
+      "must be anatomical",
     );
 
     // Orientation on a non-spatial axis -> the on-non-space marker.

--- a/ts/test/structural_validation_parity_test.ts
+++ b/ts/test/structural_validation_parity_test.ts
@@ -67,8 +67,7 @@ const CANONICAL_SPEC_RULE_IDS: string[] = [
   "global-coord-transform-after-per-level",
   "dataset-order-highest-to-lowest",
   "omero-channel-color-format",
-  "axis-orientation-consistent-type",
-  "axis-orientation-completeness",
+  "axis-orientation-anatomical-type",
   "axis-orientation-on-non-space",
   "axis-orientation-unique-axis",
   "zarr-format",
@@ -98,7 +97,7 @@ const EXPECTED_EVALUATION_ORDER: SpecRule[] = [
   SpecRule.GlobalCoordTransformAfterPerLevel, // transform order
   SpecRule.DatasetOrderHighestToLowest,
   SpecRule.OmeroChannelColorFormat,
-  SpecRule.AxisOrientationConsistentType,
+  SpecRule.AxisOrientationAnatomicalType,
 ];
 
 /** Build a single-channel OMERO block with the given channel `color`. */
@@ -124,7 +123,7 @@ function orientation(type: string, value: string): AxisOrientation {
  * Every axis rule passes (channel-then-space class order, `(z, y, x)` spatial
  * suffix, count 4), but the `y` axis declares orientation type `"other"` while
  * `z` and `x` declare `"anatomical"` -- tripping
- * {@link SpecRule.AxisOrientationConsistentType}, the last orchestrator rule,
+ * {@link SpecRule.AxisOrientationAnatomicalType}, the last orchestrator rule,
  * once every earlier rule is satisfied.
  */
 function validAxesWithInconsistentOrientation(): Axis[] {

--- a/ts/test/utils_test.ts
+++ b/ts/test/utils_test.ts
@@ -245,7 +245,7 @@ Deno.test("validateRfc4Orientation - invalid orientation value", () => {
   );
 });
 
-Deno.test("validateRfc4Orientation - inconsistent orientation types", () => {
+Deno.test("validateRfc4Orientation - non-anatomical orientation type", () => {
   const axes = [
     {
       name: "z",
@@ -261,7 +261,7 @@ Deno.test("validateRfc4Orientation - inconsistent orientation types", () => {
   assertThrows(
     () => validateRfc4Orientation(axes),
     Error,
-    "All spatial axis orientations must have the same type",
+    "must be anatomical",
   );
 });
 
@@ -279,9 +279,6 @@ Deno.test("validateRfc4Orientation - partial orientation definition", () => {
       orientation: { type: "anatomical", value: "right-to-left" },
     },
   ];
-  assertThrows(
-    () => validateRfc4Orientation(axes),
-    Error,
-    "RFC 4 requires that if orientation is defined for one spatial axis",
-  );
+  // RFC 4 makes orientation optional per spatial axis, so this is valid.
+  validateRfc4Orientation(axes);
 });


### PR DESCRIPTION
Supersedes #605, whose commit is now carried here. Rebased on `main` after #604 merged, so this PR contains exactly two commits:

1. `feat(py): add ngff-zarr conformance RFC 4 verdict subcommand` (formerly #605)
2. `fix: RFC 4 orientation is optional per axis, null equals absent, type must be anatomical`

---

## 1. The `conformance` subcommand

`ngff-zarr conformance <input>` reads one OME-Zarr and prints a canonical JSON verdict (`rfc4_valid`, `axes`, `violations`, `warnings`) that a tool-agnostic conformance driver diffs against its manifest, so ngff-zarr can be checked as a verified RFC-4 validator. It reads the raw axes so malformed metadata stays classifiable, and an unreadable or non-OME-Zarr input yields an invalid verdict carrying the read-failure code rather than `rfc4_valid: true` with empty axes.

## 2. Specification-compliance fixes

`validate_rfc4_orientation` enforced two constraints RFC 4 does not state, and missed one it does. Each point was checked against the current specification text at https://ngff.openmicroscopy.org/rfc/4/.

### All-or-none completeness — removed

RFC 4 makes `orientation` optional per spatial axis and states no completeness requirement, so an image may orient only some of its spatial axes. The rule rejected valid partially oriented images, e.g. a limb scan whose medio-lateral axis has no meaningful anatomical direction:

```json
{"name": "z", "type": "space", "orientation": {"type": "anatomical", "value": "distal-to-proximal"}}
{"name": "y", "type": "space", "orientation": {"type": "anatomical", "value": "dorsal-to-plantar"}}
{"name": "x", "type": "space"}
```

`SpecRule.AXIS_ORIENTATION_COMPLETENESS` is removed.

### Explicit `null` — now equivalent to absent

> An axis with no `orientation` field and an axis whose `orientation` is `null` are equivalent: in both cases the orientation of that axis is undefined.

A `null` orientation previously raised `AttributeError`. Null, and likewise an empty object, are now treated as undefined, so the non-space rule fires only on a real (non-empty) orientation. The `Axis`-to-dict helpers no longer render an empty `{}` as a populated `{type, value}` object, which would otherwise read back as a real orientation.

### Orientation `type` — now checked against the vocabulary

RFC 4 defines a single type, `"anatomical"` (the schema enum). The previous check only required the declared types to agree with one another, so metadata with a uniformly non-anatomical type passed validation. `SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE` becomes `SpecRule.AXIS_ORIENTATION_ANATOMICAL_TYPE`.

### Conformance output

The subcommand reports findings with the conformance contract code names (`bad-value`, `bad-type`, `missing-value`, `orientation-on-non-space`, `duplicate-anatomical-axis`) and warns on `null-orientation`, which RFC 4 says writers SHOULD omit. RFC 4 defines no error codes, so those names belong to the contract rather than to the package SpecRule vocabulary.

## Verification

Driven against the RFC-4 conformance suite, the OME-Zarr cases go from **7/24 to 24/24**. Full suites pass: 760 Python, 459 TypeScript. Mirrored in the TypeScript port for parity, with unit tests, message-marker stability tests, and the canonical rule manifest updated in both languages.

## Note for maintainers

This changes pre-existing behaviour: `from_ngff_zarr(validate=True)` now accepts partially oriented images, and two public `SpecRule` identifiers are removed/renamed.

Separately, the bundled `spec/rfc/4/orientation.schema.json` carries a stale prose description stating that orientation "MUST be defined for all the axes of type space" and that "the type of each orientation MUST be the same". Those sentences are absent from the current RFC 4 text, and the schema structure itself already models orientation as optional and nullable. The description is generated upstream, so it is left untouched here, but it likely explains the two constraints removed above and is worth re-syncing in ome/ngff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added an `ngff-zarr conformance` CLI command that prints pretty-printed JSON verdicts for RFC 4 conformance, including inputs from unpacked directories and ZIP archives.

* **Bug Fixes**
  * Updated RFC 4 orientation validation to make per-axis orientation optional for spatial axes; `null`/empty orientations are treated as absent (with warnings for `null`).
  * Updated structural/RFC 4 rule classification and error mapping to focus on the anatomical-orientation type rule.

* **Tests**
  * Expanded and aligned Python and TypeScript tests for the new conformance reporting and revised validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
