### PR TITLE
ci: update from macos-15 to macos-26

### DIFF
--- a/.github/workflows/python-pixi.yml
+++ b/.github/workflows/python-pixi.yml
@@ -13,14 +13,14 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        # macos-15 is Apple Silicon (arm64); ubuntu-24.04 is x86_64.
-        os: [ubuntu-24.04, macos-15]
+        # macos-26 is Apple Silicon (arm64); ubuntu-24.04 is x86_64.
+        os: [ubuntu-24.04, macos-26]
         # One pixi environment per supported Python version. The unpinned
         # `test` environment tracks the latest (currently 3.14).
         environment: [test-py310, test-py311, test-py312, test-py313, test]
         include:
           # Keep a single Intel macOS smoke test on the latest Python.
-          - os: macos-15-intel
+          - os: macos-26-intel
             environment: test
 
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04-arm, windows-2022, macos-15-intel]
+        os: [ubuntu-22.04, ubuntu-24.04-arm, windows-2022, macos-26-intel]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-15]
+        os: [ubuntu-24.04, windows-2025, macos-26]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
There appear to be more runners available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS test runners in the CI matrix to use macOS 26 for Apple Silicon and Intel jobs.
  * Applied the update consistently across Python, Pixi, and TypeScript workflow checks.
  * Kept Ubuntu coverage and existing Python environment coverage unchanged.
  * No changes were made to application functionality or publicly available interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->