### PR TITLE
docs: document RFC-4 validation, the conformance subcommand and the suite

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -210,6 +210,36 @@ ngff-zarr upgrade src.zarr -o dst.zarr --to 0.6 --validate --no-overwrite
 The command prints the detected source version, the target version, and which
 mode it ran. `ngff-zarr upgrade --help` lists every option.
 
+### Check RFC-4 anatomical orientation conformance
+
+The `ngff-zarr conformance` subcommand reads one store and prints a single JSON
+verdict on its [RFC-4](./rfc4.md) anatomical orientation metadata:
+
+```shell
+ngff-zarr conformance path/to/image.ome.zarr
+```
+
+```json
+{
+  "input": "path/to/image.ome.zarr",
+  "format": "ome-zarr",
+  "rfc4_valid": true,
+  "axes": {
+    "z": "inferior-to-superior",
+    "y": "anterior-to-posterior",
+    "x": "right-to-left"
+  },
+  "violations": [],
+  "warnings": []
+}
+```
+
+Directory stores and `.zip` archives are both accepted. The output is the
+canonical contract used by the
+[RFC-4 conformance suite](https://github.com/fideus-labs/ome-zarr-rfc4-validation),
+so the suite's driver can be pointed straight at this command. The
+[RFC-4 documentation](./rfc4.md) lists the violation and warning codes.
+
 ### More options
 
 ```shell

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -234,8 +234,8 @@ ngff-zarr conformance path/to/image.ome.zarr
 }
 ```
 
-Directory stores and `.zip` archives are both accepted. The output is the
-canonical contract used by the
+Directory stores and `.zip` archives are both accepted; `.ozx` archives are not
+supported by this subcommand. The output is the canonical contract used by the
 [RFC-4 conformance suite](https://github.com/fideus-labs/ome-zarr-rfc4-validation),
 so the suite's driver can be pointed straight at this command. The
 [RFC-4 documentation](./rfc4.md) lists the violation and warning codes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ python.md
 typescript.md
 cli.md
 mcp.md
+rfc4.md
 rfc5.md
 hcs.md
 spec_features.md

--- a/docs/lif.md
+++ b/docs/lif.md
@@ -3,7 +3,7 @@ orphan: true
 ---
 <!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
 <!-- SPDX-License-Identifier: MIT -->
-# Leica Image Format (LIF) Support
+# 🔬 Leica Image Format (LIF) Support
 
 NGFF-Zarr provides comprehensive support for converting Leica Image Format (LIF)
 files to OME-Zarr. LIF is a proprietary format used by Leica microscopy systems

--- a/docs/rfc4.md
+++ b/docs/rfc4.md
@@ -257,7 +257,7 @@ ngff_image = nz.NgffImage(
     dims=("z", "y", "x"),
     scale={"x": 1.0, "y": 1.0, "z": 1.0},
     translation={"x": 0.0, "y": 0.0, "z": 0.0},
-    axes_orientations=ngff_zarr.RAS
+    axes_orientations=nz.RAS
 )
 
 # Convert to multiscales and write -- orientation is written automatically
@@ -355,6 +355,113 @@ metadata include an `orientation` field:
 }
 ```
 
+## Validation and Conformance
+
+### What RFC-4 requires
+
+Beyond the vocabulary above, [RFC-4] constrains where and how orientation is
+declared:
+
+- `orientation` is used **only** on spatial axes (`type: "space"`), never on a
+  time or channel axis.
+- An orientation object carries a `type` -- `"anatomical"` is the only defined
+  value -- and a `value` drawn from the 24-term vocabulary.
+- A set of axes carries **one direction of each antonym pair**: an image cannot
+  declare both `left-to-right` and `right-to-left`.
+- Orientation is optional per axis. An absent field and an explicit `null` mean
+  the same thing, but writers SHOULD omit the field rather than serialize
+  `null`.
+
+Three of these are enforced by `validate_structural()` as the rules
+`axis-orientation-anatomical-type`, `axis-orientation-on-non-space` and
+`axis-orientation-unique-axis`, raising a `ValidationError` that names the
+offending rule and axis:
+
+```python
+from ngff_zarr import from_ngff_zarr, validate_structural, ValidationError
+
+multiscales = from_ngff_zarr("image.ome.zarr")
+try:
+    # The structural rules read the flat v0.4 axis list, so convert first when
+    # the store was read into a newer data model.
+    validate_structural(multiscales.metadata.to_version("0.4"))
+except ValidationError as exc:
+    print(exc.rule.value, exc.message)
+    # axis-orientation-unique-axis Axes 'z' and 'y' describe the same
+    # anatomical axis; RFC 4 allows only one direction per axis.
+```
+
+### The `conformance` subcommand
+
+`ngff-zarr conformance` prints a single JSON verdict for one store, in the
+canonical format a tool-agnostic conformance driver diffs against its manifest:
+
+```bash
+ngff-zarr conformance brain_icbm_ras.ome.zarr
+```
+
+```json
+{
+  "input": "brain_icbm_ras.ome.zarr",
+  "format": "ome-zarr",
+  "rfc4_valid": true,
+  "axes": {
+    "z": "inferior-to-superior",
+    "y": "anterior-to-posterior",
+    "x": "right-to-left"
+  },
+  "violations": [],
+  "warnings": []
+}
+```
+
+`axes` maps each axis that declares an orientation value to that value;
+unannotated axes are omitted. `rfc4_valid` is false whenever `violations` is
+non-empty. The axes are read raw, so malformed metadata is still classified
+rather than rejected before it can be reported, and a code repeats once per
+offending axis:
+
+| Code | Condition |
+|---|---|
+| `orientation-on-non-space` | orientation declared on a non-spatial axis |
+| `bad-type` | `orientation.type` is not `"anatomical"` |
+| `missing-value` | orientation object without a `value` |
+| `bad-value` | `value` outside the 24-term vocabulary |
+| `duplicate-anatomical-axis` | two axes describing the same anatomical axis |
+| `null-orientation` *(warning)* | `orientation: null` -- writers SHOULD omit it |
+| `input-unreadable` | the input could not be read as JSON metadata |
+| `input-not-ome-zarr` | no `multiscales[0].axes` was found |
+
+An unreadable or non-OME-Zarr input reports the read-failure code as a
+violation, never `"rfc4_valid": true` with empty axes.
+
+## RFC-4 Conformance and Validation Data
+
+A reference validator, tool-agnostic conformance suite, sample datasets,
+and viewer screenshots are available at:
+
+<https://github.com/fideus-labs/ome-zarr-rfc4-validation>
+
+The corpus spans OME-Zarr alongside source formats that carry orientation in
+their own headers -- DICOM, NIfTI, NRRD, MINC, Analyze, Bruker ParaVision, FDF
+and whole-slide imaging -- exercises the full 24-term vocabulary, and
+includes must-reject cases for each rule above. Its driver runs any tool that
+speaks the canonical contract, so the subcommand above can be checked against
+the whole suite:
+
+```bash
+python conformance/run_conformance.py \
+    --data-dir hf-data \
+    --tool "ngff-zarr conformance {input}"
+```
+
+The sample data lives in a separate
+[Hugging Face repo](https://huggingface.co/fideus-labs/ome-zarr-rfc4-data),
+mirrored to a public S3 bucket that needs no credentials. The screenshots show
+the same files opened in 3D Slicer, ITK-SNAP, NiiVue and napari -- useful for
+seeing which viewers act on the `orientation` field and which only display axis
+names.
+
 ## RFC-4 Functions
 
 ### Core Functions
@@ -402,6 +509,8 @@ unaffected.
 4. **Document orientation assumptions** in your analysis pipelines when working
    with oriented data
 5. **Validate orientations** match your expectations, especially when combining
-   data from different sources
+   data from different sources -- `ngff-zarr conformance <store>` reports the
+   per-axis verdict, and `validate_structural()` enforces the orientation rules
+   as part of structural validation
 
 [RFC-4]: https://ngff.openmicroscopy.org/rfc/4/index.html

--- a/docs/rfc4.md
+++ b/docs/rfc4.md
@@ -1,6 +1,6 @@
 <!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
 <!-- SPDX-License-Identifier: MIT -->
-# RFC-4: Anatomical Orientation Support
+# 🧠 RFC-4: Anatomical Orientation Support
 
 [RFC-4] adds support for anatomical orientation metadata to OME-NGFF axes,
 enabling precise description of spatial axis directions in biological and

--- a/docs/rfc4.md
+++ b/docs/rfc4.md
@@ -429,11 +429,14 @@ offending axis:
 | `bad-value` | `value` outside the 24-term vocabulary |
 | `duplicate-anatomical-axis` | two axes describing the same anatomical axis |
 | `null-orientation` *(warning)* | `orientation: null` -- writers SHOULD omit it |
-| `input-unreadable` | the input could not be read as JSON metadata |
-| `input-not-ome-zarr` | no `multiscales[0].axes` was found |
+| `input-unreadable` | the store or its metadata is not readable JSON |
+| `input-not-ome-zarr` | `multiscales[0].axes` is missing or malformed |
 
-An unreadable or non-OME-Zarr input reports the read-failure code as a
-violation, never `"rfc4_valid": true` with empty axes.
+The last two are read failures rather than RFC-4 findings: `input-unreadable`
+covers an unreadable archive or invalid JSON, `input-not-ome-zarr` a store whose
+metadata carries no usable `multiscales[0].axes`. Either one is reported as a
+violation with `"rfc4_valid": false` and an empty `axes` object, so an input
+that could not be read is never mistaken for a conformant one.
 
 ## RFC-4 Conformance and Validation Data
 

--- a/docs/tiff.md
+++ b/docs/tiff.md
@@ -3,7 +3,7 @@ orphan: true
 ---
 <!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
 <!-- SPDX-License-Identifier: MIT -->
-# TIFF and OME-TIFF Support
+# 🖼️ TIFF and OME-TIFF Support
 
 NGFF-Zarr provides comprehensive support for converting TIFF and OME-TIFF files
 to OME-Zarr. When reading OME-TIFF files, physical size metadata is automatically


### PR DESCRIPTION
`ngff-zarr conformance` shipped without documentation. It is in `main` and
works, but appears in neither the RFC-4 page nor the CLI page where its
sibling `upgrade` is documented so there is no way to discover it.

## What this adds

**The conformance subcommand**, on both pages, with its real output and the
verdict codes it emits:

```json
{
  "input": "brain_icbm_ras.ome.zarr",
  "format": "ome-zarr",
  "rfc4_valid": true,
  "axes": { "z": "inferior-to-superior", "y": "anterior-to-posterior", "x": "right-to-left" },
  "violations": [],
  "warnings": []
}
```

**The rules RFC-4 imposes beyond the vocabulary** — orientation on spatial axes
only, `type` must be `anatomical`, one direction per anatomical axis, `null`
equals absent — and how `validate_structural()` reports the three it enforces.

**The conformance suite and data**: reference validator, tool-agnostic suite,
sample datasets and viewer screenshots at
[fideus-labs/ome-zarr-rfc4-validation](https://github.com/fideus-labs/ome-zarr-rfc4-validation),
including how to drive the suite through the subcommand.

## Two fixes along the way

- The RAS example called `ngff_zarr.RAS` in a snippet that only imports
  `ngff_zarr as nz` — a `NameError` if copied.
- `rfc4.md` was in no toctree, reachable only from a body link in the index;
  Sphinx warned about it on every build.

## Verification

Every claim was executed rather than assumed. The JSON above is a real run
against a generated LPS store, and the error message quoted in the
`validate_structural` example is that call's literal output — the first draft of
that example was wrong (`from_ngff_zarr` returns the v0.6 model, so the call
needs `.to_version("0.4")`).

Docs build with Sphinx: the rfc4 toctree warning is gone and the three that
remain are pre-existing (`installation.md`, `rfc5.md`, `tiff.md`).

Not documented deliberately: no case or format counts are quoted, since the
suite README and its conformance manifest disagree on both and the numbers
would drift; the linked repo stays the source of truth.

## Follow-ups, out of scope here

- `ngff-zarr conformance` does not read `.ozx` archives, though the CLI writes
  them: `rfc4_conformance.py` tests `suffix == ".zip"`, so an `.ozx` reports
  `input-not-ome-zarr`. The docs say `.zip` only, which is accurate today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Added guidance for checking RFC-4 anatomical orientation conformance.
- Documented the `ngff-zarr conformance` command, including usage, JSON output, supported directory and ZIP inputs, violation codes, warnings, and malformed-input handling.
- Added RFC-4 documentation to the documentation index.
- Corrected orientation examples and expanded validation requirements, structural rules, error handling, external resources, and best practices.
- Updated LIF and TIFF/OME-TIFF documentation headings for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->