### PR TITLE
refactor(py,ts): keep the RFC-4 vocabulary in one place per port

### DIFF
--- a/py/ngff_zarr/rfc4_validation.py
+++ b/py/ngff_zarr/rfc4_validation.py
@@ -25,7 +25,13 @@ def load_rfc4_orientation_schema() -> dict:
 
 # Each RFC 4 value maps to a stable key for the anatomical axis it lies on, so the
 # two antonyms of a pair (e.g. "left-to-right" / "right-to-left") collapse to one
-# key. Used to enforce "one direction per anatomical axis" (mutual exclusion).
+# key. Used to enforce "one direction per anatomical axis" (mutual exclusion), and
+# its keys are this module's vocabulary: membership is checked against them, and
+# the "valid values are" message lists them, so a value cannot be accepted here
+# and then fail the pair lookup below.
+#
+# ``test_rfc4_vocabulary.py`` pins these keys against
+# :class:`ngff_zarr.rfc4.AnatomicalOrientationValues` and the bundled schema.
 _ANATOMICAL_AXIS_OF: dict[str, str] = {
     "left-to-right": "left-right",
     "right-to-left": "left-right",
@@ -102,34 +108,6 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
     has_orientation = False
     spatial_orientation_values: list[tuple[str, str]] = []
 
-    # Valid anatomical orientation values (from the schema)
-    valid_orientation_values = {
-        "left-to-right",
-        "right-to-left",
-        "anterior-to-posterior",
-        "posterior-to-anterior",
-        "inferior-to-superior",
-        "superior-to-inferior",
-        "dorsal-to-ventral",
-        "ventral-to-dorsal",
-        "dorsal-to-palmar",
-        "palmar-to-dorsal",
-        "dorsal-to-plantar",
-        "plantar-to-dorsal",
-        "rostral-to-caudal",
-        "caudal-to-rostral",
-        "cranial-to-caudal",
-        "caudal-to-cranial",
-        "proximal-to-distal",
-        "distal-to-proximal",
-        "superficial-to-deep",
-        "deep-to-superficial",
-        "apical-to-basal",
-        "basal-to-apical",
-        "apex-to-base",
-        "base-to-apex",
-    }
-
     for axis in axes:
         if isinstance(axis, dict) and axis.get("type") == "space":
             orientation = axis.get("orientation")
@@ -156,12 +134,12 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
 
             # Check that the orientation value is in the controlled vocabulary
             orientation_value = orientation.get("value")
-            if orientation_value not in valid_orientation_values:
+            if orientation_value not in _ANATOMICAL_AXIS_OF:
                 from jsonschema import ValidationError
 
                 raise ValidationError(
                     f"Invalid orientation value '{orientation_value}' for axis '{axis['name']}'. "
-                    f"Valid values are: {sorted(valid_orientation_values)}"
+                    f"Valid values are: {sorted(_ANATOMICAL_AXIS_OF)}"
                 )
             spatial_orientation_values.append((axis["name"], orientation_value))
 

--- a/py/ngff_zarr/rfc4_validation.py
+++ b/py/ngff_zarr/rfc4_validation.py
@@ -132,9 +132,15 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
                     f"'{axis['name']}' has type '{orientation_type}'."
                 )
 
-            # Check that the orientation value is in the controlled vocabulary
+            # Check that the orientation value is in the controlled vocabulary.
+            # The membership test is a dict lookup, so a list or object value
+            # would raise TypeError rather than the documented ValidationError;
+            # a non-string is not in the vocabulary either way.
             orientation_value = orientation.get("value")
-            if orientation_value not in _ANATOMICAL_AXIS_OF:
+            if (
+                not isinstance(orientation_value, str)
+                or orientation_value not in _ANATOMICAL_AXIS_OF
+            ):
                 from jsonschema import ValidationError
 
                 raise ValidationError(

--- a/py/test/test_rfc4_vocabulary.py
+++ b/py/test/test_rfc4_vocabulary.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""The RFC 4 vocabulary is written down more than once; pin the copies together.
+
+Three independent transcriptions of the 24 anatomical orientation values ship
+in the package: the public :class:`AnatomicalOrientationValues` enum, the
+antonym-pair table the validator checks against, and the enum inside the
+bundled RFC 4 schema. Nothing derives one from another, so these tests are what
+keeps them from drifting: a value added to one and not the others would let
+``to_ngff_zarr`` write an orientation that ``from_ngff_zarr(validate=True)``
+then rejects.
+"""
+
+from ngff_zarr.rfc4 import AnatomicalOrientationValues
+from ngff_zarr.rfc4_validation import _ANATOMICAL_AXIS_OF, load_rfc4_orientation_schema
+
+_EXPECTED_COUNT = 24
+
+
+def _schema_values() -> set[str]:
+    schema = load_rfc4_orientation_schema()
+    return set(schema["$defs"]["AnatomicalOrientationValues"]["enum"])
+
+
+def test_the_three_copies_hold_the_same_values():
+    enum_values = {member.value for member in AnatomicalOrientationValues}
+    assert enum_values == set(_ANATOMICAL_AXIS_OF)
+    assert enum_values == _schema_values()
+
+
+def test_the_vocabulary_has_not_changed_size():
+    """A term added upstream must be added deliberately, in every copy."""
+    assert len(AnatomicalOrientationValues) == _EXPECTED_COUNT
+    assert len(_ANATOMICAL_AXIS_OF) == _EXPECTED_COUNT
+    assert len(_schema_values()) == _EXPECTED_COUNT
+
+
+def test_every_anatomical_axis_carries_exactly_two_directions():
+    """The table collapses antonyms in pairs, which the mutual-exclusion rule
+    relies on: an axis key reached by one value only would make that value
+    impossible to conflict with, and one reached by three would reject a legal
+    pair of axes."""
+    per_axis: dict[str, list[str]] = {}
+    for value, axis in _ANATOMICAL_AXIS_OF.items():
+        per_axis.setdefault(axis, []).append(value)
+    assert {axis: len(values) for axis, values in per_axis.items() if len(values) != 2} == {}
+    assert len(per_axis) == _EXPECTED_COUNT // 2

--- a/py/test/test_rfc4_vocabulary.py
+++ b/py/test/test_rfc4_vocabulary.py
@@ -11,8 +11,13 @@ keeps them from drifting: a value added to one and not the others would let
 then rejects.
 """
 
+import pytest
 from ngff_zarr.rfc4 import AnatomicalOrientationValues
-from ngff_zarr.rfc4_validation import _ANATOMICAL_AXIS_OF, load_rfc4_orientation_schema
+from ngff_zarr.rfc4_validation import (
+    _ANATOMICAL_AXIS_OF,
+    load_rfc4_orientation_schema,
+    validate_rfc4_orientation,
+)
 
 _EXPECTED_COUNT = 24
 
@@ -43,5 +48,26 @@ def test_every_anatomical_axis_carries_exactly_two_directions():
     per_axis: dict[str, list[str]] = {}
     for value, axis in _ANATOMICAL_AXIS_OF.items():
         per_axis.setdefault(axis, []).append(value)
-    assert {axis: len(values) for axis, values in per_axis.items() if len(values) != 2} == {}
+    assert {
+        axis: len(values) for axis, values in per_axis.items() if len(values) != 2
+    } == {}
     assert len(per_axis) == _EXPECTED_COUNT // 2
+
+
+@pytest.mark.parametrize("value", [[], {"a": 1}, 42, None, True])
+def test_a_non_string_value_takes_the_documented_error_path(value):
+    """The vocabulary lookup is a dict lookup, so an unhashable value would
+    raise TypeError instead of the ValidationError the function documents."""
+    pytest.importorskip("jsonschema")
+    from jsonschema import ValidationError
+
+    axes = [
+        {
+            "name": "y",
+            "type": "space",
+            "orientation": {"type": "anatomical", "value": value},
+        },
+        {"name": "x", "type": "space"},
+    ]
+    with pytest.raises(ValidationError, match="Invalid orientation value"):
+        validate_rfc4_orientation(axes)

--- a/ts/src/utils/rfc4_validation.ts
+++ b/ts/src/utils/rfc4_validation.ts
@@ -9,40 +9,12 @@
 import { AnatomicalOrientationValuesSchema } from "../schemas/rfc4.ts";
 import { formatNameList } from "./py_format.ts";
 
-/** Valid anatomical orientation values */
-const VALID_ORIENTATION_VALUES = new Set([
-  "left-to-right",
-  "right-to-left",
-  "anterior-to-posterior",
-  "posterior-to-anterior",
-  "inferior-to-superior",
-  "superior-to-inferior",
-  "dorsal-to-ventral",
-  "ventral-to-dorsal",
-  "dorsal-to-palmar",
-  "palmar-to-dorsal",
-  "dorsal-to-plantar",
-  "plantar-to-dorsal",
-  "rostral-to-caudal",
-  "caudal-to-rostral",
-  "cranial-to-caudal",
-  "caudal-to-cranial",
-  "proximal-to-distal",
-  "distal-to-proximal",
-  "superficial-to-deep",
-  "deep-to-superficial",
-  "apical-to-basal",
-  "basal-to-apical",
-  "apex-to-base",
-  "base-to-apex",
-]);
-
 /**
  * Each RFC 4 value maps to a stable key for the anatomical axis it lies on, so
  * the two antonyms of a pair (e.g. "left-to-right" / "right-to-left") collapse to
  * one key. Used to enforce "one direction per anatomical axis" (mutual exclusion).
  */
-const ANATOMICAL_AXIS_OF: Record<string, string> = {
+export const ANATOMICAL_AXIS_OF: Record<string, string> = {
   "left-to-right": "left-right",
   "right-to-left": "left-right",
   "anterior-to-posterior": "anterior-posterior",
@@ -68,6 +40,14 @@ const ANATOMICAL_AXIS_OF: Record<string, string> = {
   "apex-to-base": "apex-base",
   "base-to-apex": "apex-base",
 };
+
+/**
+ * The controlled vocabulary, derived from the pair table rather than typed out
+ * again: the message that lists the valid values then cannot disagree with what
+ * the mutual-exclusion rule can look up. `rfc4_vocabulary_test.ts` pins it
+ * against the Zod schema and the `AnatomicalOrientationValues` enum.
+ */
+const VALID_ORIENTATION_VALUES = new Set(Object.keys(ANATOMICAL_AXIS_OF));
 
 /**
  * Check if the axes contain RFC 4 anatomical orientation metadata.

--- a/ts/test/rfc4_vocabulary_test.ts
+++ b/ts/test/rfc4_vocabulary_test.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * The RFC 4 vocabulary is written down more than once; pin the copies together.
+ *
+ * The 24 anatomical orientation values are transcribed independently as the
+ * `AnatomicalOrientationValues` enum, the Zod schema the validator checks
+ * against, and the antonym-pair table. Nothing derives one from another, so
+ * these tests are what keeps them from drifting. The Python twin is
+ * `py/test/test_rfc4_vocabulary.py`.
+ */
+
+import { assertEquals } from "@std/assert";
+import { AnatomicalOrientationValues } from "../src/types/rfc4.ts";
+import { AnatomicalOrientationValuesSchema } from "../src/schemas/rfc4.ts";
+import { ANATOMICAL_AXIS_OF } from "../src/utils/rfc4_validation.ts";
+
+const EXPECTED_COUNT = 24;
+
+Deno.test("the enum and the pair table hold the same values", () => {
+  const fromEnum = new Set<string>(Object.values(AnatomicalOrientationValues));
+  const fromTable = new Set(Object.keys(ANATOMICAL_AXIS_OF));
+  assertEquals([...fromEnum].sort(), [...fromTable].sort());
+});
+
+Deno.test("the schema accepts every value of the pair table", () => {
+  for (const value of Object.keys(ANATOMICAL_AXIS_OF)) {
+    assertEquals(
+      AnatomicalOrientationValuesSchema.safeParse(value).success,
+      true,
+      value,
+    );
+  }
+  assertEquals(
+    AnatomicalOrientationValuesSchema.safeParse("north-to-south").success,
+    false,
+  );
+});
+
+Deno.test("the vocabulary has not changed size", () => {
+  assertEquals(
+    Object.values(AnatomicalOrientationValues).length,
+    EXPECTED_COUNT,
+  );
+  assertEquals(Object.keys(ANATOMICAL_AXIS_OF).length, EXPECTED_COUNT);
+});
+
+Deno.test("every anatomical axis carries exactly two directions", () => {
+  const perAxis = new Map<string, string[]>();
+  for (const [value, axis] of Object.entries(ANATOMICAL_AXIS_OF)) {
+    perAxis.set(axis, [...(perAxis.get(axis) ?? []), value]);
+  }
+  assertEquals(perAxis.size, EXPECTED_COUNT / 2);
+  for (const [axis, values] of perAxis) {
+    assertEquals(values.length, 2, axis);
+  }
+});

--- a/ts/test/rfc4_vocabulary_test.ts
+++ b/ts/test/rfc4_vocabulary_test.ts
@@ -17,13 +17,34 @@ import { ANATOMICAL_AXIS_OF } from "../src/utils/rfc4_validation.ts";
 
 const EXPECTED_COUNT = 24;
 
+/**
+ * The schema's own list of values.
+ *
+ * The export is annotated as a `ZodType` over the value union, which hides the
+ * `options` a `z.enum` carries at runtime; reading it back is what lets the set
+ * be compared in both directions rather than only table-to-schema.
+ */
+function schemaValues(): Set<string> {
+  const { options } = AnatomicalOrientationValuesSchema as unknown as {
+    options: readonly string[];
+  };
+  return new Set(options);
+}
+
 Deno.test("the enum and the pair table hold the same values", () => {
   const fromEnum = new Set<string>(Object.values(AnatomicalOrientationValues));
   const fromTable = new Set(Object.keys(ANATOMICAL_AXIS_OF));
   assertEquals([...fromEnum].sort(), [...fromTable].sort());
 });
 
-Deno.test("the schema accepts every value of the pair table", () => {
+Deno.test("the schema holds exactly the values of the pair table", () => {
+  // Both directions: a value added to the schema alone would otherwise pass,
+  // and validateRfc4Orientation would accept it before looking it up as an
+  // undefined axis key. Mirrors the Python twin's set comparison.
+  assertEquals(
+    [...schemaValues()].sort(),
+    Object.keys(ANATOMICAL_AXIS_OF).sort(),
+  );
   for (const value of Object.keys(ANATOMICAL_AXIS_OF)) {
     assertEquals(
       AnatomicalOrientationValuesSchema.safeParse(value).success,
@@ -43,6 +64,7 @@ Deno.test("the vocabulary has not changed size", () => {
     EXPECTED_COUNT,
   );
   assertEquals(Object.keys(ANATOMICAL_AXIS_OF).length, EXPECTED_COUNT);
+  assertEquals(schemaValues().size, EXPECTED_COUNT);
 });
 
 Deno.test("every anatomical axis carries exactly two directions", () => {


### PR DESCRIPTION
The 24 anatomical orientation values were transcribed by hand four times per
language, none derived from another and none checked against another. Two of
those copies were traps rather than duplication:

- **Python.** `validate_rfc4_orientation` checked membership against its own
  24-value set, then looked the value up in `_ANATOMICAL_AXIS_OF` unguarded. A
  value in the set but not in the table would raise `KeyError` instead of a
  validation error, and the message-marker mapping in `validate_structural`
  would never see it. Membership is now checked against the table, as
  `rfc4_conformance` already did.
- **TypeScript.** `VALID_ORIENTATION_VALUES` stopped validating anything when
  the check moved to the Zod schema; it only formats the "valid values are"
  message, so it could advertise a vocabulary different from the enforced one.
  It is now derived from the pair table.

The copies that remain (the public enum, the bundled schema, the pair table)
are pinned by new mirrored tests: same 24 values, and exactly two directions
per anatomical axis.

Python: 913 passed, 3 skipped. TypeScript: 556 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RFC 4 anatomical-orientation validation by deriving accepted values from a single authoritative vocabulary.
  * Invalid orientation messages now consistently list the supported values.
  * Non-string and unhashable orientation inputs now return a clear validation error instead of causing unexpected type errors.

* **Tests**
  * Added consistency checks across public vocabulary definitions and the bundled schema.
  * Verified the expected 24 orientation values and two directions for each of 12 anatomical axes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->