### PR TITLE
Get tiff translation from OME stage position

### DIFF
--- a/py/ngff_zarr/tiff_to_ngff_image.py
+++ b/py/ngff_zarr/tiff_to_ngff_image.py
@@ -429,6 +429,91 @@ def _extract_ome_pixel_metadata(
     return scale, units if units else None
 
 
+def _extract_ome_translation_metadata(tif: "tifffile.TiffFile", series_index: int = 0) -> tuple[dict[str, float] | None, dict[str, str] | None]:
+    """
+    Extract translation metadata from OME-XML for a specific series.
+
+    Parameters
+    ----------
+    tif : tifffile.TiffFile
+        An open TiffFile instance.
+    series_index : int, optional
+        Index of the series to extract metadata for. Default is 0.
+
+    Returns
+    -------
+    tuple[Optional[dict[str, float]], Optional[dict[str, str]]]
+        A tuple containing two dictionaries:
+        - translation: Mapping of dimension names to translation values.
+        - units: Mapping of dimension names to translation units.
+        Returns (None, None) if OME metadata is not available or cannot be parsed.
+    """
+    if not tif.is_ome or not tif.ome_metadata:
+        return None, None
+
+    try:
+        from tifffile import xml2dict
+        ome_metadata = xml2dict(tif.ome_metadata)
+        if "OME" in ome_metadata:
+            ome_metadata = ome_metadata["OME"]
+    except:
+        return None, None
+
+    images = ome_metadata["Image"]
+    if not isinstance(images, list):
+        images = [images]
+    if series_index < len(images):
+        image = images[series_index]
+        pixels = image.get("Pixels", {})
+        plane = pixels.get("Plane")
+        if isinstance(plane, list):
+            plane = plane[0]
+    else:
+        plane = None
+
+    if plane is None:
+        return None, None
+
+    translation: dict[str, float] = {}
+    units: dict[str, str] = {}
+
+    # Extract translation values for each dimension
+    dim_mapping = {
+        "PositionX": "x",
+        "PositionY": "y",
+        "PositionZ": "z",
+    }
+    unit_mapping = {
+        "PositionXUnit": "x",
+        "PositionYUnit": "y",
+        "PositionZUnit": "z",
+    }
+
+    for ome_attr, dim in dim_mapping.items():
+        value = plane.get(ome_attr)
+        if value is not None:
+            try:
+                translation[dim] = float(value)
+            except (ValueError, TypeError):
+                warnings.warn(
+                    f"Invalid translation value '{value}' for dimension '{dim}' "
+                    "in OME-XML metadata; ignoring this value.",
+                    RuntimeWarning,
+                )
+
+    for ome_attr, dim in unit_mapping.items():
+        value = plane.get(ome_attr)
+        if value is not None:
+            ngff_unit = _normalize_unit(value)
+            if ngff_unit is not None:
+                units[dim] = ngff_unit
+
+    if not translation:
+        return None, None
+
+    return translation, units if units else None
+
+
 def _extract_ome_channel_names(
     tif: "tifffile.TiffFile",
     series_index: int = 0,
@@ -1166,6 +1251,7 @@ def _read_tiff_series(
 
             # Extract OME metadata for this series
             ome_scale, ome_units = _extract_ome_pixel_metadata(tif, series_index=idx)
+            ome_translation, ome_translation_units = _extract_ome_translation_metadata(tif, series_index=idx)
             ome_channel_names = _extract_ome_channel_names(tif, series_index=idx)
             ome_channel_colors = _extract_ome_channel_colors(tif, series_index=idx)
 
@@ -1243,11 +1329,23 @@ def _read_tiff_series(
                     if dim in ome_units:
                         axes_units[dim] = ome_units[dim]
 
+            # Build translation dict from OME metadata
+            translation = None
+            if ome_translation:
+                translation = {}
+                spatial_dims = dims if dims else ("z", "y", "x")
+                for dim in spatial_dims:
+                    if dim in ome_translation:
+                        translation[dim] = ome_translation[dim]
+                    elif dim in ("x", "y", "z"):
+                        translation[dim] = 0.0  # Default translation for spatial dims
+
             # Convert to NgffImage
             ngff_image = to_ngff_image(
                 root,
                 dims=dims,
                 scale=scale,
+                translation=translation,
                 axes_units=axes_units,
                 channel_names=ome_channel_names,
             )

--- a/py/ngff_zarr/tiff_to_ngff_image.py
+++ b/py/ngff_zarr/tiff_to_ngff_image.py
@@ -321,6 +321,61 @@ def _reshape_tiff_for_channels(
     return data.reshape(ngff_shape)
 
 
+def _convert_unit_value(value, source_unit, target_unit):
+    """
+    Convert a physical size value from source_unit to target_unit.
+
+    Parameters
+    ----------
+    value : float
+        The physical size value to convert.
+    source_unit : str
+        The unit of the input value (e.g., 'micrometer').
+    target_unit : str
+        The desired unit for the output value (e.g., 'nanometer').
+
+    Returns
+    -------
+    float
+        The converted physical size value in target_unit.
+
+    Raises
+    ------
+    ValueError
+        If the source or target units are not recognized or compatible.
+    """
+    # Define conversion factors relative to meters
+    unit_to_meters = {
+        "attometer": 1e-18,
+        "femtometer": 1e-15,
+        "picometer": 1e-12,
+        "angstrom": 1e-10,
+        "nanometer": 1e-9,
+        "micrometer": 1e-6,
+        "millimeter": 1e-3,
+        "centimeter": 1e-2,
+        "decimeter": 1e-1,
+        "meter": 1.0,
+    }
+
+    # Normalize units using OME_UNIT_TO_NGFF mapping
+    if source_unit in OME_UNIT_TO_NGFF:
+        source_unit = OME_UNIT_TO_NGFF[source_unit]
+    if target_unit in OME_UNIT_TO_NGFF:
+        target_unit = OME_UNIT_TO_NGFF[target_unit]
+
+    if source_unit not in unit_to_meters:
+        raise ValueError(f"Unrecognized source unit: {source_unit}")
+    if target_unit not in unit_to_meters:
+        raise ValueError(f"Unrecognized target unit: {target_unit}")
+
+    # Convert to meters first, then to target unit
+    value_in_meters = value * unit_to_meters[source_unit]
+    converted_value = value_in_meters / unit_to_meters[target_unit]
+
+    return converted_value
+
+
 def _extract_ome_pixel_metadata(
     tif: "tifffile.TiffFile",
     series_index: int = 0,
@@ -757,6 +812,8 @@ def _build_multiscales_from_pyramid(
     tiff_series: "tifffile.TiffPageSeries",
     ome_scale: dict[str, float] | None,
     ome_units: dict[str, str] | None,
+    ome_translation: dict[str, float] | None,
+    ome_translation_units: dict[str, str] | None,
     ome_channel_names: list[str] | None,
     ome_channel_colors: list[str] | None = None,
 ) -> "NgffMultiscales":
@@ -777,6 +834,10 @@ def _build_multiscales_from_pyramid(
         Physical pixel sizes from OME metadata (e.g., {'x': 0.5, 'y': 0.5}).
     ome_units : dict or None
         Unit strings from OME metadata (e.g., {'x': 'micrometer'}).
+    ome_translation : dict or None
+        Translation values from OME metadata (e.g., {'x': 1.0, 'y': 2.0}).
+    ome_translation_units : dict or None
+        Translation unit strings from OME metadata (e.g., {'x': 'micrometer'}).
     ome_channel_names : list or None
         Channel names from OME metadata (e.g., ['DAPI', 'GFP', 'RFP']).
     ome_channel_colors : list or None
@@ -857,11 +918,26 @@ def _build_multiscales_from_pyramid(
             if dim in ome_units:
                 axes_units[dim] = ome_units[dim]
 
+    # Build translation dict from OME metadata
+    translation = None
+    if ome_translation:
+        translation = {}
+        spatial_dims = dims if dims else ("z", "y", "x")
+        for dim in spatial_dims:
+            if dim in ome_translation:
+                if ome_translation_units and axes_units:
+                    translation[dim] = _convert_unit_value(ome_translation[dim], ome_translation_units.get(dim), axes_units.get(dim))
+                else:
+                    translation[dim] = ome_translation[dim]
+            elif dim in ("x", "y", "z"):
+                translation[dim] = 0.0  # Default translation for spatial dims
+
     # Create base NgffImage
     ngff_image_0 = to_ngff_image(
         level0_data,
         dims=dims,
         scale=scale,
+        translation=translation,
         axes_units=axes_units,
         channel_names=ome_channel_names,
     )
@@ -1279,14 +1355,14 @@ def _read_tiff_series(
             # Check if this series has existing pyramid levels we can reuse
             n_levels = len(tiff_series.levels) if hasattr(tiff_series, "levels") else 1
             if reuse_existing_pyramids and n_levels > 1:
-                # TODO: inside _build_multiscales_from_pyramid() translation needs to be (extracted) and passed to:
-                #           ngff_image_0 = to_ngff_image()
                 multiscales = _build_multiscales_from_pyramid(
                     tif,
                     idx,
                     tiff_series,
                     ome_scale,
                     ome_units,
+                    ome_translation,
+                    ome_translation_units,
                     ome_channel_names,
                     ome_channel_colors,
                 )
@@ -1339,7 +1415,10 @@ def _read_tiff_series(
                 spatial_dims = dims if dims else ("z", "y", "x")
                 for dim in spatial_dims:
                     if dim in ome_translation:
-                        translation[dim] = ome_translation[dim]
+                        if ome_translation_units and axes_units:
+                            translation[dim] = _convert_unit_value(ome_translation[dim], ome_translation_units.get(dim), axes_units.get(dim))
+                        else:
+                            translation[dim] = ome_translation[dim]
                     elif dim in ("x", "y", "z"):
                         translation[dim] = 0.0  # Default translation for spatial dims
 

--- a/py/ngff_zarr/tiff_to_ngff_image.py
+++ b/py/ngff_zarr/tiff_to_ngff_image.py
@@ -454,10 +454,11 @@ def _extract_ome_translation_metadata(tif: "tifffile.TiffFile", series_index: in
     try:
         from tifffile import xml2dict
         ome_metadata = xml2dict(tif.ome_metadata)
-        if "OME" in ome_metadata:
-            ome_metadata = ome_metadata["OME"]
-    except:
+    except ET.ParseError:
         return None, None
+
+    if "OME" in ome_metadata:
+        ome_metadata = ome_metadata["OME"]
 
     images = ome_metadata["Image"]
     if not isinstance(images, list):

--- a/py/ngff_zarr/tiff_to_ngff_image.py
+++ b/py/ngff_zarr/tiff_to_ngff_image.py
@@ -1278,6 +1278,8 @@ def _read_tiff_series(
             # Check if this series has existing pyramid levels we can reuse
             n_levels = len(tiff_series.levels) if hasattr(tiff_series, "levels") else 1
             if reuse_existing_pyramids and n_levels > 1:
+                # TODO: inside _build_multiscales_from_pyramid() translation needs to be (extracted) and passed to:
+                #           ngff_image_0 = to_ngff_image()
                 multiscales = _build_multiscales_from_pyramid(
                     tif,
                     idx,

--- a/py/ngff_zarr/tiff_to_ngff_image.py
+++ b/py/ngff_zarr/tiff_to_ngff_image.py
@@ -484,7 +484,9 @@ def _extract_ome_pixel_metadata(
     return scale, units if units else None
 
 
-def _extract_ome_translation_metadata(tif: "tifffile.TiffFile", series_index: int = 0) -> tuple[dict[str, float] | None, dict[str, str] | None]:
+def _extract_ome_translation_metadata(
+    tif: "tifffile.TiffFile", series_index: int = 0
+) -> tuple[dict[str, float] | None, dict[str, str] | None]:
     """
     Extract translation metadata from OME-XML for a specific series.
 
@@ -508,6 +510,7 @@ def _extract_ome_translation_metadata(tif: "tifffile.TiffFile", series_index: in
 
     try:
         from tifffile import xml2dict
+
         ome_metadata = xml2dict(tif.ome_metadata)
     except ET.ParseError:
         return None, None
@@ -926,7 +929,11 @@ def _build_multiscales_from_pyramid(
         for dim in spatial_dims:
             if dim in ome_translation:
                 if ome_translation_units and axes_units:
-                    translation[dim] = _convert_unit_value(ome_translation[dim], ome_translation_units.get(dim), axes_units.get(dim))
+                    translation[dim] = _convert_unit_value(
+                        ome_translation[dim],
+                        ome_translation_units.get(dim),
+                        axes_units.get(dim),
+                    )
                 else:
                     translation[dim] = ome_translation[dim]
             elif dim in ("x", "y", "z"):
@@ -1328,7 +1335,9 @@ def _read_tiff_series(
 
             # Extract OME metadata for this series
             ome_scale, ome_units = _extract_ome_pixel_metadata(tif, series_index=idx)
-            ome_translation, ome_translation_units = _extract_ome_translation_metadata(tif, series_index=idx)
+            ome_translation, ome_translation_units = _extract_ome_translation_metadata(
+                tif, series_index=idx
+            )
             ome_channel_names = _extract_ome_channel_names(tif, series_index=idx)
             ome_channel_colors = _extract_ome_channel_colors(tif, series_index=idx)
 
@@ -1416,7 +1425,11 @@ def _read_tiff_series(
                 for dim in spatial_dims:
                     if dim in ome_translation:
                         if ome_translation_units and axes_units:
-                            translation[dim] = _convert_unit_value(ome_translation[dim], ome_translation_units.get(dim), axes_units.get(dim))
+                            translation[dim] = _convert_unit_value(
+                                ome_translation[dim],
+                                ome_translation_units.get(dim),
+                                axes_units.get(dim),
+                            )
                         else:
                             translation[dim] = ome_translation[dim]
                     elif dim in ("x", "y", "z"):

--- a/py/test/test_tiff_to_ngff_image.py
+++ b/py/test/test_tiff_to_ngff_image.py
@@ -410,7 +410,7 @@ def test_tiff_file_to_ngff_images_with_ome_translation():
     except ImportError:
         pytest.skip("tifffile not available")
 
-    from ngff_zarr import tiff_file_to_ngff_images, NgffMultiscales
+    from ngff_zarr import NgffMultiscales, tiff_file_to_ngff_images
     from ngff_zarr.tiff_to_ngff_image import _convert_unit_value
 
     # Create an OME-TIFF with translation metadata
@@ -431,14 +431,12 @@ def test_tiff_file_to_ngff_images_with_ome_translation():
 
     metadata = {
         "DimensionOrder": "XYZCT",
-
         "PhysicalSizeX": pixel_size,
         "PhysicalSizeXUnit": pixel_size_unit,
         "PhysicalSizeY": pixel_size,
         "PhysicalSizeYUnit": pixel_size_unit,
         "PhysicalSizeZ": pixel_size,
         "PhysicalSizeZUnit": pixel_size_unit,
-
         "Plane": {
             "PositionX": [position_x] * nplanes,
             "PositionXUnit": [ome_unit] * nplanes,
@@ -465,7 +463,9 @@ def test_tiff_file_to_ngff_images_with_ome_translation():
 
     # Convert and check metadata
     for reuse_existing_pyramids in [False, True]:
-        images = tiff_file_to_ngff_images(tiff_path, reuse_existing_pyramids=reuse_existing_pyramids)
+        images = tiff_file_to_ngff_images(
+            tiff_path, reuse_existing_pyramids=reuse_existing_pyramids
+        )
         assert len(images) == 1
 
         name, img = images[0]

--- a/py/test/test_tiff_to_ngff_image.py
+++ b/py/test/test_tiff_to_ngff_image.py
@@ -410,53 +410,73 @@ def test_tiff_file_to_ngff_images_with_ome_translation():
     except ImportError:
         pytest.skip("tifffile not available")
 
-    from ngff_zarr import tiff_file_to_ngff_images
+    from ngff_zarr import tiff_file_to_ngff_images, NgffMultiscales
+    from ngff_zarr.tiff_to_ngff_image import _convert_unit_value
 
     # Create an OME-TIFF with translation metadata
     tmpdir = Path(tempfile.mkdtemp())
     tiff_path = tmpdir / "ome_with_translation.ome.tiff"
 
+    pixel_size = 1
+    pixel_size_unit = "nm"
+
     size_x, size_y, size_z = 100, 100, 10
     position_x, position_y, position_z = 1.1, 2.2, 3.3
     ome_unit = "µm"
-    normalized_unit = "micrometer"
+    nplanes = size_z
+
+    expected_position_x = _convert_unit_value(position_x, ome_unit, pixel_size_unit)
+    expected_position_y = _convert_unit_value(position_y, ome_unit, pixel_size_unit)
+    expected_position_z = _convert_unit_value(position_z, ome_unit, pixel_size_unit)
+
+    metadata = {
+        "DimensionOrder": "XYZCT",
+
+        "PhysicalSizeX": pixel_size,
+        "PhysicalSizeXUnit": pixel_size_unit,
+        "PhysicalSizeY": pixel_size,
+        "PhysicalSizeYUnit": pixel_size_unit,
+        "PhysicalSizeZ": pixel_size,
+        "PhysicalSizeZUnit": pixel_size_unit,
+
+        "Plane": {
+            "PositionX": [position_x] * nplanes,
+            "PositionXUnit": [ome_unit] * nplanes,
+            "PositionY": [position_y] * nplanes,
+            "PositionYUnit": [ome_unit] * nplanes,
+            "PositionZ": [position_z] * nplanes,
+            "PositionZUnit": [ome_unit] * nplanes,
+        },
+    }
 
     with tifffile.TiffWriter(tiff_path, ome=True) as tif:
-        nplanes = size_z
         tif.write(
             np.random.rand(size_z, size_y, size_x).astype(np.float32),
             photometric="minisblack",
-            metadata={
-                "DimensionOrder": "XYZCT",
-                "Plane": {
-                    "PositionX": [position_x] * nplanes,
-                    "PositionXUnit": [ome_unit] * nplanes,
-                    "PositionY": [position_y] * nplanes,
-                    "PositionYUnit": [ome_unit] * nplanes,
-                    "PositionZ": [position_z] * nplanes,
-                    "PositionZUnit": [ome_unit] * nplanes,
-                },
-            },
+            metadata=metadata,
+            subifds=1,
+        )
+        tif.write(
+            np.random.rand(size_z // 2, size_y // 2, size_x // 2).astype(np.float32),
+            photometric="minisblack",
+            metadata=metadata,
+            subfiletype=1,
         )
 
     # Convert and check metadata
-    images = tiff_file_to_ngff_images(tiff_path)
-    assert len(images) == 1
+    for reuse_existing_pyramids in [False, True]:
+        images = tiff_file_to_ngff_images(tiff_path, reuse_existing_pyramids=reuse_existing_pyramids)
+        assert len(images) == 1
 
-    name, img = images[0]
+        name, img = images[0]
+        if isinstance(img, NgffMultiscales):
+            img = img.images[0]  # Get the first NgffImage from the multiscales
 
-    # Check translation was extracted from OME metadata
-    assert img.translation is not None
-    assert img.translation["x"] == pytest.approx(position_x)
-    assert img.translation["y"] == pytest.approx(position_y)
-    assert img.translation["z"] == pytest.approx(position_z)
-
-    # Check units were extracted and normalized
-    # TODO: NgffImage does not currently store translation units
-    #assert img.translation_units is not None
-    #assert img.translation_units["x"] == normalized_unit
-    #assert img.translation_units["y"] == normalized_unit
-    #assert img.translation_units["z"] == normalized_unit
+        # Check translation was extracted from OME metadata
+        assert img.translation is not None
+        assert img.translation["x"] == pytest.approx(expected_position_x)
+        assert img.translation["y"] == pytest.approx(expected_position_y)
+        assert img.translation["z"] == pytest.approx(expected_position_z)
 
 
 def test_tiff_file_to_ngff_images_simple_rgb():

--- a/py/test/test_tiff_to_ngff_image.py
+++ b/py/test/test_tiff_to_ngff_image.py
@@ -403,6 +403,62 @@ def test_tiff_file_to_ngff_images_with_sample_axis():
     assert img.data.shape == (5, 100, 100, 3)
 
 
+def test_tiff_file_to_ngff_images_with_ome_translation():
+    """Test that OME translation metadata is extracted."""
+    try:
+        import tifffile
+    except ImportError:
+        pytest.skip("tifffile not available")
+
+    from ngff_zarr import tiff_file_to_ngff_images
+
+    # Create an OME-TIFF with translation metadata
+    tmpdir = Path(tempfile.mkdtemp())
+    tiff_path = tmpdir / "ome_with_translation.ome.tiff"
+
+    size_x, size_y, size_z = 100, 100, 10
+    position_x, position_y, position_z = 1.1, 2.2, 3.3
+    ome_unit = "µm"
+    normalized_unit = "micrometer"
+
+    with tifffile.TiffWriter(tiff_path, ome=True) as tif:
+        nplanes = size_z
+        tif.write(
+            np.random.rand(size_z, size_y, size_x).astype(np.float32),
+            photometric="minisblack",
+            metadata={
+                "DimensionOrder": "XYZCT",
+                "Plane": {
+                    "PositionX": [position_x] * nplanes,
+                    "PositionXUnit": [ome_unit] * nplanes,
+                    "PositionY": [position_y] * nplanes,
+                    "PositionYUnit": [ome_unit] * nplanes,
+                    "PositionZ": [position_z] * nplanes,
+                    "PositionZUnit": [ome_unit] * nplanes,
+                },
+            },
+        )
+
+    # Convert and check metadata
+    images = tiff_file_to_ngff_images(tiff_path)
+    assert len(images) == 1
+
+    name, img = images[0]
+
+    # Check translation was extracted from OME metadata
+    assert img.translation is not None
+    assert img.translation["x"] == pytest.approx(position_x)
+    assert img.translation["y"] == pytest.approx(position_y)
+    assert img.translation["z"] == pytest.approx(position_z)
+
+    # Check units were extracted and normalized
+    # TODO: NgffImage does not currently store translation units
+    #assert img.translation_units is not None
+    #assert img.translation_units["x"] == normalized_unit
+    #assert img.translation_units["y"] == normalized_unit
+    #assert img.translation_units["z"] == normalized_unit
+
+
 def test_tiff_file_to_ngff_images_simple_rgb():
     """Test handling of simple RGB TIFF (YXS -> yxc)."""
     try:


### PR DESCRIPTION
Issue: NgffImage doesn't support translation unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OME-TIFF conversion now preserves X, Y, and Z spatial translation metadata for both pyramidal and non-pyramidal images.
  * Translation values are converted to the image’s axis units and propagated across pyramid levels.
  * Missing spatial translation values default to zero for consistent image positioning.

* **Bug Fixes**
  * Translation metadata units are normalized during extraction, including micrometer-to-nanometer conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->