### PR TITLE
docs: name to_ome_zarr and from_ome_zarr as the read/write API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ The central workflow follows this pattern across all implementations:
    metadata)
 2. **NgffImage → NgffMultiscales**: Generate multiple resolution levels via
    `to_multiscales()`
-3. **NgffMultiscales → OME-Zarr**: Write to zarr stores via `to_ngff_zarr()`
-4. **OME-Zarr → NgffMultiscales**: Read back via `from_ngff_zarr()`
+3. **NgffMultiscales → OME-Zarr**: Write to zarr stores via `to_ome_zarr()`
+4. **OME-Zarr → NgffMultiscales**: Read back via `from_ome_zarr()`
 
 ### Key Data Classes
 
@@ -289,11 +289,26 @@ these conventions to prevent reformatting churn:
 from .__about__ import __version__
 
 # Import core functions, not classes
-from ngff_zarr import from_ngff_zarr, to_ngff_zarr, to_multiscales
+from ngff_zarr import from_ome_zarr, to_ome_zarr, to_multiscales
 
 # TypeScript: Function-based exports (not classes)
-import { fromNgffZarr, toNgffZarr } from "./io/from_ngff_zarr.ts";
+import { fromOmeZarr, toOmeZarr } from "./io/from_ngff_zarr.ts";
 ```
+
+### Read/Write Function Names (CRITICAL for AI Agents)
+
+`to_ome_zarr` / `from_ome_zarr` (Python) and `toOmeZarr` / `fromOmeZarr`
+(TypeScript) are the names to use in new code, tests, docstrings, comments, and
+documentation.
+
+`to_ngff_zarr` / `from_ngff_zarr` and `toNgffZarr` / `fromNgffZarr` still exist
+and still work: they are plain aliases bound to the same objects, kept so
+existing callers keep running. They are not the names to write. New code that
+uses them gets flagged in review.
+
+The module and file names keep the historical spelling
+(`py/ngff_zarr/to_ngff_zarr.py`, `ts/src/io/from_ngff_zarr.ts`), so a path is
+not a naming violation; only the called function is.
 
 ### Configuration & Memory Management
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,8 @@ from .__about__ import __version__
 from ngff_zarr import from_ome_zarr, to_ome_zarr, to_multiscales
 
 # TypeScript: Function-based exports (not classes)
-import { fromOmeZarr, toOmeZarr } from "./io/from_ngff_zarr.ts";
+import { fromOmeZarr } from "./io/from_ngff_zarr.ts";
+import { toOmeZarr } from "./io/to_ngff_zarr.ts";
 ```
 
 ### Read/Write Function Names (CRITICAL for AI Agents)


### PR DESCRIPTION
`to_ome_zarr` / `from_ome_zarr` and `toOmeZarr` / `fromOmeZarr` are the current
names. `to_ngff_zarr` / `from_ngff_zarr` and `toNgffZarr` / `fromNgffZarr` are
aliases bound to the same objects, kept so existing callers keep running:

```python
to_ngff_zarr = to_ome_zarr        # py/ngff_zarr/to_ngff_zarr.py
from_ngff_zarr = from_ome_zarr    # py/ngff_zarr/from_ngff_zarr.py
```

```ts
export const toNgffZarr = toOmeZarr;      // ts/src/io/to_ngff_zarr.ts
export const fromNgffZarr = fromOmeZarr;  // ts/src/io/from_ngff_zarr.ts
```

AGENTS.md still showed the alias in the pipeline description and the import
example, so agents reading it wrote the alias and reviewers asked for the
change by hand (#651, #660).

This states the preference once, under Project-Specific Conventions, and
records that the module paths keep the historical spelling, so
`py/ngff_zarr/to_ngff_zarr.py` is not itself a violation.

Docs only. No code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated OME-Zarr read/write function names in Python and TypeScript documentation.
  - Clarified that historical function names remain supported as aliases for existing integrations, while recommending current names for new code.
  - Corrected the TypeScript `toOmeZarr` import example to use its dedicated module path.
  - Updated multiscale pipeline guidance to reflect current naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->