### PR TITLE
feat(mcp): support stateless Streamable HTTP transport

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -132,14 +132,31 @@ Add this to your Windsurf MCP config file. See
 }
 ```
 
-#### SSE Transport
+#### Streamable HTTP Transport
+
+```json
+{
+  "mcpServers": {
+    "ngff-zarr": {
+      "url": "http://localhost:8000/mcp",
+      "description": "ngff-zarr server running with Streamable HTTP transport"
+    }
+  }
+}
+```
+
+#### SSE Transport (deprecated)
+
+The HTTP+SSE transport was deprecated in MCP specification revision
+2025-03-26 in favor of Streamable HTTP. It remains available for older
+clients:
 
 ```json
 {
   "mcpServers": {
     "ngff-zarr": {
       "url": "http://localhost:8000/sse",
-      "description": "ngff-zarr server running with SSE transport"
+      "description": "ngff-zarr server running with legacy SSE transport"
     }
   }
 }
@@ -592,15 +609,36 @@ The server can be run in different transport modes:
 # STDIO transport (default)
 ngff-zarr-mcp
 
-# Server-Sent Events transport
+# Streamable HTTP transport (recommended for network deployments)
+ngff-zarr-mcp --transport streamable-http --host localhost --port 8000
+
+# Stateless Streamable HTTP for load-balanced or serverless deployments
+ngff-zarr-mcp --transport streamable-http --stateless-http --json-response
+
+# Legacy Server-Sent Events transport (deprecated)
 ngff-zarr-mcp --transport sse --host localhost --port 8000
 ```
 
 ### Transport Options
 
 - **STDIO**: Default transport for most MCP clients
-- **SSE**: Server-Sent Events for web-based clients or when HTTP transport is
-  preferred
+- **Streamable HTTP**: The HTTP transport introduced in MCP specification
+  revision 2025-03-26. Serves a single `/mcp` endpoint and supports optional
+  session management via the `Mcp-Session-Id` header.
+- **SSE**: The legacy HTTP+SSE transport, deprecated in MCP specification
+  revision 2025-03-26. Kept for backwards compatibility with older clients.
+
+### Stateless Operation
+
+With `--stateless-http`, the server does not issue an `Mcp-Session-Id`
+header and treats every request as self-contained. This allows horizontal
+scaling behind a load balancer without session affinity and deployment on
+serverless platforms. Adding `--json-response` returns plain
+`application/json` bodies instead of opening a Server-Sent Events stream per
+request, which is friendlier to proxies that buffer streaming responses.
+Note that stateless mode disables server-initiated interactions that require
+a persistent session (such as sampling and elicitation); the ngff-zarr tools
+do not rely on these features.
 
 See the installation section above for client-specific configuration examples.
 

--- a/mcp/ngff_zarr_mcp/server.py
+++ b/mcp/ngff_zarr_mcp/server.py
@@ -278,19 +278,72 @@ def main():
     parser = argparse.ArgumentParser(description="ngff-zarr MCP Server")
     parser.add_argument(
         "--transport",
-        choices=["stdio", "sse"],
+        choices=["stdio", "streamable-http", "sse"],
         default="stdio",
-        help="Transport mechanism to use",
+        help=(
+            "Transport mechanism to use. 'streamable-http' is the Streamable "
+            "HTTP transport introduced in MCP specification revision "
+            "2025-03-26; 'sse' (the legacy HTTP+SSE transport) is deprecated "
+            "and kept only for backwards compatibility."
+        ),
     )
-    parser.add_argument("--host", default="localhost", help="Host for SSE transport")
-    parser.add_argument("--port", type=int, default=8000, help="Port for SSE transport")
+    parser.add_argument("--host", default="localhost", help="Host for HTTP transports")
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Port for HTTP transports"
+    )
+    parser.add_argument(
+        "--stateless-http",
+        action="store_true",
+        help=(
+            "Run the Streamable HTTP transport in stateless mode: the server "
+            "does not issue an Mcp-Session-Id header and every request is "
+            "self-contained, so instances can run behind load balancers or in "
+            "serverless environments without session affinity. Requires "
+            "--transport streamable-http."
+        ),
+    )
+    parser.add_argument(
+        "--json-response",
+        action="store_true",
+        help=(
+            "Return plain application/json responses instead of opening a "
+            "text/event-stream (SSE) response per request. Useful for "
+            "stateless deployments behind proxies that do not handle "
+            "streaming responses. Requires --transport streamable-http."
+        ),
+    )
 
     args = parser.parse_args()
 
+    if (
+        args.stateless_http or args.json_response
+    ) and args.transport != "streamable-http":
+        parser.error(
+            "--stateless-http and --json-response require --transport streamable-http"
+        )
+
     if args.transport == "stdio":
         mcp.run()
+        return
+
+    mcp.settings.host = args.host
+    mcp.settings.port = args.port
+
+    if args.transport == "streamable-http":
+        mcp.settings.stateless_http = args.stateless_http
+        mcp.settings.json_response = args.json_response
+        mcp.run(transport="streamable-http")
     elif args.transport == "sse":
-        mcp.run_sse(host=args.host, port=args.port)
+        import warnings
+
+        warnings.warn(
+            "The HTTP+SSE transport was deprecated in MCP specification "
+            "revision 2025-03-26 in favor of Streamable HTTP. "
+            "Use --transport streamable-http instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        mcp.run(transport="sse")
 
 
 if __name__ == "__main__":

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -31,7 +31,10 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "mcp",
+    # >= 1.8.0 for the Streamable HTTP transport with stateless_http and
+    # json_response support (MCP specification revision 2025-03-26);
+    # < 2 because mcp 2.0 removed the mcp.server.fastmcp module.
+    "mcp >= 1.8.0, < 2",
     "ngff-zarr[cli,tensorstore] >= 0.15.2",
     "pydantic >= 2.0",
     "httpx",


### PR DESCRIPTION
MCP specification revision 2025-03-26 replaced the HTTP+SSE transport
with Streamable HTTP (modelcontextprotocol PR #206) and made protocol
sessions optional: a server MAY assign an Mcp-Session-Id header at
initialization, and one that does not treats every request as
self-contained, allowing deployment behind load balancers or on
serverless platforms without session affinity. Revision 2025-06-18
additionally requires the MCP-Protocol-Version header on subsequent
HTTP requests, which the mcp Python SDK handles for this transport.

- Add a streamable-http transport choice serving the single /mcp
  endpoint, with --stateless-http (no Mcp-Session-Id issued, no
  session persistence) and --json-response (plain application/json
  bodies instead of a per-request SSE stream) flags wired to the
  FastMCP stateless_http and json_response settings.
- Fix the SSE code path, which called the nonexistent
  FastMCP.run_sse(); it now uses mcp.run(transport="sse") and emits a
  DeprecationWarning pointing at Streamable HTTP, per the transport's
  deprecation in spec revision 2025-03-26.
- Reject --stateless-http/--json-response with other transports.
- Constrain the mcp dependency to >= 1.8.0, < 2: 1.8.0 introduced
  stateless streamable HTTP support and mcp 2.0 removed the
  mcp.server.fastmcp module this server imports.
- Document the new transport, stateless operation, and the /mcp
  client endpoint in the README.

The ngff-zarr tools do not use sampling or elicitation, so no tool
behavior changes in stateless mode.
