### PR TITLE
fix(py): count itemsize once in memory_usage, not once per dimension

### DIFF
--- a/py/ngff_zarr/memory_usage.py
+++ b/py/ngff_zarr/memory_usage.py
@@ -17,7 +17,7 @@ def memory_usage(image: NgffImage, constrained_dims: set[str] | None = None) -> 
         constrained_dims = set()
     for dim in range(arr.ndim):
         if dims[dim] in constrained_dims:
-            partition_size *= block[dim] * arr.itemsize
+            partition_size *= block[dim]
         else:
-            partition_size *= shape[dim] * arr.itemsize
-    return partition_size
+            partition_size *= shape[dim]
+    return partition_size * arr.itemsize

--- a/py/test/test_memory_usage.py
+++ b/py/test/test_memory_usage.py
@@ -39,3 +39,19 @@ def test_memory_usage():
     assert usage == 64
     usage = memory_usage(image, {"z"})
     assert usage == 32
+
+
+def test_memory_usage_multi_byte_dtype():
+    """The itemsize counts once, not once per dimension.
+
+    The uint8 case above cannot see the difference: an itemsize of 1 is unchanged by being multiplied
+    in repeatedly. Any wider dtype can, and by a lot -- a 4-D float32 array is overstated 64-fold if
+    the itemsize enters the product on every axis.
+    """
+    arr = dask.array.zeros((3, 4, 5, 6), dtype=np.float32, chunks=(3, 2, 5, 6))
+    image = to_ngff_image(arr, dims=("c", "z", "y", "x"))
+
+    assert arr.nbytes == 3 * 4 * 5 * 6 * 4
+    assert memory_usage(image) == arr.nbytes
+    # One constrained dimension: that axis contributes its chunk rather than its full extent.
+    assert memory_usage(image, {"z"}) == 3 * 2 * 5 * 6 * 4


### PR DESCRIPTION
`memory_usage` returns a value `itemsize^(ndim-1)` times too large — 64× for a 4-D `float32` array.

```python
arr = dask.array.zeros((3, 514, 1331, 1775), dtype=np.float32, chunks=(3, 128, 128, 128))
image = to_ngff_image(arr, dims=("c", "z", "y", "x"))

arr.nbytes           #  13.6 GiB
memory_usage(image)  # 868.6 GiB
```

`arr.itemsize` is applied on every iteration of the loop over dimensions, so the product ends up in
`bytes^ndim`. Applying it once, at the end, makes `memory_usage(image) == arr.nbytes` hold exactly,
for every shape and dtype I tried — including the `uint8` case the existing test pins.

### Why it went unnoticed

Two reasons, and neither is anyone's oversight.

Nothing produces a wrong file: the output is correct either way, only the path taken to write it
changes. And `test_memory_usage` uses a `uint8` array, where `itemsize^(ndim-1)` is 1 — the single
dtype for which the error is arithmetically invisible. That same test asserts `usage == arr.nbytes`,
which I take as confirming the intended meaning rather than changing it.

### What it affects

Ten call sites compare this value against `config.memory_target`, so all of them behave as if memory
were 64× scarcer.

**Slab sizing in `to_ngff_zarr`.** `slab_slices = ceil(memory_target / memory_usage(image, {"z"}))`
collapses to its floor:

| array | slab | passes over the array |
|---|---|---|
| `(3, 514, 1331, 1775)` float32 | 1 z-slice instead of 13 | **514** instead of 40 |
| `(514, 1331, 1775)` float32 | 3 z-slices instead of 38 | **172** instead of 14 |

**Caching in `to_multiscales`.** `should_cache` becomes true for images that fit in memory many times
over, sending them through `_large_image_serialization`. Describing a 1.07 GiB `float32` array
`(3, 288, 576, 576)`, with `memory_target` at its default 42.6 GiB:

| | wall time | peak RSS |
|---|---|---|
| cache engaged — what the overestimate forces | 124.4 s | 35.4 GiB |
| cache skipped — what the corrected value selects | 0.01 s | 0.09 GiB |

Both bite hardest on multi-component float32 arrays, where `ndim` and `itemsize` are largest at once.

### Tests

A `float32` case is added to `test_memory_usage`; nothing existing is modified. It fails on `main`
(`assert memory_usage(image) == arr.nbytes`) and passes with the fix, while the `uint8` case passes
either way — which is the point.

`pytest test/` gives **784 passed, 3 skipped**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory usage estimates for arrays with multi-byte data types.
  * Corrected calculations for constrained dimensions to reflect chunk extents accurately.

* **Tests**
  * Added coverage for memory estimation of multi-byte, multidimensional arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->