### PR TITLE
ci: fix PyPI publish failure on metadata 2.5 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,15 @@ on:
       - 'py-v*'
       - 'ts-v*'
       - 'mcp-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Existing release tag to (re-)publish, e.g. py-v0.42.0. Run this from
+          the branch holding the workflow you want (usually main); the tag only
+          selects which source revision is built and published.
+        required: true
+        type: string
 
 permissions:
   contents: write  # Required to create releases
@@ -24,12 +33,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # Empty on tag pushes, which checks out the triggering tag as usual.
+          ref: ${{ inputs.tag }}
           fetch-depth: 0  # Full history for changelog extraction
 
       - name: Identify project and version from tag
         id: identify
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${INPUT_TAG:-${GITHUB_REF#refs/tags/}}"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
           # Extract project prefix and version
@@ -239,6 +252,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Explicit: on workflow_dispatch the ref is a branch, not the tag.
+          tag_name: ${{ steps.identify.outputs.tag }}
           name: "${{ steps.identify.outputs.project_name }} v${{ steps.identify.outputs.version }}"
           body_path: ${{ steps.changelog.outputs.changelog_file }}
           prerelease: ${{ steps.identify.outputs.prerelease }}
@@ -269,7 +284,7 @@ jobs:
 
       - name: Publish Python package to PyPI
         if: steps.identify.outputs.project == 'py'
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: py/dist/
           skip-existing: true
@@ -279,7 +294,7 @@ jobs:
 
       - name: Publish MCP package to PyPI
         if: steps.identify.outputs.project == 'mcp'
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: mcp/dist/
           skip-existing: true


### PR DESCRIPTION
## Problem

The [`py-v0.42.0` release job](https://github.com/fideus-labs/ngff-zarr/actions/runs/31728031587/job/94562361259) failed at **Publish Python package to PyPI**:

```
Checking py/dist/ngff_zarr-0.42.0-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling **1.32.0** was released 2026-08-11, two days before the run, and bumped emitted core metadata to `Metadata-Version: 2.5`. The workflow installs hatch unpinned, so the runner picked it up. Meanwhile `pypa/gh-action-pypi-publish` was pinned to commit `ed0c539` (Sept 2025), which bundles `twine==6.1.0` + `packaging==25.0` — and packaging 25.0's `_VALID_METADATA_VERSIONS` tops out at `"2.4"`. `twine check` therefore rejected a perfectly valid wheel.

|  | pinned `ed0c539` | `v1.14.2` (`dc37677`) |
|---|---|---|
| twine | 6.1.0 | 7.0.0 |
| packaging | 25.0 → max metadata **2.4** | 26.2 → max metadata **2.6** |

PyPI itself accepts 2.5 — hatchling 1.32.0's own wheel is on PyPI with `Metadata-Version: 2.5`. The rejection was purely client-side in the stale action image.

## Changes

- Bump both PyPI publish steps (py and mcp) to `pypa/gh-action-pypi-publish@dc37677` (v1.14.2, current `release/v1` HEAD). The `packages-dir` / `skip-existing` / `verbose` inputs are unchanged in 1.14.x. The mcp step is fixed too since it would hit the identical failure on the next `mcp-v*` tag.
- Add a `workflow_dispatch` trigger taking a `tag` input. Re-running a failed job replays the workflow file *from the tagged commit*, so a fix on `main` can't rescue an already-pushed tag — recovery today means deleting the release and tag and re-tagging. With this, dispatch from `main` with `tag: py-v0.42.0` and the fixed workflow builds and publishes that tag's source.
  - Checkout takes `ref: ${{ inputs.tag }}`, which is empty on tag pushes and so preserves existing behavior.
  - The identify step derives `TAG` from `INPUT_TAG` via env (not direct interpolation) to avoid script injection from the dispatch input, falling back to `GITHUB_REF`.
  - `action-gh-release` now gets an explicit `tag_name`, since on dispatch the ref is a branch rather than the tag.

## Verification

- `actionlint` 1.7.12 passes clean on the workflow.
- Both `TAG` derivation paths tested in bash: push mode yields `py-v0.42.0` from `refs/tags/py-v0.42.0`, dispatch mode yields the input tag.
- Checked that shipping metadata 2.5 doesn't break installs: `pip 24.0` installs `hatchling==1.32.0` (a metadata 2.5 wheel) without complaint, so pinning hatchling back to 1.31 isn't needed.

## Release state

`py-v0.42.0` is on GitHub Releases but **not on PyPI** (latest there is 0.41.1). Re-tagging to actually ship 0.42.0 is being handled separately.