### PR TITLE
fix(py): open public S3 OME-Zarr inputs anonymously

### DIFF
--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -957,7 +957,10 @@ def _convert_main(argv: list[str] | None = None) -> None:
 
         if input_backend is ConversionBackend.NGFF_ZARR:
             # Pass the path directly to from_ome_zarr to let it handle .ozx files
-            multiscales = from_ome_zarr(args.input[0])
+            storage_options = (
+                {"anon": True} if args.input[0].startswith("s3://") else None
+            )
+            multiscales = from_ome_zarr(args.input[0], storage_options=storage_options)
             _multiscales_to_ngff_zarr(
                 live,
                 args,

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -7,6 +7,7 @@ if __name__ == "__main__" and __package__ is None:
 
 import argparse
 import atexit
+import json
 import re
 import signal
 import sys
@@ -56,6 +57,45 @@ from .rich_dask_progress import NgffProgress, NgffProgressCallback
 from .to_multiscales import to_multiscales
 from .to_ngff_zarr import to_ome_zarr
 from .v04.zarr_metadata import Omero, OmeroChannel, OmeroWindow, is_unit_supported
+
+_REMOTE_SCHEMES = ("s3://", "gs://", "az://", "azure://", "http://", "https://")
+
+
+def _parse_storage_options(value: str) -> dict[str, object]:
+    """Parse fsspec storage options supplied as a JSON object."""
+    try:
+        options = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise argparse.ArgumentTypeError(
+            f"storage options must be valid JSON: {error.msg}"
+        ) from error
+    if not isinstance(options, dict):
+        raise argparse.ArgumentTypeError("storage options must be a JSON object")
+    return options
+
+
+def _resolve_cli_input_store(
+    input_path: str, storage_options: dict[str, object] | None
+) -> tuple[StoreLike, dict[str, object] | None]:
+    """Apply CLI remote storage options across supported zarr versions."""
+    scheme, separator, remainder = input_path.partition("://")
+    normalized_scheme = f"{scheme.lower()}{separator}"
+    if separator and normalized_scheme in _REMOTE_SCHEMES:
+        input_path = f"{normalized_scheme}{remainder}"
+
+    if storage_options is None and input_path.startswith("s3://"):
+        storage_options = {"anon": True}
+
+    is_remote = input_path.startswith(_REMOTE_SCHEMES)
+    if (
+        is_remote
+        and storage_options is not None
+        and not hasattr(zarr.storage, "FsspecStore")
+    ):
+        store = zarr.storage.FSStore(input_path, mode="r", **storage_options)
+        return store, None
+
+    return input_path, storage_options
 
 
 class _ReplacingTextIO:
@@ -622,6 +662,16 @@ def _convert_main(argv: list[str] | None = None) -> None:
         choices=conversion_backends_values,
         help="Input conversion backend",
     )
+    processing_group.add_argument(
+        "--storage-options",
+        type=_parse_storage_options,
+        metavar="JSON",
+        help=(
+            "JSON object of fsspec options for remote inputs, such as "
+            '\'{"anon": false, "requester_pays": true}\'. S3 inputs default '
+            "to anonymous access when this option is omitted."
+        ),
+    )
     processing_group.add_argument("--memory-target", help="Memory limit, e.g. 4GB")
     processing_group.add_argument(
         "--cache-dir", help="Directory to use for caching with large datasets"
@@ -645,8 +695,6 @@ def _convert_main(argv: list[str] | None = None) -> None:
     )
 
     args = parser.parse_args(argv)
-
-    _REMOTE_SCHEMES = ("s3://", "gs://", "az://", "azure://", "http://", "https://")
 
     def _is_remote(path_str: str) -> bool:
         lower = path_str.lower()
@@ -957,10 +1005,10 @@ def _convert_main(argv: list[str] | None = None) -> None:
 
         if input_backend is ConversionBackend.NGFF_ZARR:
             # Pass the path directly to from_ome_zarr to let it handle .ozx files
-            storage_options = (
-                {"anon": True} if args.input[0].startswith("s3://") else None
+            input_store, storage_options = _resolve_cli_input_store(
+                args.input[0], args.storage_options
             )
-            multiscales = from_ome_zarr(args.input[0], storage_options=storage_options)
+            multiscales = from_ome_zarr(input_store, storage_options=storage_options)
             _multiscales_to_ngff_zarr(
                 live,
                 args,

--- a/py/test/test_cli_s3.py
+++ b/py/test/test_cli_s3.py
@@ -5,31 +5,116 @@ from unittest.mock import Mock
 import pytest
 from ngff_zarr import cli
 
+S3_URI = (
+    "s3://aind-scratch-data/exaspim-ccfv4-template-dev/nifti-to-omezarr/"
+    "Registration_EXASPIM_delivery_ExaSPIM_template_10specimens_30um."
+    "ome.zarr"
+)
+
 
 @pytest.mark.parametrize(
-    ("uri", "expected_storage_options"),
+    ("argv", "expected_input", "expected_storage_options"),
     [
-        (
-            "s3://aind-scratch-data/exaspim-ccfv4-template-dev/nifti-to-omezarr/"
-            "Registration_EXASPIM_delivery_ExaSPIM_template_10specimens_30um."
-            "ome.zarr",
+        pytest.param(
+            ["-i", S3_URI],
+            S3_URI,
             {"anon": True},
+            id="anonymous-s3",
         ),
-        ("https://example.com/image.ome.zarr", None),
+        pytest.param(
+            ["-i", S3_URI.replace("s3://", "S3://")],
+            S3_URI,
+            {"anon": True},
+            id="normalized-s3-scheme",
+        ),
+        pytest.param(
+            [
+                "--storage-options",
+                '{"anon": false, "requester_pays": true}',
+                "-i",
+                S3_URI,
+            ],
+            S3_URI,
+            {"anon": False, "requester_pays": True},
+            id="authenticated-requester-pays-s3",
+        ),
+        pytest.param(
+            ["-i", "https://example.com/image.ome.zarr"],
+            "https://example.com/image.ome.zarr",
+            None,
+            id="default-https",
+        ),
     ],
-    ids=("anonymous-s3", "default-https"),
+)
+@pytest.mark.skipif(
+    not hasattr(cli.zarr.storage, "FsspecStore"),
+    reason="zarr-python 3 storage options path",
 )
 def test_cli_configures_remote_storage_options(
-    monkeypatch, uri, expected_storage_options
+    monkeypatch, argv, expected_input, expected_storage_options
 ):
-    """Only S3 CLI inputs opt into anonymous remote access."""
+    """S3 defaults to anonymous access but accepts explicit fsspec options."""
     multiscales = object()
     from_ome_zarr = Mock(return_value=multiscales)
     render = Mock()
     monkeypatch.setattr(cli, "from_ome_zarr", from_ome_zarr)
     monkeypatch.setattr(cli, "_multiscales_to_ngff_zarr", render)
 
-    cli.main(["--quiet", "-i", uri])
+    cli.main(["--quiet", *argv])
 
-    from_ome_zarr.assert_called_once_with(uri, storage_options=expected_storage_options)
+    from_ome_zarr.assert_called_once_with(
+        expected_input, storage_options=expected_storage_options
+    )
     assert render.call_args.args[4] is multiscales
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_storage_options"),
+    [
+        pytest.param([], {"anon": True}, id="anonymous-s3"),
+        pytest.param(
+            [
+                "--storage-options",
+                '{"anon": false, "profile": "research"}',
+            ],
+            {"anon": False, "profile": "research"},
+            id="authenticated-s3",
+        ),
+    ],
+)
+def test_cli_configures_zarr2_s3_store(
+    monkeypatch, extra_args, expected_storage_options
+):
+    """Zarr 2 receives S3 options through FSStore instead of the v3-only API."""
+    multiscales = object()
+    legacy_store = object()
+    from_ome_zarr = Mock(return_value=multiscales)
+    fs_store = Mock(return_value=legacy_store)
+    render = Mock()
+    monkeypatch.delattr(cli.zarr.storage, "FsspecStore", raising=False)
+    monkeypatch.setattr(cli.zarr.storage, "FSStore", fs_store, raising=False)
+    monkeypatch.setattr(cli, "from_ome_zarr", from_ome_zarr)
+    monkeypatch.setattr(cli, "_multiscales_to_ngff_zarr", render)
+
+    cli.main(["--quiet", "-i", S3_URI, *extra_args])
+
+    fs_store.assert_called_once_with(S3_URI, mode="r", **expected_storage_options)
+    from_ome_zarr.assert_called_once_with(legacy_store, storage_options=None)
+    assert render.call_args.args[4] is multiscales
+
+
+@pytest.mark.parametrize("storage_options", ["not-json", "[]"])
+def test_cli_rejects_invalid_storage_options(storage_options, capsys):
+    """Storage options must decode to a JSON object."""
+    with pytest.raises(SystemExit):
+        cli.main(
+            [
+                "--quiet",
+                "-i",
+                S3_URI,
+                "--storage-options",
+                storage_options,
+            ]
+        )
+
+    assert "storage options must be" in capsys.readouterr().err

--- a/py/test/test_cli_s3.py
+++ b/py/test/test_cli_s3.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+from unittest.mock import Mock
+
+import pytest
+from ngff_zarr import cli
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected_storage_options"),
+    [
+        (
+            "s3://aind-scratch-data/exaspim-ccfv4-template-dev/nifti-to-omezarr/"
+            "Registration_EXASPIM_delivery_ExaSPIM_template_10specimens_30um."
+            "ome.zarr",
+            {"anon": True},
+        ),
+        ("https://example.com/image.ome.zarr", None),
+    ],
+    ids=("anonymous-s3", "default-https"),
+)
+def test_cli_configures_remote_storage_options(
+    monkeypatch, uri, expected_storage_options
+):
+    """Only S3 CLI inputs opt into anonymous remote access."""
+    multiscales = object()
+    from_ome_zarr = Mock(return_value=multiscales)
+    render = Mock()
+    monkeypatch.setattr(cli, "from_ome_zarr", from_ome_zarr)
+    monkeypatch.setattr(cli, "_multiscales_to_ngff_zarr", render)
+
+    cli.main(["--quiet", "-i", uri])
+
+    from_ome_zarr.assert_called_once_with(uri, storage_options=expected_storage_options)
+    assert render.call_args.args[4] is multiscales


### PR DESCRIPTION
## Summary

- Open `s3://` OME-Zarr CLI inputs with anonymous S3 access.
- Preserve the existing storage behavior for non-S3 remote inputs such as HTTPS.
- Add focused regression coverage for both branches of the remote-storage selection.

## Why

Inspecting a public OME-Zarr store with `ngff-zarr -i s3://...` previously let
`s3fs` use its credential-seeking default. On systems without configured AWS
credentials, the public metadata request therefore failed with
`NoCredentialsError` instead of inspecting the store.

## Implementation

The direct NGFF CLI path now passes `storage_options={"anon": True}` to
`from_ome_zarr` for `s3://` inputs. Other URI schemes continue to pass no
storage options, keeping the change scoped to public S3 inspection and reusing
the existing `FsspecStore` construction in `from_ome_zarr`.

The new parameterized CLI test uses the reported AIND S3 URI and an HTTPS URI
to verify both the anonymous-S3 behavior and the unchanged non-S3 behavior
without making network requests.

## Validation

- Relevant Python tests: 18 passed, 1 opt-in network test skipped
- Changed executable lines covered, with both conditional outcomes asserted
- Full `prek` hook suite passed
- CodeRabbit review completed with no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring remote storage options with JSON when loading NGFF-Zarr data.
  - Improved remote URL handling, including normalized S3 paths and automatic anonymous S3 access when no options are provided.
  - Added compatibility for loading S3 data with older Zarr versions.
  - HTTPS inputs continue to use standard storage settings.

- **Bug Fixes**
  - Invalid storage-option input is now rejected with clear validation.

- **Tests**
  - Expanded coverage for S3, HTTPS, storage options, and older Zarr compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->