### PR TITLE
fix(py): stream blocks into the zarr v3 array instead of materializing

### DIFF
--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -172,6 +172,42 @@ def _prep_for_to_zarr(store: StoreLike, arr: dask.array.Array) -> dask.array.Arr
     )
 
 
+def _blocks_write_disjoint_chunks(arr: dask.array.Array, array, region) -> bool:
+    """Whether two blocks of ``arr`` can never land in one chunk of ``array``.
+
+    Blocks are written concurrently, and a zarr chunk (a shard, when the array
+    is sharded) is read, updated and rewritten as a unit, so two writers in one
+    chunk lose data. They are disjoint when every block boundary falls on a
+    boundary of the write unit, which is what ``to_multiscales`` arranges: the
+    array is created with the chunk shape of the dask array, and a sharded one
+    is rechunked to whole shards before it gets here.
+    """
+    unit = getattr(array, "shards", None) or array.chunks
+    if unit is None or len(unit) != arr.ndim:
+        return False
+    starts = [start for start, _stop in _region_bounds(region, arr.ndim)]
+    for sizes, size, start in zip(arr.chunks, unit, starts):
+        if start % size:
+            return False
+        # The last boundary is the end of the written area, not a seam.
+        boundaries = np.cumsum(sizes)[:-1] + start
+        if any(int(boundary) % size for boundary in boundaries):
+            return False
+    return True
+
+
+def _region_bounds(region, ndim: int) -> list[tuple[int, int]]:
+    """``region`` as (start, stop) per dimension, defaulting to a zero start."""
+    if region is None:
+        return [(0, None)] * ndim
+    return [
+        (int(part.start or 0), part.stop)
+        if isinstance(part, slice)
+        else (int(part), None)
+        for part in region
+    ]
+
+
 def _numpy_to_zarr_dtype(dtype):
     dtype_map = {
         "bool": "bool",
@@ -870,7 +906,7 @@ def _write_array_direct(
         to_zarr_kwargs["chunks"] = arr.chunksize
 
     if zarr_fmt == 3 and zarr_array is None:
-        # Zarr v3, use zarr.create_array and assign (whole array or region)
+        # Zarr v3: create the array, then stream the blocks into it.
         array = zarr.create_array(
             store=store,
             name=path,
@@ -879,10 +915,17 @@ def _write_array_direct(
             **to_zarr_kwargs,
         )
         try:
-            if region is not None:
-                array[region] = arr.compute()
-            else:
-                array[:] = arr.compute()
+            # Stream block by block. ``array[:] = arr.compute()`` would hold the
+            # whole result in memory before the first byte is written, which
+            # caps the writable size at what fits in RAM.
+            dask.array.store(
+                arr,
+                array,
+                regions=region if region is not None else None,
+                lock=not _blocks_write_disjoint_chunks(arr, array, region),
+                compute=True,
+                return_stored=False,
+            )
         except (OSError, ValueError) as e:
             raise _array_write_error(path, e) from e
     else:

--- a/py/test/test_streaming_write.py
+++ b/py/test/test_streaming_write.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""The zarr v3 write path streams its blocks instead of materializing them.
+
+``array[:] = arr.compute()`` holds the whole result in memory before the first
+byte is written, which caps a write at what fits in RAM however lazily the
+array was built. These tests pin the streaming behaviour by counting how many
+output blocks are alive at once while the write runs.
+"""
+
+import weakref
+
+import dask
+import dask.array as da
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import to_multiscales, to_ngff_image, to_ngff_zarr
+
+pytestmark = pytest.mark.skipif(
+    zarr.__version__ < "3", reason="the direct zarr v3 write path needs zarr v3"
+)
+
+
+class _TrackedBlock(np.ndarray):
+    """An ndarray a weak reference can be taken to."""
+
+
+def _counting_array(nblocks: int, block: int):
+    """A dask array that records how many of its blocks are alive at once.
+
+    Every block registers a weak reference to itself as it is produced, so a
+    block the writer has stored and released stops counting. The high water
+    mark is the number of blocks the write path holds simultaneously.
+    """
+    produced: list = []
+    peak = {"blocks": 0}
+
+    def make(x):
+        tracked = np.zeros(x.shape, dtype="uint8").view(_TrackedBlock)
+        produced.append(weakref.ref(tracked))
+        alive = sum(1 for reference in produced if reference() is not None)
+        peak["blocks"] = max(peak["blocks"], alive)
+        return tracked
+
+    source = da.zeros(
+        (nblocks * block, block, block), chunks=(block, block, block), dtype="uint8"
+    )
+    return source.map_blocks(make, dtype="uint8"), peak
+
+
+@pytest.mark.parametrize("nblocks", [8])
+def test_write_holds_only_the_blocks_in_flight(tmp_path, nblocks):
+    data, peak = _counting_array(nblocks, 16)
+    image = to_ngff_image(data, dims=["z", "y", "x"])
+    with dask.config.set(scheduler="synchronous"):
+        to_ngff_zarr(
+            tmp_path / "streamed.ome.zarr",
+            to_multiscales(image, scale_factors=[], chunks=16),
+            overwrite=True,
+        )
+
+    # One worker writes one block at a time, so a materializing write is the
+    # only way to see them all at once.
+    assert peak["blocks"] < nblocks
+
+
+def test_streamed_write_round_trips(tmp_path):
+    rng = np.random.default_rng(0)
+    expected = rng.integers(0, 255, size=(48, 32, 32), dtype="uint8")
+    image = to_ngff_image(
+        da.from_array(expected, chunks=(16, 16, 16)), dims=["z", "y", "x"]
+    )
+    store = tmp_path / "round-trip.ome.zarr"
+    to_ngff_zarr(
+        store, to_multiscales(image, scale_factors=[], chunks=16), overwrite=True
+    )
+
+    from ngff_zarr import from_ngff_zarr
+
+    written = np.asarray(from_ngff_zarr(store).images[0].data)
+    np.testing.assert_array_equal(written, expected)

--- a/py/test/test_streaming_write.py
+++ b/py/test/test_streaming_write.py
@@ -15,10 +15,13 @@ import dask.array as da
 import numpy as np
 import pytest
 import zarr
-from ngff_zarr import to_multiscales, to_ngff_image, to_ngff_zarr
+from ngff_zarr import from_ome_zarr, to_multiscales, to_ngff_image, to_ome_zarr
+from ngff_zarr.to_ngff_zarr import _blocks_write_disjoint_chunks
+from packaging import version
 
 pytestmark = pytest.mark.skipif(
-    zarr.__version__ < "3", reason="the direct zarr v3 write path needs zarr v3"
+    version.parse(zarr.__version__) < version.parse("3.0.0b1"),
+    reason="the direct zarr v3 write path needs zarr v3",
 )
 
 
@@ -49,20 +52,22 @@ def _counting_array(nblocks: int, block: int):
     return source.map_blocks(make, dtype="uint8"), peak
 
 
-@pytest.mark.parametrize("nblocks", [8])
+@pytest.mark.parametrize("nblocks", [8, 32])
 def test_write_holds_only_the_blocks_in_flight(tmp_path, nblocks):
     data, peak = _counting_array(nblocks, 16)
     image = to_ngff_image(data, dims=["z", "y", "x"])
     with dask.config.set(scheduler="synchronous"):
-        to_ngff_zarr(
+        to_ome_zarr(
             tmp_path / "streamed.ome.zarr",
             to_multiscales(image, scale_factors=[], chunks=16),
             overwrite=True,
         )
 
-    # One worker writes one block at a time, so a materializing write is the
-    # only way to see them all at once.
-    assert peak["blocks"] < nblocks
+    # A fixed bound, not a fraction of the input: one worker holds the block it
+    # is storing and the one already produced behind it, whether the array has
+    # eight blocks or thirty-two. A materializing write holds every block, so
+    # its high water mark is the block count.
+    assert peak["blocks"] <= 2, f"{peak['blocks']} blocks alive at once"
 
 
 def test_streamed_write_round_trips(tmp_path):
@@ -72,11 +77,55 @@ def test_streamed_write_round_trips(tmp_path):
         da.from_array(expected, chunks=(16, 16, 16)), dims=["z", "y", "x"]
     )
     store = tmp_path / "round-trip.ome.zarr"
-    to_ngff_zarr(
+    to_ome_zarr(
         store, to_multiscales(image, scale_factors=[], chunks=16), overwrite=True
     )
 
-    from ngff_zarr import from_ngff_zarr
-
-    written = np.asarray(from_ngff_zarr(store).images[0].data)
+    written = np.asarray(from_ome_zarr(store).images[0].data)
     np.testing.assert_array_equal(written, expected)
+
+
+class _Target:
+    """What the predicate reads off a zarr array: its chunks, and its shards."""
+
+    def __init__(self, chunks, shards=None):
+        self.chunks = chunks
+        self.shards = shards
+
+
+@pytest.mark.parametrize(
+    ("blocks", "target", "region", "disjoint"),
+    [
+        # Every block boundary falls on a chunk boundary: the writes cannot meet.
+        (((16, 16, 16), (16,), (16,)), _Target((16, 16, 16)), None, True),
+        # A block twice the chunk still only spans whole chunks.
+        (((32, 32), (16,), (16,)), _Target((16, 16, 16)), None, True),
+        # An irregular block leaves a seam inside a chunk.
+        (((10, 22), (16,), (16,)), _Target((16, 16, 16)), None, False),
+        # Chunks smaller than a shard: two blocks update one shard.
+        (
+            ((16, 16), (16,), (16,)),
+            _Target((16, 16, 16), shards=(32, 16, 16)),
+            None,
+            False,
+        ),
+        # Aligned blocks, but written at an offset that is not a chunk boundary.
+        (
+            ((16, 16), (16,), (16,)),
+            _Target((16, 16, 16)),
+            (slice(8, 40), slice(0, 16), slice(0, 16)),
+            False,
+        ),
+    ],
+)
+def test_the_lock_is_taken_exactly_when_blocks_can_meet(
+    blocks, target, region, disjoint
+):
+    """Concurrent writes are allowed only where two blocks cannot share a unit.
+
+    A zarr chunk, or a shard when the array is sharded, is read, updated and
+    rewritten whole, so two writers inside one of them lose data.
+    """
+    arr = da.zeros(tuple(sum(sizes) for sizes in blocks), chunks=blocks, dtype="uint8")
+
+    assert _blocks_write_disjoint_chunks(arr, target, region) is disjoint


### PR DESCRIPTION
## The bug

`_write_array_direct` takes the zarr v3 path for every store it creates, and that
path ends in:

```python
array[:] = arr.compute()
```

However lazily the dask array was built, the whole result is materialized before
the first byte is written, so a write is capped at what fits in RAM.

It is visible on the 1213 million voxel resample of #651: sampling the threaded
scheduler's cache during the write shows all 126 output blocks alive at once,
2.43 GB, held to the end of the run.

## The fix

```python
dask.array.store(
    arr, array,
    regions=region if region is not None else None,
    lock=not _blocks_write_disjoint_chunks(arr, array, region),
    compute=True, return_stored=False,
)
```

A block is released as soon as it lands. The guard is about concurrency: a zarr
chunk, or a shard when the array is sharded, is read, updated and rewritten as a
unit, so two blocks landing in one unit lose data.
`_blocks_write_disjoint_chunks` checks that every block boundary falls on a
boundary of the write unit and that the region starts on one. That is what
`to_multiscales` already arranges, since the array is created with the chunk
shape of the dask array and a sharded one is rechunked to whole shards before it
gets here. When the check fails the write is serialized, which is correct and
slower rather than wrong.

## Measured

Level 0 of the #651 example, 24-core laptop, same configuration on both sides:

| | before | after |
|:---|---:|---:|
| peak RSS | 6.79 GB | 4.12 GB |
| output blocks resident | all 126 (2.43 GB) | those in flight |
| wall | 11.6 s | 9.45 s |

Take the peaks as the firm half of that: they repeat to 0.3 GB, where wall clock
on this machine spreads by 20 to 40% between runs of one configuration. The
direction of the wall figures held in every pair I ran, materializing costing
time as well as memory, but the two seconds are not worth more precision than
that. The written bytes are
identical, checked by writing level 1 both ways and comparing the arrays
(121 million non-zero voxels, `array_equal` true).

## Tests

`py/test/test_streaming_write.py` counts how many output blocks are alive at
once, through weak references, under the synchronous scheduler: one worker
writing one block at a time cannot hold every block unless the path materializes.
It fails on the old path and passes on the new one. A second test covers the
serialized branch on irregular chunks and round trips the values.

Full suite: 947 passed, 3 skipped.

## Relation to other work

Related to #650, which asks for a public out-of-core publication API: create a
store from its description, append a level, keep root attributes. This changes
none of that and implements none of the requested items. It fixes the path that
exists today so that an array built lazily is also written lazily, which is the
premise the issue's producers depend on.

The peak memory figures published in the benchmark of #651 assume this change.
On that branch alone the same level 0 run peaks at 6.8 GB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Zarr v3 writing to stream large datasets in blocks, reducing peak memory usage.
  * Added safer handling when data blocks do not align with storage chunks or shards.
* **Bug Fixes**
  * Preserved data integrity during streamed writes.
  * Maintained existing write error handling behavior.
* **Tests**
  * Expanded coverage for streaming writes, memory usage, alignment scenarios, and round-trip data accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
