### PR TITLE
feat(py): out-of-core writing: metadata_only, start_level, and the writer bugs behind them

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -133,3 +133,16 @@ pip install "ngff-zarr[dask-image]"
 [scale space]: https://en.wikipedia.org/wiki/Scale_space
 [scipy]: https://scipy.org/
 [WebAssembly]: https://webassembly.org/
+
+## `DASK_BIN_SHRINK`
+
+Uses the [local mean] for the output value, computed with
+`dask.array.coarsen`. Produces the same samples as `ITKWASM_BIN_SHRINK` and
+`ITK_BIN_SHRINK`: the remainder past the last full window is dropped, and
+integer values are rounded half up.
+
+Runs on plain dask with no native or WebAssembly dependency, accepts any chunk
+layout, and has no limit on block size. Fast but generates more artifacts than
+gaussian-based methods.
+
+Appropriate for intensity images.

--- a/docs/python.md
+++ b/docs/python.md
@@ -418,6 +418,28 @@ fill the arrays; `to_ome_zarr` is not involved, and the example above uses
 zarr-python, which ngff-zarr does not depend on. Chunks that are never written
 read back as the fill value.
 
+### Append coarser levels to an existing store
+
+Once the finest level is on disk, `start_level` derives the next levels from
+it and writes them beside it. The levels below `start_level` are read, never
+rewritten; root attributes the writer does not own are kept; the multiscales
+entry is rewritten in full.
+
+```python
+base = nz.from_ome_zarr('volume.ome.zarr').images[0]
+multiscales = nz.to_multiscales(base, scale_factors=[2, 4], chunks=chunks)
+nz.to_ome_zarr('volume.ome.zarr', multiscales, version='0.5',
+                overwrite=False, start_level=1)
+```
+
+`start_level` requires `overwrite=False`, and the store must hold every level
+below it with the shape and dtype the multiscales describes. Running the same
+call again replaces the appended levels. `metadata_only=True` composes with it
+to allocate the new levels empty. The appended levels take the chunks given to
+`to_multiscales`; pass the chunks of the stored level to keep one grid. A level
+whose data the caller replaced in the multiscales is written as given, so a
+pipeline that already holds a coarse level can bring it instead of deriving it.
+
 ## TIFF and OME-TIFF Files
 
 NGFF-Zarr provides support for converting TIFF files, including multi-series

--- a/docs/python.md
+++ b/docs/python.md
@@ -464,6 +464,35 @@ to allocate the new levels empty. The appended levels take the chunks given to
 whose data the caller replaced in the multiscales is written as given, so a
 pipeline that already holds a coarse level can bring it instead of deriving it.
 
+### Read a store region by region
+
+A chunk is the unit a reader decompresses. A window that covers part of a chunk
+costs the whole chunk, and a sweep that advances in steps smaller than the chunk
+pays that for every step. On a 256 MB volume with chunks of 64 along z, reading
+the whole of it in slabs 8 deep takes about four times the chunk-aligned read,
+and in slabs 2 deep about fifteen times.
+
+The chunk grid is therefore chosen for the way the data will be read, and a
+producer that creates its store with `metadata_only=True` chooses both grids at
+once: pass `to_multiscales(chunks=...)` the shape of the regions the readers
+will ask for.
+
+For a store whose grid is already fixed, read the aligned block that contains
+the windows and slice it in memory. `open_array` reports the grid:
+
+```python
+level0 = nz.open_array('volume.ome.zarr', 'scale0/image')
+depth = level0.chunks[1]
+
+for start in range(0, level0.shape[1], depth):
+    block = level0[:, start:start + depth]        # one aligned read
+    for z in range(block.shape[1]):
+        plane = block[:, z]                       # a view, no read
+```
+
+This reaches the same speed as reading the volume in aligned blocks, whatever
+the size of the windows the loop serves.
+
 ## TIFF and OME-TIFF Files
 
 NGFF-Zarr provides support for converting TIFF files, including multi-series

--- a/docs/python.md
+++ b/docs/python.md
@@ -416,7 +416,6 @@ at once whatever the image size.
 
 ```python
 import dask.array as da
-import zarr
 
 shape = (1, 4096, 8192, 8192)
 chunks = (1, 64, 512, 512)
@@ -425,7 +424,7 @@ image = nz.to_ngff_image(placeholder, dims=['c', 'z', 'y', 'x'])
 multiscales = nz.to_multiscales(image, scale_factors=[], chunks=chunks, cache=False)
 nz.to_ome_zarr('volume.ome.zarr', multiscales, version='0.5', metadata_only=True)
 
-level0 = zarr.open_array('volume.ome.zarr', path='scale0/image', mode='r+')
+level0 = nz.open_array('volume.ome.zarr', multiscales.metadata.datasets[0].path)
 for z in range(0, shape[1], 64):
     level0[:, z:z + 64] = compute_slab(z)
 ```
@@ -438,10 +437,10 @@ no pyramid graph is built; coarser levels can be appended later with
 Choose the chunk grid from the regions the producer writes: when every region
 covers whole chunks (whole shards when `chunks_per_shard` is set), each chunk
 has exactly one writer, so no locking and no read-modify-write is needed, and
-the fill stays safe across processes and cluster ranks. Any Zarr writer can
-fill the arrays; `to_ome_zarr` is not involved, and the example above uses
-zarr-python, which ngff-zarr does not depend on. Chunks that are never written
-read back as the fill value.
+the fill stays safe across processes and cluster ranks. The handle from
+`open_array` reads and writes regions through zarrista, and any other Zarr
+writer can fill the arrays as well; `to_ome_zarr` is not involved. Chunks that
+are never written read back as the fill value.
 
 ### Append coarser levels to an existing store
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -379,6 +379,45 @@ for a chunk shape of `(64, 64, 64)`.
 Sharded stores are written through the same zarrista direct-write path as
 regular stores; no extra options are required.
 
+### Create the store before its data
+
+A producer that drives its own computation, such as an acquisition writer
+filling a volume over hours, a stitcher placing tiles as they arrive, or a GPU
+pipeline running one block at a time, can create the store first and fill it
+afterwards. With `metadata_only=True`, `to_ome_zarr` writes the OME-Zarr
+metadata and creates every scale array with its shape, dtype, chunks, shards
+and codecs, but evaluates no dask graph and writes no chunk. The call returns
+at once whatever the image size.
+
+```python
+import dask.array as da
+import zarr
+
+shape = (1, 4096, 8192, 8192)
+chunks = (1, 64, 512, 512)
+placeholder = da.zeros(shape, dtype='float32', chunks=chunks)
+image = nz.to_ngff_image(placeholder, dims=['c', 'z', 'y', 'x'])
+multiscales = nz.to_multiscales(image, scale_factors=[], chunks=chunks, cache=False)
+nz.to_ome_zarr('volume.ome.zarr', multiscales, version='0.5', metadata_only=True)
+
+level0 = zarr.open_array('volume.ome.zarr', path='scale0/image', mode='r+')
+for z in range(0, shape[1], 64):
+    level0[:, z:z + 64] = compute_slab(z)
+```
+
+Pass `cache=False` to `to_multiscales`: the placeholder has nothing worth
+caching, and the default would serialize it to disk. With `scale_factors=[]`
+no pyramid graph is built; coarser levels can be appended later with
+`start_level` (below).
+
+Choose the chunk grid from the regions the producer writes: when every region
+covers whole chunks (whole shards when `chunks_per_shard` is set), each chunk
+has exactly one writer, so no locking and no read-modify-write is needed, and
+the fill stays safe across processes and cluster ranks. Any Zarr writer can
+fill the arrays; `to_ome_zarr` is not involved, and the example above uses
+zarr-python, which ngff-zarr does not depend on. Chunks that are never written
+read back as the fill value.
+
 ## TIFF and OME-TIFF Files
 
 NGFF-Zarr provides support for converting TIFF files, including multi-series

--- a/docs/python.md
+++ b/docs/python.md
@@ -379,6 +379,31 @@ for a chunk shape of `(64, 64, 64)`.
 Sharded stores are written through the same zarrista direct-write path as
 regular stores; no extra options are required.
 
+### Root attributes
+
+Keys beside the OME metadata at the root of a store hold application
+metadata: a direction matrix, provenance, a processing log. `from_ome_zarr`
+reads them into `multiscales.root_attributes`, `to_ome_zarr` writes them back
+beside the OME keys, and an overwrite of an existing store keeps the ones
+already there. The OME keys themselves (`multiscales`, `omero`, `ome`) are
+derived from the multiscales and cannot be set this way.
+
+```python
+multiscales.root_attributes = {'acquisition': {'direction': [0, -1, 0, 1, 0, 0, 0, 0, 1]}}
+nz.to_ome_zarr('image.ome.zarr', multiscales, version='0.5')
+
+nz.from_ome_zarr('image.ome.zarr').root_attributes
+# {'acquisition': {'direction': [0, -1, 0, 1, 0, 0, 0, 0, 1]}}
+```
+
+A fact known only once the data is on disk, such as the bound of a field
+filled region by region, goes in afterwards; existing keys are replaced and
+the others kept:
+
+```python
+nz.update_root_attributes('image.ome.zarr', {'acquisition': {'max_displacement': 3.2}})
+```
+
 ### Create the store before its data
 
 A producer that drives its own computation, such as an acquisition writer

--- a/mcp/ngff_zarr_mcp/server.py
+++ b/mcp/ngff_zarr_mcp/server.py
@@ -242,6 +242,7 @@ def get_downsampling_methods() -> str:
         "dask_image_gaussian": "Gaussian smoothing with dask-image (scipy-based)",
         "dask_image_mode": "Mode-based downsampling for labels (slower, fewer artifacts)",
         "dask_image_nearest": "Nearest neighbor for labels (artifacts, fast)",
+        "dask_bin_shrink": "Local mean with dask.array.coarsen (no native or wasm dependency)",
     }
 
     for method in methods:

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -9,6 +9,7 @@ from ._supported_versions import (
     V06_ONDISK_VERSION,
     NgffVersion,
 )
+from ._zarrista_utils import open_array
 from .cli_input_to_ngff_image import cli_input_to_ngff_image
 from .codecs import codec_from_name, get_available_codecs
 from .compute_omero import (
@@ -148,6 +149,7 @@ __all__ = [
     "to_ngff_zarr",
     "ScaleStrategy",
     "from_ome_zarr",
+    "open_array",
     "from_ngff_zarr",
     "upgrade_ome_zarr",
     "detect_cli_io_backend",

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -81,7 +81,12 @@ from .tiff_to_ngff_image import (
 )
 from .to_multiscales import to_multiscales
 from .to_ngff_image import to_ngff_image
-from .to_ngff_zarr import ScaleStrategy, to_ngff_zarr, to_ome_zarr
+from .to_ngff_zarr import (
+    ScaleStrategy,
+    to_ngff_zarr,
+    to_ome_zarr,
+    update_root_attributes,
+)
 from .upgrade_ome_zarr import upgrade_ome_zarr
 from .v04.zarr_metadata import (
     AxesType,
@@ -139,6 +144,7 @@ __all__ = [
     "to_multiscales",
     "Methods",
     "to_ome_zarr",
+    "update_root_attributes",
     "to_ngff_zarr",
     "ScaleStrategy",
     "from_ome_zarr",

--- a/py/ngff_zarr/_zarrista_utils.py
+++ b/py/ngff_zarr/_zarrista_utils.py
@@ -103,13 +103,22 @@ class _ZarristaArrayAdapter:
     or non-native-byte-order write input. dask needs a tuple ``shape``, a
     numpy ``dtype``, ndarray ``__getitem__`` results, and a tolerant
     ``__setitem__`` (see :func:`_native_contiguous`).
+
+    ``store_path`` and ``node_path`` record where an array of a local store
+    lives, so the writer can tell that an image still reads from the store it
+    is about to replace. They are ``None`` for arrays without a local
+    directory.
     """
 
-    def __init__(self, arr):
+    def __init__(
+        self, arr, store_path: Path | None = None, node_path: str | None = None
+    ):
         self._arr = arr
         self.shape = tuple(arr.shape)
         self.dtype = np.dtype(arr.dtype.name)
         self.ndim = arr.ndim
+        self.store_path = store_path
+        self.node_path = node_path
 
     def _fetch(self, selection) -> np.ndarray:
         """Materialize *selection*; the async remote adapter overrides this."""
@@ -775,22 +784,30 @@ def is_zarrista_array(obj) -> bool:
     return isinstance(obj, Array)
 
 
-def zarrista_array_to_dask(arr) -> dask.array.Array:
+def zarrista_array_to_dask(
+    arr, store_path: Path | None = None, node_path: str | None = None
+) -> dask.array.Array:
     """Wrap zarrista ``Array`` *arr* as a lazy dask array.
 
     Chunks follow the stored chunk grid, using the subchunk (inner chunk)
     shape for sharded arrays so reads stay at the efficient granularity.
+    *store_path* and *node_path* name the array's place in a local store
+    (see :class:`_ZarristaArrayAdapter`).
     """
     if arr.is_sharded:
         chunks = tuple(arr.subchunk_shape)
     else:
         chunks = tuple(arr.chunk_shape([0] * arr.ndim))
-    return dask.array.from_array(_ZarristaArrayAdapter(arr), chunks=chunks)
+    return dask.array.from_array(
+        _ZarristaArrayAdapter(arr, store_path, node_path), chunks=chunks
+    )
 
 
 def open_zarrista_lazy(path, component: str | None = None) -> dask.array.Array:
     """Open the array at *component* within *path* as a lazy dask array."""
-    return zarrista_array_to_dask(open_zarrista_array(path, component))
+    path = normalize_store(path)
+    node_path = str(component).strip("/") if component else ""
+    return zarrista_array_to_dask(open_zarrista_array(path, component), path, node_path)
 
 
 def open_ozx_store(path):

--- a/py/ngff_zarr/_zarrista_utils.py
+++ b/py/ngff_zarr/_zarrista_utils.py
@@ -55,6 +55,7 @@ __all__ = [
     "has_consolidated_metadata",
     "is_zarrista_array",
     "normalize_store",
+    "open_array",
     "open_lazy_array",
     "open_local_node",
     "open_ozx_store",
@@ -99,6 +100,37 @@ def _native_contiguous(value) -> np.ndarray:
     return value
 
 
+def _normalize_selection(shape, selection) -> tuple[tuple[slice, ...], list[int]]:
+    """``selection`` as one slice per axis, and the axes an integer index drops.
+
+    An ellipsis and missing trailing axes expand to full slices. An integer
+    becomes the length-1 slice zarrista reads it as, and its axis is reported
+    so numpy semantics, where the axis is dropped, can be restored.
+    """
+    if not isinstance(selection, tuple):
+        selection = (selection,)
+    ndim = len(shape)
+    if Ellipsis in selection:
+        explicit = [index for index in selection if index is not Ellipsis]
+        fill = (slice(None),) * (ndim - len(explicit))
+        at = selection.index(Ellipsis)
+        selection = selection[:at] + fill + selection[at + 1 :]
+        selection = tuple(index for index in selection if index is not Ellipsis)
+    selection = selection + (slice(None),) * (ndim - len(selection))
+    normalized = []
+    dropped = []
+    for axis, index in enumerate(selection):
+        if isinstance(index, (int, np.integer)):
+            index = int(index)
+            if index < 0:
+                index += shape[axis]
+            normalized.append(slice(index, index + 1))
+            dropped.append(axis)
+        else:
+            normalized.append(index)
+    return tuple(normalized), dropped
+
+
 class _ZarristaArrayAdapter:
     """Minimal numpy-protocol surface over a zarrista ``Array`` for dask.
 
@@ -132,26 +164,8 @@ class _ZarristaArrayAdapter:
         # zarrista treats an integer index like a length-1 slice, keeping the
         # axis; dask's fused getters rely on numpy semantics where integer
         # indices drop it. Normalize integers to slices and squeeze after.
-        if not isinstance(selection, tuple):
-            selection = (selection,)
-        if Ellipsis in selection:
-            explicit = [index for index in selection if index is not Ellipsis]
-            fill = (slice(None),) * (self.ndim - len(explicit))
-            at = selection.index(Ellipsis)
-            selection = selection[:at] + fill + selection[at + 1 :]
-            selection = tuple(index for index in selection if index is not Ellipsis)
-        drop_axes = []
-        normalized = []
-        for axis, index in enumerate(selection):
-            if isinstance(index, (int, np.integer)):
-                index = int(index)
-                if index < 0:
-                    index += self.shape[axis]
-                normalized.append(slice(index, index + 1))
-                drop_axes.append(axis)
-            else:
-                normalized.append(index)
-        result = self._fetch(tuple(normalized))
+        normalized, drop_axes = _normalize_selection(self.shape, selection)
+        result = self._fetch(normalized)
         if drop_axes:
             result = np.squeeze(result, axis=tuple(drop_axes))
         return result
@@ -926,10 +940,13 @@ def _local_node_attrs(dirpath: Path, doc: dict, zarr_format: int) -> AttrsDict:
 
 
 class LocalZarrArray:
-    """Read-only handle for an array node within a local directory store.
+    """Handle for an array node within a local directory store.
 
-    Exposes ``shape``/``attrs`` for node inspection and :meth:`to_dask` for
-    lazy pixel access through zarrista.
+    Exposes the node's ``shape``, ``dtype``, ``chunks`` and ``attrs``, numpy
+    style ``[]`` reads and writes through zarrista, and :meth:`to_dask` for
+    lazy pixel access. A write lands on the stored chunks it covers, so a
+    producer filling a store created with ``metadata_only=True`` needs no
+    lock while its regions follow the chunk grid.
     """
 
     def __init__(self, store_root: Path, path: str, zarr_format: int, doc: dict):
@@ -940,6 +957,43 @@ class LocalZarrArray:
         self.ndim = len(self.shape)
         dirpath = store_root.joinpath(*path.split("/")) if path else store_root
         self.attrs = _local_node_attrs(dirpath, doc, zarr_format)
+        self._adapter: _ZarristaArrayAdapter | None = None
+
+    def _array(self) -> _ZarristaArrayAdapter:
+        if self._adapter is None:
+            arr = open_zarrista_array(self._store_root, self.path or None)
+            self._adapter = _ZarristaArrayAdapter(arr, self._store_root, self.path)
+        return self._adapter
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._array().dtype
+
+    @property
+    def chunks(self) -> tuple[int, ...]:
+        """The stored chunk grid, the inner chunk shape of a sharded array."""
+        arr = self._array()._arr
+        if arr.is_sharded:
+            return tuple(int(c) for c in arr.subchunk_shape)
+        return tuple(int(c) for c in arr.chunk_shape([0] * arr.ndim))
+
+    def __getitem__(self, selection) -> np.ndarray:
+        return self._array()[selection]
+
+    def __setitem__(self, selection, value) -> None:
+        normalized, dropped = _normalize_selection(self.shape, selection)
+        region = tuple(
+            len(range(*index.indices(size)))
+            for index, size in zip(normalized, self.shape)
+        )
+        # numpy semantics for the value: an integer index drops its axis, a
+        # scalar or a smaller array broadcasts over the region.
+        numpy_shape = tuple(
+            size for axis, size in enumerate(region) if axis not in dropped
+        )
+        value = np.asarray(value).astype(self.dtype, copy=False)
+        value = np.broadcast_to(value, numpy_shape).reshape(region)
+        self._array()[normalized] = value
 
     def to_dask(self) -> dask.array.Array:
         return open_zarrista_lazy(self._store_root, self.path or None)
@@ -1014,6 +1068,26 @@ def open_local_node(store, node_path=None, *, zarr_format: int):
     if node_type == "array":
         return LocalZarrArray(root, path, zarr_format, doc)
     return LocalZarrGroup(root, path, zarr_format, doc)
+
+
+def open_array(store, path: str | None = None) -> LocalZarrArray:
+    """Open the array at ``path`` within the local directory store ``store``.
+
+    The handle reads and writes regions through zarrista and needs no other
+    Zarr library: ``to_ome_zarr(..., metadata_only=True)`` creates the arrays
+    of a store, and this opens one of them for a producer to fill. The node
+    is looked up as zarr format 3 first, then format 2.
+    """
+    for zarr_format in (3, 2):
+        node = open_local_node(store, path, zarr_format=zarr_format)
+        if node is None:
+            continue
+        if isinstance(node, LocalZarrArray):
+            return node
+        raise ValueError(
+            f"'{path}' in '{normalize_store(store)}' is a group, not an array."
+        )
+    raise FileNotFoundError(f"No array at '{path}' in '{normalize_store(store)}'.")
 
 
 def consolidate_metadata(path, zarr_format: int) -> None:

--- a/py/ngff_zarr/_zarrista_utils.py
+++ b/py/ngff_zarr/_zarrista_utils.py
@@ -47,6 +47,7 @@ from .rfc9_zip import ZipReadStore, is_ozx_path
 __all__ = [
     "LocalZarrArray",
     "LocalZarrGroup",
+    "OME_ROOT_KEYS",
     "consolidate_metadata",
     "create_zarrista_array",
     "create_zarrista_group",
@@ -68,6 +69,9 @@ __all__ = [
 
 _BLOSC_SHUFFLE_TO_INT = {"noshuffle": 0, "shuffle": 1, "bitshuffle": 2}
 _BLOSC_SHUFFLE_TO_STR = {v: k for k, v in _BLOSC_SHUFFLE_TO_INT.items()}
+
+#: Root attribute keys the OME-Zarr writer owns, across every version.
+OME_ROOT_KEYS = frozenset({"multiscales", "omero", "ome"})
 
 
 def _native_contiguous(value) -> np.ndarray:

--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -11,6 +11,7 @@ from ._remote_reader import (
 )
 from ._store_types import StoreLike
 from ._zarrista_utils import (
+    OME_ROOT_KEYS,
     _is_bytes_mapping,
     _is_local_path,
     open_local_node,
@@ -436,7 +437,12 @@ def from_ome_zarr(
     metadata_obj.type = method_type
     metadata_obj.metadata = method_metadata
 
-    return NgffMultiscales(images, metadata_obj, method=method)
+    root_attributes = {
+        key: value for key, value in root_attrs.items() if key not in OME_ROOT_KEYS
+    }
+    return NgffMultiscales(
+        images, metadata_obj, method=method, root_attributes=root_attributes or None
+    )
 
 
 #: Backwards-compatible alias for :func:`from_ome_zarr`.

--- a/py/ngff_zarr/methods/__init__.py
+++ b/py/ngff_zarr/methods/__init__.py
@@ -58,6 +58,11 @@ class Methods(Enum):
     """Nearest neighbor for label images. Will have many artifacts for
     high-frequency content and/or multiple scales."""
 
+    DASK_BIN_SHRINK = "dask_bin_shrink"
+    """Uses the local mean for the output value, computed with dask.array.coarsen.
+    Same samples as the ITK bin-shrink methods, no native or WebAssembly
+    dependency and no limit on block size. Appropriate for intensity images."""
+
 
 # Backwards-compatible (name, value) pairs and value strings, derived from the
 # Methods enum. ``methods_values`` is used for CLI ``--method`` argument choices.

--- a/py/ngff_zarr/methods/_dask.py
+++ b/py/ngff_zarr/methods/_dask.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import math
+
+import dask.array
+import numpy as np
+
+from ..ngff_image import NgffImage
+from ._support import (
+    _dim_scale_factors,
+    _next_scale_metadata,
+    _spatial_dims,
+    _update_previous_dim_factors,
+)
+
+
+def _bin_shrink(data: dask.array.Array, axes: dict[int, int]) -> dask.array.Array:
+    """Local mean over ``axes`` windows, remainder trimmed, integers rounded half up.
+
+    The mean accumulates in float64, which is exact for integers of up to 32
+    bits; 64-bit integers take the integer path. Rounding half up on integer
+    input gives the same samples as ITK's BinShrinkImageFilter.
+    """
+    if all(factor == 1 for factor in axes.values()):
+        return data
+    if np.issubdtype(data.dtype, np.integer) and data.dtype.itemsize == 8:
+        return _bin_shrink_wide_integers(data, axes)
+    mean = dask.array.coarsen(np.mean, data.astype(np.float64), axes, trim_excess=True)
+    if np.issubdtype(data.dtype, np.integer):
+        return dask.array.floor(mean + 0.5).astype(data.dtype)
+    return mean.astype(data.dtype)
+
+
+def _bin_shrink_wide_integers(
+    data: dask.array.Array, axes: dict[int, int]
+) -> dask.array.Array:
+    """Half-up window mean of 64-bit integers in integer arithmetic.
+
+    float64 carries 53 bits, so a 64-bit sample converted to it can lose low
+    bits. Each sample is split by the window size into a quotient and a
+    remainder; the quotient sum stays within the dtype and the remainder sum
+    is small, so the mean is exact.
+    """
+    # Scalars carry the array dtype: a uint64 array combined with an int64
+    # scalar is promoted to float64.
+    count = data.dtype.type(math.prod(axes.values()))
+    two = data.dtype.type(2)
+    quotient = dask.array.coarsen(np.sum, data // count, axes, trim_excess=True)
+    remainder = dask.array.coarsen(np.sum, data % count, axes, trim_excess=True)
+    rounded = (two * remainder + count) // (two * count)
+    return (quotient + rounded).astype(data.dtype)
+
+
+def _reaches_target(ngff_image, previous_image, scale_factor, dim_factors) -> bool:
+    """Whether shrinking ``previous_image`` by ``dim_factors`` hits the level size."""
+    for dim, factor in dim_factors.items():
+        if dim not in _spatial_dims:
+            continue
+        original_size = ngff_image.data.shape[ngff_image.dims.index(dim)]
+        absolute = (
+            scale_factor.get(dim, 1) if isinstance(scale_factor, dict) else scale_factor
+        )
+        target_size = int(original_size / absolute)
+        previous_size = previous_image.data.shape[previous_image.dims.index(dim)]
+        if int(previous_size / factor) != target_size:
+            return False
+    return True
+
+
+def _downsample_dask_bin_shrink(
+    ngff_image: NgffImage, default_chunks, out_chunks, scale_factors
+):
+    multiscales = [ngff_image]
+    dims = tuple(ngff_image.dims)
+    spatial_dims = tuple(dim for dim in dims if dim in _spatial_dims)
+    previous_image = ngff_image
+    previous_dim_factors = dict.fromkeys(dims, 1)
+
+    for scale_factor in scale_factors:
+        dim_factors = _dim_scale_factors(
+            dims,
+            scale_factor,
+            previous_dim_factors,
+            original_image=ngff_image,
+            previous_image=previous_image,
+        )
+        source_image = previous_image
+        if not _reaches_target(ngff_image, previous_image, scale_factor, dim_factors):
+            dim_factors = _dim_scale_factors(dims, scale_factor, dict.fromkeys(dims, 1))
+            source_image = ngff_image
+
+        axes = {
+            index: dim_factors.get(dim, 1) if dim in _spatial_dims else 1
+            for index, dim in enumerate(dims)
+        }
+        data = _bin_shrink(source_image.data, axes)
+        data = data.rechunk(tuple(out_chunks.get(dim, 1) for dim in dims))
+
+        translation, scale = _next_scale_metadata(
+            source_image, dim_factors, spatial_dims
+        )
+        current_image = NgffImage(data, dims, scale, translation)
+        multiscales.append(current_image)
+
+        previous_image = current_image
+        previous_dim_factors = _update_previous_dim_factors(
+            scale_factor, spatial_dims, previous_dim_factors
+        )
+
+    return multiscales

--- a/py/ngff_zarr/methods/_itkwasm.py
+++ b/py/ngff_zarr/methods/_itkwasm.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
+import copy
 from itertools import product
 
 import dask.array
@@ -26,6 +27,83 @@ _image_dims: tuple[str, str, str, str] = ("x", "y", "z", "t")
 # Images with more components will iterate over channels individually to avoid
 # itkwasm limitations with VariableLengthVector images.
 _MAX_VECTOR_COMPONENTS = 8
+
+
+#: Largest block, in bytes, each itkwasm-downsample filter can process before
+#: the wasm32 heap is exhausted. Measured on float32 blocks: the Gaussian
+#: filter aborts at 1.5 GiB and BinShrink at 2.0 GiB.
+_WASM_BLOCK_LIMITS = {
+    "gaussian": int(1.25 * 1024**3),
+    "label_image": int(1.25 * 1024**3),
+    "bin_shrink": int(1.75 * 1024**3),
+}
+
+
+def _check_wasm_block_size(
+    image: NgffImage, is_vector: bool, smoothing: str, kernel_radius=None
+) -> None:
+    """Raise before building a graph whose blocks the wasm sandbox cannot hold.
+
+    A block handed to itkwasm spans the spatial chunk, the channel chunk when
+    channels travel as vector components, and the overlap the Gaussian filter
+    reads past the chunk. Chunks smaller than that overlap are merged by
+    map_overlap before the filter runs, so the merged chunks are what count.
+    Integer input to the Gaussian filter is converted to float32 first, which
+    is the size that counts.
+    """
+    from dask.array.overlap import ensure_minimum_chunksize
+
+    numel = 1
+    shape = []
+    depth = 0 if kernel_radius is None else int(max(kernel_radius))
+    for dim, axis_chunks in zip(image.dims, image.data.chunks):
+        if dim in _spatial_dims:
+            if depth:
+                axis_chunks = ensure_minimum_chunksize(depth, axis_chunks)
+            extent = max(axis_chunks) + 2 * depth
+        elif dim == "c" and is_vector:
+            extent = max(axis_chunks)
+        else:
+            continue
+        shape.append(extent)
+        numel *= extent
+    dtype = image.data.dtype
+    if smoothing == "gaussian" and np.issubdtype(dtype, np.integer):
+        itemsize = 4
+    else:
+        itemsize = np.dtype(dtype).itemsize
+    nbytes = numel * itemsize
+    limit = _WASM_BLOCK_LIMITS[smoothing]
+    if nbytes > limit:
+        raise ValueError(
+            f"itkwasm {smoothing} downsampling needs {nbytes / 1024**3:.2f} GiB "
+            f"for one block of shape {tuple(shape)} ({dtype}), above the "
+            f"{limit / 1024**3:.2f} GiB the wasm sandbox can hold. Use smaller "
+            "chunks (to_multiscales(chunks=...)), or a method without this "
+            "limit: Methods.DASK_BIN_SHRINK, Methods.DASK_IMAGE_GAUSSIAN, "
+            "Methods.ITK_GAUSSIAN or Methods.ITK_BIN_SHRINK."
+        )
+
+
+def _trim_to_shrink_multiple(image: NgffImage, dim_factors: dict) -> NgffImage:
+    """Drop the voxels past the last full shrink window on each spatial axis.
+
+    BinShrink produces floor(n / factor) samples along an axis; the remainder
+    never contributes to the output, and a block made only of that remainder
+    shrinks to zero voxels, which aborts the wasm sandbox.
+    """
+    slices = []
+    trimmed = False
+    for dim, size in zip(image.dims, image.data.shape):
+        factor = dim_factors.get(dim, 1) if dim in _spatial_dims else 1
+        keep = (size // factor) * factor if factor > 1 else size
+        slices.append(slice(0, keep))
+        trimmed = trimmed or keep != size
+    if not trimmed:
+        return image
+    result = copy.copy(image)
+    result.data = image.data[tuple(slices)]
+    return result
 
 
 def _itkwasm_blur_and_downsample(
@@ -225,6 +303,9 @@ def _downsample_itkwasm(
         # but is_vector is False (many channels).  In that case itkwasm
         # needs each channel processed individually, so we fall through to
         # the standard path which iterates over non-spatial dims.
+        if smoothing == "bin_shrink":
+            source_image = _trim_to_shrink_multiple(source_image, dim_factors)
+
         _fp_source = _spatial_dims_last_zyx(source_image)
         _fp_c_is_last = _fp_source.dims[-1] == "c"
         if _fp_c_is_last:
@@ -257,6 +338,7 @@ def _downsample_itkwasm(
             is_vector = _fp_is_vector if c_is_last else False
 
             dtype = current_image.data.dtype
+            _check_wasm_block_size(current_image, is_vector, smoothing)
 
             # Build output chunks: input_chunk // factor for spatial dims,
             # unchanged for non-spatial dims.
@@ -354,6 +436,12 @@ def _downsample_itkwasm(
         kernel_radius = gaussian_kernel_radius(size=block_0_size, sigma=sigma_values)
 
         dtype = block_0_input.dtype
+        _check_wasm_block_size(
+            current_image,
+            is_vector,
+            smoothing,
+            kernel_radius if smoothing != "bin_shrink" else None,
+        )
 
         output_chunks = list(current_image.data.chunks)
         output_chunks_start = 0

--- a/py/ngff_zarr/methods/_metadata.py
+++ b/py/ngff_zarr/methods/_metadata.py
@@ -89,4 +89,9 @@ _METHOD_INFO: dict[str, dict[str, str]] = {
         "package": "dask-image",
         "method": "dask_image.ndinterp.affine_transform",
     },
+    "DASK_BIN_SHRINK": {
+        "description": "Uses the local mean for the output value, computed with dask.array.coarsen. Same samples as the ITK bin-shrink methods, without a native or WebAssembly dependency. Appropriate for intensity images.",
+        "package": "dask",
+        "method": "dask.array.coarsen",
+    },
 }

--- a/py/ngff_zarr/multiscales.py
+++ b/py/ngff_zarr/multiscales.py
@@ -37,6 +37,14 @@ class NgffMultiscales:
     the level still carries the key recorded here; a level whose data has been
     replaced is written as given.
     """
+    root_attributes: dict[str, Any] | None = None
+    """Root attributes beside the OME metadata of the store.
+
+    :func:`from_ome_zarr` fills them with every root key the OME-Zarr writer
+    does not own, and :func:`to_ome_zarr` writes them back beside the OME
+    keys, so application metadata such as provenance follows the image
+    through a round trip.
+    """
 
     def to_ome_zarr(self, store: StoreLike, **kwargs: Any) -> None:
         """Write this multiscale image to an OME-Zarr store.

--- a/py/ngff_zarr/multiscales.py
+++ b/py/ngff_zarr/multiscales.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from ._store_types import StoreLike
@@ -28,6 +28,15 @@ class NgffMultiscales:
         | Mapping[Any, None | int | tuple[int, ...]]
         | None
     ) = None
+    generated_data_keys: list[str] | None = field(
+        default=None, repr=False, compare=False
+    )
+    """Dask graph key of each level as :func:`to_multiscales` produced it.
+
+    The writer re-derives a level from the level written before it only while
+    the level still carries the key recorded here; a level whose data has been
+    replaced is written as given.
+    """
 
     def to_ome_zarr(self, store: StoreLike, **kwargs: Any) -> None:
         """Write this multiscale image to an OME-Zarr store.

--- a/py/ngff_zarr/ngff_image.py
+++ b/py/ngff_zarr/ngff_image.py
@@ -24,3 +24,27 @@ class NgffImage:
     channel_names: list[str] | None = None
     channel_colors: list[str] | None = None
     computed_callbacks: list[ComputedCallback] = field(default_factory=list)
+
+
+#: The axis type to_multiscales gives a dimension when the image carries none.
+_DEFAULT_AXIS_TYPES = {
+    "x": "space",
+    "y": "space",
+    "z": "space",
+    "c": "channel",
+    "t": "time",
+}
+
+
+def non_default_axes_types(axes) -> dict[str, str] | None:
+    """Axis types that a multiscales rebuilt from the dims alone would lose.
+
+    Readers pass these on as ``NgffImage.axes_types`` so a displacement or
+    coordinate field stays typed through to_multiscales and a later write.
+    """
+    types = {
+        axis.name: axis.type
+        for axis in axes
+        if axis.type is not None and axis.type != _DEFAULT_AXIS_TYPES.get(axis.name)
+    }
+    return types or None

--- a/py/ngff_zarr/to_multiscales.py
+++ b/py/ngff_zarr/to_multiscales.py
@@ -25,6 +25,7 @@ from ._zarrista_utils import (
 from .config import config
 from .memory_usage import memory_usage
 from .methods import Methods
+from .methods._dask import _downsample_dask_bin_shrink
 from .methods._dask_image import _downsample_dask_image
 from .methods._itk import (
     _downsample_itk_bin_shrink,
@@ -611,6 +612,10 @@ def to_multiscales(
     elif method is Methods.DASK_IMAGE_MODE:
         images = _downsample_dask_image(
             ngff_image, default_chunks, out_chunks, scale_factors, label="mode"
+        )
+    elif method is Methods.DASK_BIN_SHRINK:
+        images = _downsample_dask_bin_shrink(
+            ngff_image, default_chunks, out_chunks, scale_factors
         )
 
     # Propagate channel_names and channel_colors from the input image to

--- a/py/ngff_zarr/to_multiscales.py
+++ b/py/ngff_zarr/to_multiscales.py
@@ -717,4 +717,11 @@ def to_multiscales(
         metadata=method_metadata,
     )
 
-    return NgffMultiscales(images, metadata, scale_factors, method, out_chunks)
+    return NgffMultiscales(
+        images,
+        metadata,
+        scale_factors,
+        method,
+        out_chunks,
+        generated_data_keys=[image.data.name for image in images],
+    )

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -5,6 +5,7 @@ import json
 import shutil
 import tempfile
 import warnings
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal
@@ -16,6 +17,7 @@ from itkwasm import array_like_to_numpy_array
 from ._store_types import StoreLike
 from ._supported_versions import V06_ONDISK_VERSION, NgffVersion
 from ._zarrista_utils import (
+    OME_ROOT_KEYS,
     _ZarristaArrayAdapter,
     create_zarrista_group,
     create_zarrista_subgroup,
@@ -613,8 +615,41 @@ def _root_ome_attrs(metadata_dict: dict, version: str) -> dict:
     return attrs
 
 
-#: Root attributes the writer owns, across every OME-Zarr version.
-_OME_ROOT_ATTRS = frozenset({"multiscales", "omero", "ome"})
+def _check_root_attributes(attributes: Mapping[str, Any] | None) -> dict:
+    """The root attributes a caller writes beside the OME metadata."""
+    if not attributes:
+        return {}
+    owned = sorted(OME_ROOT_KEYS.intersection(attributes))
+    if owned:
+        raise ValueError(
+            f"root_attributes cannot set {owned}: the writer derives the OME "
+            "metadata from the multiscales."
+        )
+    return dict(attributes)
+
+
+def update_root_attributes(store: StoreLike, attributes: Mapping[str, Any]) -> None:
+    """Merge ``attributes`` into the root attributes of an existing OME-Zarr store.
+
+    Keys beside the OME metadata hold application metadata, such as a fact
+    only known once the last region of a store created with
+    ``metadata_only=True`` has been written. Existing keys are replaced and
+    the others kept; the OME keys cannot be set this way. Consolidated
+    metadata is refreshed when the store carries it.
+    """
+    attributes = _check_root_attributes(attributes)
+    if not attributes:
+        return
+    store_path = normalize_store(store)
+    for zarr_format in (3, 2):
+        if read_group_attributes(store_path, zarr_format=zarr_format) is not None:
+            break
+    else:
+        raise ValueError(f"No OME-Zarr root group at '{store_path}'.")
+    consolidated = has_consolidated_metadata(store_path, zarr_format)
+    create_zarrista_group(store_path, attributes, zarr_format)
+    if consolidated:
+        _zarrista_consolidate_metadata(store_path, zarr_format)
 
 
 def _foreign_root_attrs(store: StoreLike) -> dict:
@@ -638,7 +673,7 @@ def _foreign_root_attrs(store: StoreLike) -> dict:
             return {
                 key: value
                 for key, value in attributes.items()
-                if key not in _OME_ROOT_ATTRS
+                if key not in OME_ROOT_KEYS
             }
     return {}
 
@@ -648,15 +683,19 @@ def _create_zarr_root(
     version: str,
     overwrite: bool,
     metadata_dict: dict,
+    root_attributes: dict | None = None,
 ):
     """Create and configure the root Zarr group with proper attributes.
 
     The group metadata is written through the zarrista compatibility layer
     and the returned handle is a ``zarrista.Group``. An overwrite keeps the
-    root attributes the writer does not own.
+    root attributes the writer does not own; ``root_attributes`` are written
+    over them, and the OME keys over both.
     """
     zarr_format = 2 if version == "0.4" else 3
     attributes = _foreign_root_attrs(store) if overwrite else {}
+    if root_attributes:
+        attributes.update(root_attributes)
     attributes.update(_root_ome_attrs(metadata_dict, version))
     return create_zarrista_group(store, attributes, zarr_format, overwrite=overwrite)
 
@@ -1325,6 +1364,7 @@ def to_ome_zarr(
     :type  store: StoreLike
 
     :param multiscales: NgffMultiscales OME-NGFF image pixel data and metadata. Can be generated with ngff_zarr.to_multiscales.
+        Its ``root_attributes`` are written beside the OME metadata at the root of the store.
     :type  multiscales: NgffMultiscales
 
     :param version: OME-Zarr specification version. For .ozx files, version 0.5 is required.
@@ -1514,6 +1554,7 @@ def _to_ngff_zarr_impl(
         )
     if overwrite:
         _guard_overwrite_of_source_store(multiscales, store_path)
+    root_attributes = _check_root_attributes(multiscales.root_attributes)
     metadata, dimension_names, _ = _prepare_metadata(multiscales, version)
     _gate_top_level_transforms(metadata, version)
     if start_level:
@@ -1533,11 +1574,11 @@ def _to_ngff_zarr_impl(
     if start_level:
         kept = copy.deepcopy(metadata_dict)
         kept["datasets"] = kept["datasets"][:start_level]
-        _create_zarr_root(store, version, overwrite, kept)
+        _create_zarr_root(store, version, overwrite, kept, root_attributes)
         if has_consolidated_metadata(store, zarr_format):
             _zarrista_consolidate_metadata(store, zarr_format)
     else:
-        _create_zarr_root(store, version, overwrite, metadata_dict)
+        _create_zarr_root(store, version, overwrite, metadata_dict, root_attributes)
 
     if version == "0.4" and kwargs.get("compressors") is not None:
         raise ValueError(
@@ -1710,7 +1751,7 @@ def _to_ngff_zarr_impl(
         )
 
     if start_level:
-        _create_zarr_root(store, version, False, metadata_dict)
+        _create_zarr_root(store, version, False, metadata_dict, root_attributes)
 
     # Clean up callbacks
     for image in multiscales.images:

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
 import copy
+import json
 import shutil
 import tempfile
 import warnings
@@ -20,6 +21,7 @@ from ._zarrista_utils import (
     create_zarrista_subgroup,
     normalize_store,
     open_lazy_array,
+    read_group_attributes,
 )
 from ._zarrista_utils import (
     consolidate_metadata as _zarrista_consolidate_metadata,
@@ -508,6 +510,36 @@ def _root_ome_attrs(metadata_dict: dict, version: str) -> dict:
     return attrs
 
 
+#: Root attributes the writer owns, across every OME-Zarr version.
+_OME_ROOT_ATTRS = frozenset({"multiscales", "omero", "ome"})
+
+
+def _foreign_root_attrs(store: StoreLike) -> dict:
+    """Root attributes of an existing store that the writer does not own.
+
+    Application metadata such as direction cosines or provenance lives beside
+    the OME keys and survives an overwrite; the OME keys of every version are
+    excluded so a version change never leaves a stale entry behind. An absent
+    store or root group has nothing to preserve, and a root that holds an
+    array carries no group attributes. Any other failure to read the root
+    propagates, so an unreadable store is never cleared.
+    """
+    for zarr_format in (3, 2):
+        try:
+            attributes = read_group_attributes(store, zarr_format=zarr_format)
+        except json.JSONDecodeError:
+            raise
+        except ValueError:
+            return {}
+        if attributes is not None:
+            return {
+                key: value
+                for key, value in attributes.items()
+                if key not in _OME_ROOT_ATTRS
+            }
+    return {}
+
+
 def _create_zarr_root(
     store: StoreLike,
     version: str,
@@ -517,15 +549,13 @@ def _create_zarr_root(
     """Create and configure the root Zarr group with proper attributes.
 
     The group metadata is written through the zarrista compatibility layer
-    and the returned handle is a ``zarrista.Group``.
+    and the returned handle is a ``zarrista.Group``. An overwrite keeps the
+    root attributes the writer does not own.
     """
     zarr_format = 2 if version == "0.4" else 3
-    return create_zarrista_group(
-        store,
-        _root_ome_attrs(metadata_dict, version),
-        zarr_format,
-        overwrite=overwrite,
-    )
+    attributes = _foreign_root_attrs(store) if overwrite else {}
+    attributes.update(_root_ome_attrs(metadata_dict, version))
+    return create_zarrista_group(store, attributes, zarr_format, overwrite=overwrite)
 
 
 def _configure_sharding(

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -1572,10 +1572,13 @@ def _to_ngff_zarr_impl(
     # Appending names only the levels it keeps until the new arrays are in
     # place, so an interrupted call leaves a store that reads as those levels.
     if start_level:
+        # Read before the rewrite: at zarr format 3 _create_zarr_root writes a
+        # fresh zarr.json without consolidated_metadata.
+        was_consolidated = has_consolidated_metadata(store, zarr_format)
         kept = copy.deepcopy(metadata_dict)
         kept["datasets"] = kept["datasets"][:start_level]
         _create_zarr_root(store, version, overwrite, kept, root_attributes)
-        if has_consolidated_metadata(store, zarr_format):
+        if was_consolidated:
             _zarrista_consolidate_metadata(store, zarr_format)
     else:
         _create_zarr_root(store, version, overwrite, metadata_dict, root_attributes)
@@ -1721,15 +1724,32 @@ def _to_ngff_zarr_impl(
                     f"[green]Writing scale {index + 1} of {nscales}"
                 )
 
-            # For small arrays, write in one go
+            # For small arrays, write in one go, clamping a shard wider than
+            # the array as the other two paths do. Only the sharding case goes
+            # through the resolver: its other branch re-derives chunks from the
+            # leading dask chunk, partial after a slice (issue #488).
+            small_chunks, small_shards, small_internal_chunk_shape = (
+                chunks,
+                shards,
+                internal_chunk_shape,
+            )
+            if sharding_kwargs and "_shard_shape" in sharding_kwargs:
+                (
+                    _,
+                    small_chunks,
+                    small_shards,
+                    small_internal_chunk_shape,
+                ) = _resolve_scale_chunks(
+                    arr, chunks, sharding_kwargs, internal_chunk_shape, shards
+                )
             region = tuple([slice(arr.shape[i]) for i in range(arr.ndim)])
             _write_array_with_zarrista(
                 store_path,
                 path,
                 arr,
-                chunks,
-                shards,
-                internal_chunk_shape,
+                small_chunks,
+                small_shards,
+                small_internal_chunk_shape,
                 zarr_format,
                 dimension_names,
                 region,

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -976,6 +976,15 @@ def _compute_plane_regions(
     return plane_regions
 
 
+def _is_generated_level(multiscales: NgffMultiscales, index: int) -> bool:
+    """Whether level ``index`` still carries the data to_multiscales gave it."""
+    keys = multiscales.generated_data_keys
+    if keys is None or index >= len(keys):
+        return False
+    data = multiscales.images[index].data
+    return getattr(data, "name", None) == keys[index]
+
+
 def _prepare_next_scale(
     image,
     index: int,
@@ -1000,8 +1009,15 @@ def _prepare_next_scale(
     # No next scale if we're at the last one
     if index >= nscales - 1:
         return None
-    # Minimize task graph depth
-    if multiscales.scale_factors and multiscales.method and multiscales.chunks:
+    # Re-deriving the next level from the level just written keeps the task
+    # graph shallow. Only a level still holding the data to_multiscales
+    # generated for it is re-derived; anything else is written as given.
+    if (
+        multiscales.scale_factors
+        and multiscales.method
+        and multiscales.chunks
+        and _is_generated_level(multiscales, index + 1)
+    ):
         for callback in image.computed_callbacks:
             callback()
         image.computed_callbacks = []

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -426,22 +426,31 @@ def _gate_axis_model(metadata, version) -> None:
                 ) from exc
 
 
-def _lazy_array_leaves(arr: dask.array.Array):
+def _lazy_array_leaves(arr: dask.array.Array, seen: set[str] | None = None):
     """Yield the local store arrays embedded in the dask graph of ``arr``.
 
     An array opened from a local store enters a dask graph as a
     ``_ZarristaArrayAdapter`` held by a materialized layer; blockwise layers
     only reference it by key. Materialized data (``persist()``) holds none.
+
+    ``seen`` carries the layer names already walked. The levels of a
+    multiscales are derived from one another, so each level's graph holds
+    every layer the levels below it hold, and walking them per level costs
+    the same layer once per level that keeps it.
     """
     graph = arr.__dask_graph__()
     layers = getattr(graph, "layers", None)
     if layers is None:
         sources = graph.values()
     else:
+        if seen is None:
+            seen = set()
+        fresh = [name for name in layers if name not in seen]
+        seen.update(fresh)
         sources = (
             value
-            for layer in layers.values()
-            for value in getattr(layer, "mapping", {}).values()
+            for name in fresh
+            for value in getattr(layers[name], "mapping", {}).values()
         )
     for value in sources:
         stack = [value]
@@ -476,10 +485,11 @@ def _guard_overwrite_of_source_store(
     write silently fills the store with zeros.
     """
     destination = Path(store_path).resolve()
+    seen: set[str] = set()
     for index, image in enumerate(multiscales.images):
         if not isinstance(image.data, dask.array.Array):
             continue
-        for leaf in _lazy_array_leaves(image.data):
+        for leaf in _lazy_array_leaves(image.data, seen):
             if _reads_below(leaf, destination):
                 raise ValueError(
                     f"Cannot overwrite '{store_path}': multiscales.images[{index}] "
@@ -504,11 +514,12 @@ def _guard_rewrite_of_read_levels(
         store_root.joinpath(*_node_parts(dataset.path)): dataset.path
         for dataset in datasets[start_level:]
     }
+    seen: set[str] = set()
     for index in range(start_level, len(multiscales.images)):
         data = multiscales.images[index].data
         if not isinstance(data, dask.array.Array):
             continue
-        for leaf in _lazy_array_leaves(data):
+        for leaf in _lazy_array_leaves(data, seen):
             array_dir = _leaf_array_dir(leaf)
             if array_dir in replaced:
                 raise ValueError(

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -117,6 +117,83 @@ def _numpy_to_zarr_dtype(dtype):
         raise ValueError(f"dtype {dtype} cannot be mapped to Zarr v3 core dtype")
 
 
+def _create_dataset(
+    store_path: str,
+    shape,
+    dtype,
+    chunks,
+    zarr_format,
+    dimension_names=None,
+    internal_chunk_shape=None,
+    compression_chain=None,
+):
+    """Create the array node at ``store_path`` (``<store>/<path>``) and return it.
+
+    ``compression_chain`` carries the ordered compression codec chain (for
+    zarr format 2 metadata only its first entry is stored): ``None`` requests
+    the engine default, an empty sequence requests no compression. An array
+    already at the path is opened instead of created.
+    """
+    from ._zarrista_utils import create_zarrista_array, open_zarrista_array
+
+    scale_path = Path(store_path)
+    store_root = scale_path.parent
+    node_name = scale_path.name
+
+    create_kwargs = {}
+    if zarr_format == 2:
+        if compression_chain is None:
+            # Mirror zarr-python's zarr format 2 default compressor so the
+            # zarrista engine's output is indistinguishable from what the
+            # legacy engine wrote.
+            compressor = {"id": "zstd", "level": 0}
+        elif compression_chain:
+            compressor = compression_chain[0]
+        else:
+            compressor = None
+        create_kwargs["compressor"] = compressor
+    elif zarr_format == 3:
+        default_compression = {
+            "name": "zstd",
+            "configuration": {"level": 0, "checksum": False},
+        }
+        if compression_chain is None:
+            # Mirror the zarr-python default codec chain.
+            create_kwargs["compressors"] = [default_compression]
+        else:
+            # An explicit chain is preserved in order; an explicit empty
+            # chain means no compression, matching zarr-python.
+            create_kwargs["compressors"] = list(compression_chain)
+        if dimension_names:
+            create_kwargs["dimension_names"] = tuple(dimension_names)
+        if internal_chunk_shape:
+            # ``chunks`` is the shard (outer chunk) grid; the subchunks
+            # inside each shard are the internal chunk shape.
+            create_kwargs["shards"] = tuple(chunks)
+            chunks = tuple(internal_chunk_shape)
+    else:
+        raise ValueError(f"Unsupported zarr format: {zarr_format}")
+
+    # Try to create the dataset first, open existing only if needed
+    try:
+        return create_zarrista_array(
+            store_root,
+            node_name,
+            tuple(shape),
+            dtype,
+            chunks,
+            zarr_format,
+            **create_kwargs,
+        )
+    except Exception as create_error:
+        # Dataset may already exist: fall back to opening it, surfacing
+        # the create failure when there is nothing to open.
+        try:
+            return open_zarrista_array(store_root, node_name)
+        except Exception:
+            raise create_error from None
+
+
 def _write_with_zarrista(
     store_path: str,
     array,
@@ -132,14 +209,11 @@ def _write_with_zarrista(
 ) -> None:
     """Write array using the zarrista backend.
 
-    *store_path* addresses the array node itself (``<store>/<path>``).
-    ``compression_chain`` carries the ordered compression codec chain (for
-    zarr format 2 metadata only its first entry is stored): ``None`` requests
-    the engine default, an empty sequence requests no compression.
+    *store_path* addresses the array node itself (``<store>/<path>``); see
+    :func:`_create_dataset` for ``compression_chain``.
     """
     from ._zarrista_utils import (
         _native_contiguous,
-        create_zarrista_array,
         open_zarrista_array,
         write_dask_array,
     )
@@ -148,65 +222,21 @@ def _write_with_zarrista(
     dataset_shape = tuple(
         full_array_shape if full_array_shape is not None else array.shape
     )
-    scale_path = Path(store_path)
-    store_root = scale_path.parent
-    node_name = scale_path.name
 
     if create_dataset:
-        create_kwargs = {}
-        if zarr_format == 2:
-            if compression_chain is None:
-                # Mirror zarr-python's zarr format 2 default compressor so the
-                # zarrista engine's output is indistinguishable from what the
-                # legacy engine wrote.
-                compressor = {"id": "zstd", "level": 0}
-            elif compression_chain:
-                compressor = compression_chain[0]
-            else:
-                compressor = None
-            create_kwargs["compressor"] = compressor
-        elif zarr_format == 3:
-            default_compression = {
-                "name": "zstd",
-                "configuration": {"level": 0, "checksum": False},
-            }
-            if compression_chain is None:
-                # Mirror the zarr-python default codec chain.
-                create_kwargs["compressors"] = [default_compression]
-            else:
-                # An explicit chain is preserved in order; an explicit empty
-                # chain means no compression, matching zarr-python.
-                create_kwargs["compressors"] = list(compression_chain)
-            if dimension_names:
-                create_kwargs["dimension_names"] = tuple(dimension_names)
-            if internal_chunk_shape:
-                # ``chunks`` is the shard (outer chunk) grid; the subchunks
-                # inside each shard are the internal chunk shape.
-                create_kwargs["shards"] = tuple(chunks)
-                chunks = tuple(internal_chunk_shape)
-        else:
-            raise ValueError(f"Unsupported zarr format: {zarr_format}")
-
-        # Try to create the dataset first, open existing only if needed
-        try:
-            dataset = create_zarrista_array(
-                store_root,
-                node_name,
-                dataset_shape,
-                array.dtype,
-                chunks,
-                zarr_format,
-                **create_kwargs,
-            )
-        except Exception as create_error:
-            # Dataset may already exist: fall back to opening it, surfacing
-            # the create failure when there is nothing to open.
-            try:
-                dataset = open_zarrista_array(store_root, node_name)
-            except Exception:
-                raise create_error from None
+        dataset = _create_dataset(
+            store_path,
+            dataset_shape,
+            array.dtype,
+            chunks,
+            zarr_format,
+            dimension_names,
+            internal_chunk_shape,
+            compression_chain,
+        )
     else:
-        dataset = open_zarrista_array(store_root, node_name)
+        scale_path = Path(store_path)
+        dataset = open_zarrista_array(scale_path.parent, scale_path.name)
 
     # Try to write the dask array directly first
     try:
@@ -607,28 +637,17 @@ def _is_bytes_codec(codec) -> bool:
     return name == "bytes"
 
 
-def _write_array_with_zarrista(
-    store_path: str,
-    path: str,
-    arr: dask.array.Array,
-    chunks: tuple[int, ...] | list[int],
-    shards: tuple[int, ...] | None,
-    internal_chunk_shape: tuple[int, ...] | None,
-    zarr_format: int,
-    dimension_names: tuple[str, ...] | None,
-    region: tuple[slice, ...],
-    full_array_shape: tuple[int, ...] | None = None,
-    create_dataset: bool = True,
-    **kwargs,
-) -> None:
-    """Write an array using the zarrista backend."""
-    # Translate the public compression kwargs into a single ordered chain:
-    # ``None`` selects the engine default and an empty chain selects no
-    # compression. Mirroring the legacy engine's kwargs handling, an explicit
-    # ``compressor=None`` disables compression while ``compressors=None`` is
-    # indistinguishable from unset (default compression); the unset cases are
-    # detected with a sentinel. Only the array-to-bytes ("bytes") codec is
-    # dropped from a supplied chain since the writer always leads with one.
+def _compression_chain(kwargs: dict) -> list | None:
+    """Translate the public compression kwargs into a single ordered chain.
+
+    ``None`` selects the engine default and an empty chain selects no
+    compression. Mirroring the legacy engine's kwargs handling, an explicit
+    ``compressor=None`` disables compression while ``compressors=None`` is
+    indistinguishable from unset (default compression); the unset cases are
+    detected with a sentinel. Only the array-to-bytes ("bytes") codec is
+    dropped from a supplied chain since the writer always leads with one. The
+    consumed keys are removed from ``kwargs``.
+    """
     filters = kwargs.pop("filters", None)
     if filters:
         raise ValueError(
@@ -648,6 +667,25 @@ def _write_array_with_zarrista(
     else:
         compression_chain = None
     kwargs.pop("chunks", None)  # Remove chunks from kwargs since it's a positional arg
+    return compression_chain
+
+
+def _write_array_with_zarrista(
+    store_path: str,
+    path: str,
+    arr: dask.array.Array,
+    chunks: tuple[int, ...] | list[int],
+    shards: tuple[int, ...] | None,
+    internal_chunk_shape: tuple[int, ...] | None,
+    zarr_format: int,
+    dimension_names: tuple[str, ...] | None,
+    region: tuple[slice, ...],
+    full_array_shape: tuple[int, ...] | None = None,
+    create_dataset: bool = True,
+    **kwargs,
+) -> None:
+    """Write an array using the zarrista backend."""
+    compression_chain = _compression_chain(kwargs)
 
     scale_path = f"{store_path}/{path}"
     sharding_kwargs = (
@@ -692,31 +730,21 @@ def _array_write_error(path: str, error: Exception) -> OSError:
     return OSError(msg)
 
 
-def _handle_large_array_writing(
-    image,
+def _resolve_scale_chunks(
     arr: dask.array.Array,
-    path: str,
-    dims: tuple[str, ...],
-    dim_factors: dict[str, int],
     chunks: tuple[int, ...],
     sharding_kwargs: dict,
-    store_path: str,
-    zarr_format: int,
-    dimension_names: tuple[str, ...],
     internal_chunk_shape: tuple[int, ...] | None,
     shards: tuple[int, ...] | None,
-    progress: NgffProgress | NgffProgressCallback | None,
-    index: int,
-    nscales: int,
-    **kwargs,
-) -> None:
-    """Handle writing large arrays by splitting them into manageable pieces."""
-    shrink_factors = []
-    for dim in dims:
-        if dim in dim_factors:
-            shrink_factors.append(dim_factors[dim])
-        else:
-            shrink_factors.append(1)
+) -> tuple[
+    tuple[int, ...], tuple[int, ...], tuple[int, ...] | None, tuple[int, ...] | None
+]:
+    """Resolve the stored chunk grid of a scale array from the requested one.
+
+    Returns the chunk shape to plan region writes on (the shard shape when
+    sharding), the chunks clamped to the axes, the shard shape and the inner
+    chunk shape of a shard.
+    """
 
     # Region writes and shard/array chunk sizes do not need to divide the
     # dimension evenly: Zarr v3 permits a partial final chunk. Region slabs are
@@ -815,6 +843,73 @@ def _handle_large_array_writing(
             ]
         )
         zarr_chunk_shape = chunks
+
+    return zarr_chunk_shape, chunks, shards, internal_chunk_shape
+
+
+def _create_scale_array(
+    store_path: str,
+    path: str,
+    arr: dask.array.Array,
+    chunks: tuple[int, ...],
+    sharding_kwargs: dict,
+    zarr_format: int,
+    dimension_names: tuple[str, ...] | None,
+    internal_chunk_shape: tuple[int, ...] | None,
+    shards: tuple[int, ...] | None,
+    **kwargs,
+):
+    """Create the empty array of one scale level.
+
+    Chunk, shard and compression settings are resolved the way the region
+    writer resolves them, so an array created for a metadata-only store is
+    identical to one the writer fills itself.
+    """
+    _, chunks, shards, internal_chunk_shape = _resolve_scale_chunks(
+        arr, chunks, sharding_kwargs, internal_chunk_shape, shards
+    )
+    compression_chain = _compression_chain(dict(kwargs))
+    return _create_dataset(
+        f"{store_path}/{path}",
+        arr.shape,
+        arr.dtype,
+        chunks,
+        zarr_format,
+        dimension_names,
+        internal_chunk_shape if shards is not None else None,
+        compression_chain,
+    )
+
+
+def _handle_large_array_writing(
+    image,
+    arr: dask.array.Array,
+    path: str,
+    dims: tuple[str, ...],
+    dim_factors: dict[str, int],
+    chunks: tuple[int, ...],
+    sharding_kwargs: dict,
+    store_path: str,
+    zarr_format: int,
+    dimension_names: tuple[str, ...],
+    internal_chunk_shape: tuple[int, ...] | None,
+    shards: tuple[int, ...] | None,
+    progress: NgffProgress | NgffProgressCallback | None,
+    index: int,
+    nscales: int,
+    **kwargs,
+) -> None:
+    """Handle writing large arrays by splitting them into manageable pieces."""
+    shrink_factors = []
+    for dim in dims:
+        if dim in dim_factors:
+            shrink_factors.append(dim_factors[dim])
+        else:
+            shrink_factors.append(1)
+
+    zarr_chunk_shape, chunks, shards, internal_chunk_shape = _resolve_scale_chunks(
+        arr, chunks, sharding_kwargs, internal_chunk_shape, shards
+    )
 
     shape = image.data.shape
     x_index = dims.index("x")
@@ -1145,6 +1240,7 @@ def to_ome_zarr(
     progress: NgffProgress | NgffProgressCallback | None = None,
     chunks_per_shard: int | tuple[int, ...] | dict[str, int] | None = None,
     scale_strategy: ScaleStrategy = "pad",
+    metadata_only: bool = False,
     **kwargs,
 ) -> None:
     """
@@ -1189,6 +1285,14 @@ def to_ome_zarr(
         coordinate metadata.
     :type  scale_strategy: "pad" or "exact", optional
 
+    :param metadata_only: If True, write the OME-Zarr metadata and create every scale
+        array with its shape, dtype, chunks, shards and codecs, but compute and write no
+        pixel data. Nothing in the dask graphs is evaluated, so the call returns at once
+        whatever the image size. Fill the arrays afterwards with any Zarr writer; a chunk
+        grid that follows the regions each writer produces gives every chunk a single
+        writer and needs no locking. Not available for .ozx output.
+    :type  metadata_only: bool, optional
+
     :param **kwargs: Array-creation options, e.g. `compressor` / `compressors`
         compression settings.
     """
@@ -1214,6 +1318,11 @@ def to_ome_zarr(
 
     # RFC-9: Handle .ozx (zipped OME-Zarr) files
     if isinstance(store, (str, Path)) and is_ozx_path(store):
+        if metadata_only:
+            raise ValueError(
+                "metadata_only=True is not available for .ozx output: a zipped "
+                "OME-Zarr is written in one piece, with its data."
+            )
         if version != "0.5":
             raise ValueError(
                 "RFC-9 zipped OME-Zarr (.ozx) requires OME-Zarr version 0.5. "
@@ -1259,6 +1368,7 @@ def to_ome_zarr(
         progress=progress,
         chunks_per_shard=chunks_per_shard,
         scale_strategy=scale_strategy,
+        metadata_only=metadata_only,
         **kwargs,
     )
 
@@ -1277,6 +1387,7 @@ def _to_ngff_zarr_impl(
     progress: NgffProgress | NgffProgressCallback | None = None,
     chunks_per_shard: int | tuple[int, ...] | dict[str, int] | None = None,
     scale_strategy: ScaleStrategy = "pad",
+    metadata_only: bool = False,
     **kwargs,
 ) -> None:
     """
@@ -1324,7 +1435,7 @@ def _to_ngff_zarr_impl(
 
     # Process each scale level
     nscales = len(multiscales.images)
-    if progress:
+    if progress and not metadata_only:
         progress.add_multiscales_task("[green]Writing scales", nscales)
 
     next_image = multiscales.images[0]
@@ -1332,7 +1443,7 @@ def _to_ngff_zarr_impl(
     previous_dim_factors = dict.fromkeys(dims, 1)
 
     for index in range(nscales):
-        if progress:
+        if progress and not metadata_only:
             progress.update_multiscales_task_completed(index + 1)
 
         image = next_image
@@ -1384,6 +1495,25 @@ def _to_ngff_zarr_impl(
             chunks = shards
         else:
             shards = None
+
+        if metadata_only:
+            # The levels keep the shapes to_multiscales gave them, which are
+            # the shapes the datasets metadata describes.
+            _create_scale_array(
+                store_path,
+                path,
+                arr,
+                chunks,
+                sharding_kwargs,
+                zarr_format,
+                dimension_names,
+                internal_chunk_shape,
+                shards,
+                **kwargs,
+            )
+            if index + 1 < nscales:
+                next_image = multiscales.images[index + 1]
+            continue
 
         # Determine write method based on memory requirements
         if memory_usage(image) > config.memory_target:

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -19,6 +19,7 @@ from ._zarrista_utils import (
     _ZarristaArrayAdapter,
     create_zarrista_group,
     create_zarrista_subgroup,
+    has_consolidated_metadata,
     normalize_store,
     open_lazy_array,
     read_group_attributes,
@@ -486,6 +487,78 @@ def _guard_overwrite_of_source_store(
                     "levels with start_level, or materialize the data first, "
                     "e.g. image.data = image.data.persist()."
                 )
+
+
+def _guard_rewrite_of_read_levels(
+    multiscales: NgffMultiscales, store_path: str, datasets, start_level: int
+) -> None:
+    """Refuse to replace a stored level that a level to be written still reads.
+
+    A level at or above ``start_level`` replaces the array at its path, and
+    the array is removed before its replacement is computed.
+    """
+    store_root = Path(store_path).resolve()
+    replaced = {
+        store_root.joinpath(*_node_parts(dataset.path)): dataset.path
+        for dataset in datasets[start_level:]
+    }
+    for index in range(start_level, len(multiscales.images)):
+        data = multiscales.images[index].data
+        if not isinstance(data, dask.array.Array):
+            continue
+        for leaf in _lazy_array_leaves(data):
+            array_dir = _leaf_array_dir(leaf)
+            if array_dir in replaced:
+                raise ValueError(
+                    f"multiscales.images[{index}] reads the array at "
+                    f"'{replaced[array_dir]}', which start_level={start_level} "
+                    "replaces before its data is computed. Materialize that "
+                    "level first, e.g. image.data = image.data.persist(), or "
+                    f"pass a multiscales whose levels from {start_level} on are "
+                    f"derived from the stored level {start_level - 1}."
+                )
+
+
+def _node_parts(path: str) -> list[str]:
+    """Path components of a node path within a store."""
+    return [part for part in str(path).split("/") if part not in ("", ".")]
+
+
+def _bind_existing_level(image, store_path: str, path: str, index: int) -> None:
+    """Point ``image`` at the array already stored for scale ``index``.
+
+    The array must match the shape and dtype the multiscales describes for
+    that level: the levels written after it are derived from it, and the
+    datasets metadata is rewritten from the multiscales.
+    """
+    from ._zarrista_utils import open_zarrista_array
+
+    try:
+        existing = open_zarrista_array(store_path, path)
+    except Exception as error:
+        raise ValueError(
+            f"start_level expects scale level {index} at '{path}', but the "
+            f"store has no readable array there: {type(error).__name__}: {error}"
+        ) from error
+    shape = tuple(existing.shape)
+    dtype = np.dtype(existing.dtype.name)
+    if shape != tuple(image.data.shape) or dtype != np.dtype(image.data.dtype):
+        raise ValueError(
+            f"The array stored for scale level {index} at '{path}' has shape "
+            f"{shape} and dtype {dtype}, but the multiscales describes "
+            f"{tuple(image.data.shape)} {image.data.dtype}."
+        )
+    for callback in image.computed_callbacks:
+        callback()
+    image.computed_callbacks = []
+    image.data = open_lazy_array(store_path, path)
+
+
+def _remove_existing_level(store_path: str, path: str) -> None:
+    """Remove the array stored at ``path``, so its replacement starts clean."""
+    node_dir = Path(store_path).joinpath(*_node_parts(path))
+    if node_dir.exists():
+        shutil.rmtree(node_dir)
 
 
 def _prepare_metadata(
@@ -1241,6 +1314,7 @@ def to_ome_zarr(
     chunks_per_shard: int | tuple[int, ...] | dict[str, int] | None = None,
     scale_strategy: ScaleStrategy = "pad",
     metadata_only: bool = False,
+    start_level: int = 0,
     **kwargs,
 ) -> None:
     """
@@ -1293,6 +1367,14 @@ def to_ome_zarr(
         writer and needs no locking. Not available for .ozx output.
     :type  metadata_only: bool, optional
 
+    :param start_level: Index of the first scale level to write. The levels below it must
+        already exist in the store with the shape and dtype the multiscales describes; they
+        are read, never rewritten, and the first written level is derived from the last of
+        them on disk. Requires ``overwrite=False``. Root attributes the writer does not own
+        are kept, the multiscales entry is rewritten in full, and a level at or above
+        ``start_level`` that already exists is replaced.
+    :type  start_level: int, optional
+
     :param **kwargs: Array-creation options, e.g. `compressor` / `compressors`
         compression settings.
     """
@@ -1322,6 +1404,11 @@ def to_ome_zarr(
             raise ValueError(
                 "metadata_only=True is not available for .ozx output: a zipped "
                 "OME-Zarr is written in one piece, with its data."
+            )
+        if start_level:
+            raise ValueError(
+                "start_level is not available for .ozx output: a zipped OME-Zarr "
+                "is written in one piece."
             )
         if version != "0.5":
             raise ValueError(
@@ -1369,6 +1456,7 @@ def to_ome_zarr(
         chunks_per_shard=chunks_per_shard,
         scale_strategy=scale_strategy,
         metadata_only=metadata_only,
+        start_level=start_level,
         **kwargs,
     )
 
@@ -1388,6 +1476,7 @@ def _to_ngff_zarr_impl(
     chunks_per_shard: int | tuple[int, ...] | dict[str, int] | None = None,
     scale_strategy: ScaleStrategy = "pad",
     metadata_only: bool = False,
+    start_level: int = 0,
     **kwargs,
 ) -> None:
     """
@@ -1413,19 +1502,42 @@ def _to_ngff_zarr_impl(
     store_path = str(normalize_store(store))
 
     _validate_ngff_parameters(version, chunks_per_shard)
+    if not 0 <= start_level < len(multiscales.images):
+        raise ValueError(
+            f"start_level={start_level} is out of range for "
+            f"{len(multiscales.images)} scale levels."
+        )
+    if start_level and overwrite:
+        raise ValueError(
+            "start_level keeps the levels already in the store, which "
+            "overwrite=True would delete. Pass overwrite=False."
+        )
     if overwrite:
         _guard_overwrite_of_source_store(multiscales, store_path)
     metadata, dimension_names, _ = _prepare_metadata(multiscales, version)
     _gate_top_level_transforms(metadata, version)
+    if start_level:
+        _guard_rewrite_of_read_levels(
+            multiscales, store_path, metadata.datasets, start_level
+        )
     metadata_dict = asdict(metadata)
     metadata_dict = _pop_metadata_optionals(metadata_dict)
     metadata_dict["@type"] = "ngff:Image"
 
-    # Create Zarr root
-    _create_zarr_root(store, version, overwrite, metadata_dict)
-
     # Format parameters
     zarr_format = 2 if version == "0.4" else 3
+
+    # Create Zarr root
+    # Appending names only the levels it keeps until the new arrays are in
+    # place, so an interrupted call leaves a store that reads as those levels.
+    if start_level:
+        kept = copy.deepcopy(metadata_dict)
+        kept["datasets"] = kept["datasets"][:start_level]
+        _create_zarr_root(store, version, overwrite, kept)
+        if has_consolidated_metadata(store, zarr_format):
+            _zarrista_consolidate_metadata(store, zarr_format)
+    else:
+        _create_zarr_root(store, version, overwrite, metadata_dict)
 
     if version == "0.4" and kwargs.get("compressors") is not None:
         raise ValueError(
@@ -1451,15 +1563,6 @@ def _to_ngff_zarr_impl(
         path = metadata.datasets[index].path
         parent = str(PurePosixPath(path).parent)
 
-        # Create parent groups if needed
-        if parent not in (".", "/"):
-            create_zarrista_subgroup(
-                store,
-                parent,
-                {"_ARRAY_DIMENSIONS": list(image.dims)},
-                zarr_format,
-            )
-
         # Calculate dimension factors
         if index > 0 and index < nscales - 1 and multiscales.scale_factors:
             dim_factors = _dim_scale_factors(
@@ -1468,6 +1571,42 @@ def _to_ngff_zarr_impl(
         else:
             dim_factors = dict.fromkeys(dims, 1)
         previous_dim_factors = dim_factors
+
+        if index < start_level:
+            _bind_existing_level(image, store_path, path, index)
+            next_image = _prepare_next_scale(
+                image,
+                index,
+                nscales,
+                multiscales,
+                store,
+                path,
+                progress,
+                scale_strategy=scale_strategy,
+            )
+            continue
+
+        # Create parent groups if needed
+        if parent not in (".", "/"):
+            if (
+                not start_level
+                and not overwrite
+                and read_group_attributes(store, parent, zarr_format=zarr_format)
+                is not None
+            ):
+                raise ValueError(
+                    f"The store already holds scale level {index} at "
+                    f"'{parent}'. Pass start_level to append levels after the "
+                    "ones it holds, or overwrite=True to replace the store."
+                )
+            create_zarrista_subgroup(
+                store,
+                parent,
+                {"_ARRAY_DIMENSIONS": list(image.dims)},
+                zarr_format,
+            )
+        if start_level:
+            _remove_existing_level(store_path, path)
 
         # Configure sharding if needed
         # TODO check with recent updates to zarr by Ilan whether sharding can just be configured on zarr side.
@@ -1569,6 +1708,9 @@ def _to_ngff_zarr_impl(
             progress,
             scale_strategy=scale_strategy,
         )
+
+    if start_level:
+        _create_zarr_root(store, version, False, metadata_dict)
 
     # Clean up callbacks
     for image in multiscales.images:

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -15,13 +15,14 @@ from itkwasm import array_like_to_numpy_array
 from ._store_types import StoreLike
 from ._supported_versions import V06_ONDISK_VERSION, NgffVersion
 from ._zarrista_utils import (
-    consolidate_metadata as _zarrista_consolidate_metadata,
-)
-from ._zarrista_utils import (
+    _ZarristaArrayAdapter,
     create_zarrista_group,
     create_zarrista_subgroup,
     normalize_store,
     open_lazy_array,
+)
+from ._zarrista_utils import (
+    consolidate_metadata as _zarrista_consolidate_metadata,
 )
 from .config import config
 from .memory_usage import memory_usage
@@ -388,6 +389,71 @@ def _gate_axis_model(metadata, version) -> None:
                     "0.9.dev1 is the only OME-Zarr version that adopts RFC-3 "
                     "(arbitrary axis count, names, types and ordering)."
                 ) from exc
+
+
+def _lazy_array_leaves(arr: dask.array.Array):
+    """Yield the local store arrays embedded in the dask graph of ``arr``.
+
+    An array opened from a local store enters a dask graph as a
+    ``_ZarristaArrayAdapter`` held by a materialized layer; blockwise layers
+    only reference it by key. Materialized data (``persist()``) holds none.
+    """
+    graph = arr.__dask_graph__()
+    layers = getattr(graph, "layers", None)
+    if layers is None:
+        sources = graph.values()
+    else:
+        sources = (
+            value
+            for layer in layers.values()
+            for value in getattr(layer, "mapping", {}).values()
+        )
+    for value in sources:
+        stack = [value]
+        while stack:
+            item = stack.pop()
+            if isinstance(item, _ZarristaArrayAdapter):
+                if item.store_path is not None:
+                    yield item
+            elif isinstance(item, (tuple, list)):
+                stack.extend(item)
+
+
+def _leaf_array_dir(leaf: _ZarristaArrayAdapter) -> Path:
+    """Directory of the array a lazy array leaf reads from."""
+    parts = [p for p in (leaf.node_path or "").split("/") if p not in ("", ".")]
+    return Path(leaf.store_path).resolve().joinpath(*parts)
+
+
+def _reads_below(leaf: _ZarristaArrayAdapter, directory: Path) -> bool:
+    """Whether a lazy array leaf reads an array at or below ``directory``."""
+    array_dir = _leaf_array_dir(leaf)
+    return array_dir == directory or directory in array_dir.parents
+
+
+def _guard_overwrite_of_source_store(
+    multiscales: NgffMultiscales, store_path: str
+) -> None:
+    """Refuse an overwrite that would clear the store the images still read.
+
+    Overwriting removes every node of the store before dask computes a
+    chunk. Reads of the removed chunks then return the fill value, so the
+    write silently fills the store with zeros.
+    """
+    destination = Path(store_path).resolve()
+    for index, image in enumerate(multiscales.images):
+        if not isinstance(image.data, dask.array.Array):
+            continue
+        for leaf in _lazy_array_leaves(image.data):
+            if _reads_below(leaf, destination):
+                raise ValueError(
+                    f"Cannot overwrite '{store_path}': multiscales.images[{index}] "
+                    "reads its data from that store, and overwrite=True removes "
+                    "the store contents before the data is computed, which "
+                    "would write zeros. Write to a different store, append "
+                    "levels with start_level, or materialize the data first, "
+                    "e.g. image.data = image.data.persist()."
+                )
 
 
 def _prepare_metadata(
@@ -1190,6 +1256,8 @@ def _to_ngff_zarr_impl(
     store_path = str(normalize_store(store))
 
     _validate_ngff_parameters(version, chunks_per_shard)
+    if overwrite:
+        _guard_overwrite_of_source_store(multiscales, store_path)
     metadata, dimension_names, _ = _prepare_metadata(multiscales, version)
     _gate_top_level_transforms(metadata, version)
     metadata_dict = asdict(metadata)

--- a/py/ngff_zarr/v04/zarr_metadata.py
+++ b/py/ngff_zarr/v04/zarr_metadata.py
@@ -440,7 +440,7 @@ class Metadata:
         import packaging.version
 
         from .._zarrista_utils import open_lazy_array
-        from ..ngff_image import NgffImage
+        from ..ngff_image import NgffImage, non_default_axes_types
         from ..parse_metadata import _parse_omero, _raw_axes
         from ..rfc4_validation import (
             has_any_rfc4_orientation,
@@ -593,6 +593,7 @@ class Metadata:
                 translation=translation,
                 name=root_attrs.get("name", "image"),
                 axes_units=units,
+                axes_types=non_default_axes_types(axes),
             )
             images.append(ngff_image)
 

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -730,7 +730,7 @@ class Metadata:
         import sys
 
         from .._zarrista_utils import open_lazy_array
-        from ..ngff_image import NgffImage
+        from ..ngff_image import NgffImage, non_default_axes_types
         from ..parse_metadata import _parse_omero, _raw_axes
         from ..rfc4_validation import (
             has_any_rfc4_orientation,
@@ -880,6 +880,7 @@ class Metadata:
                 translation=dict(zip(dims, translation.translation)),
                 name=root_attrs.get("name", "image"),
                 axes_units=dict(zip(dims, [ax.unit for ax in cs_intrinsic.axes])),
+                axes_types=non_default_axes_types(cs_intrinsic.axes),
             )
             images.append(ngff_image)
 

--- a/py/test/test_dask_bin_shrink.py
+++ b/py/test/test_dask_bin_shrink.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import numpy as np
+import pytest
+from ngff_zarr import Methods, to_multiscales, to_ngff_image
+from ngff_zarr.methods._metadata import get_method_metadata
+
+
+def _image(data, dims=("c", "z", "y", "x")):
+    dims = list(dims)
+    return to_ngff_image(
+        data,
+        dims=dims,
+        scale=dict.fromkeys(dims, 1),
+        translation=dict.fromkeys(dims, 0),
+    )
+
+
+def _random(shape, dtype, seed=0):
+    rng = np.random.default_rng(seed)
+    if np.issubdtype(dtype, np.integer):
+        info = np.iinfo(dtype)
+        return rng.integers(info.min, info.max, shape, dtype=dtype)
+    return rng.random(shape, dtype=dtype)
+
+
+def _itkwasm_reference(data, factors_zyx):
+    """BinShrink of one whole (c, z, y, x) block through itkwasm."""
+    from ngff_zarr.methods._itkwasm import _itkwasm_chunk_bin_shrink
+
+    shrink_xyz = list(reversed(factors_zyx))
+    return np.stack(
+        [_itkwasm_chunk_bin_shrink(channel, shrink_xyz) for channel in data]
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.int16, np.float32])
+@pytest.mark.parametrize("scale_factors", [[2], [2, 4], [3], [{"x": 2, "y": 4}]])
+def test_matches_itkwasm_bin_shrink(dtype, scale_factors):
+    data = _random((2, 35, 34, 33), dtype)
+    multiscales = to_multiscales(
+        _image(data),
+        scale_factors,
+        method=Methods.DASK_BIN_SHRINK,
+        chunks=(1, 16, 16, 16),
+        cache=False,
+    )
+    assert len(multiscales.images) == len(scale_factors) + 1
+
+    previous = data
+    previous_factor = {"z": 1, "y": 1, "x": 1}
+    for level, scale_factor in zip(multiscales.images[1:], scale_factors):
+        absolute = (
+            {dim: scale_factor.get(dim, 1) for dim in previous_factor}
+            if isinstance(scale_factor, dict)
+            else dict.fromkeys(previous_factor, scale_factor)
+        )
+        step = [absolute[dim] // previous_factor[dim] for dim in ("z", "y", "x")]
+        expected = _itkwasm_reference(previous, step)
+        got = level.data.compute()
+        assert got.shape == expected.shape
+        assert got.dtype == dtype
+        if np.issubdtype(dtype, np.integer):
+            np.testing.assert_array_equal(got, expected)
+        else:
+            np.testing.assert_allclose(got, expected, rtol=1e-6, atol=1e-7)
+        for dim in ("z", "y", "x"):
+            assert level.scale[dim] == absolute[dim]
+            assert level.translation[dim] == 0.5 * (absolute[dim] - 1)
+        previous = got
+        previous_factor = absolute
+
+
+def test_any_chunk_layout():
+    data = _random((1, 514, 33, 41), np.float32)
+    multiscales = to_multiscales(
+        _image(data),
+        scale_factors=[4],
+        chunks=(1, 2, 33, 41),
+        method=Methods.DASK_BIN_SHRINK,
+        cache=False,
+    )
+    level1 = multiscales.images[1].data.compute()
+    assert level1.shape == (1, 128, 8, 10)
+    expected = (
+        data[:, :512, :32, :40]
+        .astype(np.float64)
+        .reshape(1, 128, 4, 8, 4, 10, 4)
+        .mean(axis=(2, 4, 6))
+    )
+    np.testing.assert_allclose(level1, expected, rtol=1e-6, atol=1e-7)
+
+
+def test_two_dimensional_image():
+    data = _random((65, 64), np.uint16)
+    multiscales = to_multiscales(
+        _image(data, dims=("y", "x")),
+        scale_factors=[2],
+        method=Methods.DASK_BIN_SHRINK,
+        cache=False,
+    )
+    assert multiscales.images[1].data.shape == (32, 32)
+    assert multiscales.metadata.type == "dask_bin_shrink"
+
+
+def test_method_metadata():
+    metadata = get_method_metadata(Methods.DASK_BIN_SHRINK)
+    assert metadata.method == "dask.array.coarsen"
+    assert metadata.version != "unknown"
+
+
+def _window_mean_half_up(data, factor):
+    """Reference in Python integers: floor((sum + n / 2) / n) per window."""
+    c, z, y, x = data.shape
+    out = np.empty((c, z // factor, y // factor, x // factor), dtype=object)
+    for index in np.ndindex(out.shape):
+        window = data[
+            index[0],
+            index[1] * factor : (index[1] + 1) * factor,
+            index[2] * factor : (index[2] + 1) * factor,
+            index[3] * factor : (index[3] + 1) * factor,
+        ]
+        total = sum(int(v) for v in window.ravel())
+        count = factor**3
+        out[index] = (2 * total + count) // (2 * count)
+    return out
+
+
+@pytest.mark.parametrize(
+    "dtype, low, high",
+    [
+        (np.uint64, 2**64 - 64, 2**64 - 1),
+        (np.int64, -(2**63), -(2**63) + 64),
+        (np.int64, 2**63 - 64, 2**63 - 1),
+        (np.uint64, 0, 2**64 - 1),
+    ],
+)
+def test_64_bit_integers_keep_every_bit(dtype, low, high):
+    rng = np.random.default_rng(0)
+    values = rng.integers(low, high, size=(2, 4, 6, 8), endpoint=True, dtype=dtype)
+    multiscales = to_multiscales(
+        _image(values),
+        scale_factors=[2],
+        method=Methods.DASK_BIN_SHRINK,
+        chunks=(1, 4, 4, 4),
+        cache=False,
+    )
+    got = multiscales.images[1].data.compute()
+    expected = _window_mean_half_up(values, 2)
+    assert got.dtype == dtype
+    assert [int(v) for v in got.ravel()] == [int(v) for v in expected.ravel()]

--- a/py/test/test_displacement_field.py
+++ b/py/test/test_displacement_field.py
@@ -217,3 +217,16 @@ def test_axes_types_unknown_dim_raises():
     """An axes_types entry naming a missing dimension is rejected."""
     with pytest.raises(ValueError):
         to_multiscales(_field_image({"q": "displacement"}), scale_factors=[])
+
+
+@requires_zarr_v3
+def test_read_back_image_carries_the_displacement_type(tmp_path):
+    """A re-generated multiscales keeps the axis type the store declares."""
+    multiscales = to_multiscales(_field_image({"c": "displacement"}), scale_factors=[])
+    path = str(tmp_path / "field.ome.zarr")
+    nz.to_ome_zarr(path, multiscales, version="0.6")
+
+    image = nz.from_ome_zarr(path).images[0]
+    assert image.axes_types == {"c": "displacement"}
+    regenerated = to_multiscales(image, scale_factors=[])
+    assert [a.type for a in _axes(regenerated)] == ["displacement", "space", "space"]

--- a/py/test/test_itkwasm_block_limits.py
+++ b/py/test/test_itkwasm_block_limits.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import dask.array as da
+import numpy as np
+import pytest
+from ngff_zarr import Methods, to_multiscales, to_ngff_image
+from ngff_zarr.methods import _itkwasm
+
+
+def _image(data):
+    return to_ngff_image(
+        data,
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+
+
+def _block_mean(data, factor):
+    c, z, y, x = data.shape
+    z, y, x = (
+        (z // factor) * factor,
+        (y // factor) * factor,
+        (x // factor) * factor,
+    )
+    trimmed = data[:, :z, :y, :x].astype(np.float64)
+    shaped = trimmed.reshape(
+        c, z // factor, factor, y // factor, factor, x // factor, factor
+    )
+    return shaped.mean(axis=(2, 4, 6))
+
+
+def test_bin_shrink_remainder_smaller_than_the_factor():
+    data = np.random.default_rng(0).random((1, 514, 33, 41)).astype(np.float32)
+    multiscales = to_multiscales(
+        _image(data),
+        scale_factors=[4],
+        chunks=(1, 2, 33, 41),
+        method=Methods.ITKWASM_BIN_SHRINK,
+        cache=False,
+    )
+    level1 = multiscales.images[1].data.compute()
+    assert level1.shape == (1, 128, 8, 10)
+    np.testing.assert_allclose(level1, _block_mean(data, 4), rtol=1e-5, atol=1e-6)
+
+
+def test_bin_shrink_remainder_keeps_translation():
+    data = np.zeros((1, 9, 9, 9), dtype=np.uint8)
+    multiscales = to_multiscales(
+        _image(data),
+        scale_factors=[2],
+        chunks=(1, 4, 9, 9),
+        method=Methods.ITKWASM_BIN_SHRINK,
+        cache=False,
+    )
+    level1 = multiscales.images[1]
+    assert level1.data.shape == (1, 4, 4, 4)
+    assert level1.translation["z"] == 0.5
+    assert level1.scale["z"] == 2
+
+
+@pytest.mark.parametrize(
+    "method, smoothing",
+    [
+        (Methods.ITKWASM_GAUSSIAN, "gaussian"),
+        (Methods.ITKWASM_BIN_SHRINK, "bin_shrink"),
+    ],
+)
+def test_oversized_block_raises_before_compute(monkeypatch, method, smoothing):
+    monkeypatch.setitem(_itkwasm._WASM_BLOCK_LIMITS, smoothing, 1024)
+    data = np.zeros((1, 32, 32, 32), dtype=np.float32)
+    with pytest.raises(ValueError, match="wasm sandbox"):
+        to_multiscales(
+            _image(data),
+            scale_factors=[2],
+            chunks=(1, 32, 32, 32),
+            method=method,
+            cache=False,
+        )
+
+
+def test_gaussian_counts_integer_input_as_float32(monkeypatch):
+    data = np.zeros((1, 32, 32, 32), dtype=np.uint8)
+    limit = 2 * 32 * 32 * 32
+    monkeypatch.setitem(_itkwasm._WASM_BLOCK_LIMITS, "gaussian", limit)
+    monkeypatch.setitem(_itkwasm._WASM_BLOCK_LIMITS, "bin_shrink", limit)
+
+    to_multiscales(
+        _image(data),
+        scale_factors=[2],
+        chunks=(1, 32, 32, 32),
+        method=Methods.ITKWASM_BIN_SHRINK,
+        cache=False,
+    )
+    with pytest.raises(ValueError, match="wasm sandbox"):
+        to_multiscales(
+            _image(data),
+            scale_factors=[2],
+            chunks=(1, 32, 32, 32),
+            method=Methods.ITKWASM_GAUSSIAN,
+            cache=False,
+        )
+
+
+def test_overlap_larger_than_the_chunks_counts_the_merged_chunks(monkeypatch):
+    from ngff_zarr.ngff_image import NgffImage
+
+    data = da.zeros((1, 40, 8, 8), dtype=np.float32, chunks=(1, 4, 8, 8))
+    image = NgffImage(data, dims=["c", "z", "y", "x"], scale={}, translation={})
+    radius = [1, 1, 6]
+    # Chunks of 4 along z are merged to at least 6 before the overlap of 6 on
+    # each side is added: the block is at least (6 + 12) * 8 * 8 samples.
+    naive = (4 + 12) * (8 + 2) * (8 + 2) * 4
+    merged = (6 + 12) * (8 + 2) * (8 + 2) * 4
+    monkeypatch.setitem(_itkwasm._WASM_BLOCK_LIMITS, "gaussian", (naive + merged) // 2)
+    with pytest.raises(ValueError, match="wasm sandbox"):
+        _itkwasm._check_wasm_block_size(image, False, "gaussian", radius)

--- a/py/test/test_methods.py
+++ b/py/test/test_methods.py
@@ -28,6 +28,7 @@ EXPECTED_MEMBERS = {
     "DASK_IMAGE_GAUSSIAN": "dask_image_gaussian",
     "DASK_IMAGE_MODE": "dask_image_mode",
     "DASK_IMAGE_NEAREST": "dask_image_nearest",
+    "DASK_BIN_SHRINK": "dask_bin_shrink",
 }
 
 

--- a/py/test/test_open_array.py
+++ b/py/test/test_open_array.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import dask.array as da
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import NgffImage, from_ome_zarr, open_array, to_multiscales, to_ome_zarr
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+needs_zarr_v3 = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
+VERSIONS = ["0.4", pytest.param("0.5", marks=needs_zarr_v3)]
+SHAPE = (1, 32, 32, 32)
+CHUNKS = (1, 16, 16, 16)
+
+
+def _empty_store(path, ngff_version="0.4", **kwargs):
+    image = NgffImage(
+        da.zeros(SHAPE, dtype=np.float32, chunks=CHUNKS),
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+    multiscales = to_multiscales(image, scale_factors=[], chunks=CHUNKS, cache=False)
+    to_ome_zarr(path, multiscales, version=ngff_version, metadata_only=True, **kwargs)
+    return multiscales.metadata.datasets[0].path
+
+
+@pytest.mark.parametrize("ngff_version", VERSIONS)
+def test_handle_describes_the_array(tmp_path, ngff_version):
+    path = str(tmp_path / "image.ome.zarr")
+    level0 = open_array(path, _empty_store(path, ngff_version))
+    assert level0.shape == SHAPE
+    assert level0.dtype == np.float32
+    assert level0.chunks == CHUNKS
+    assert level0.path == "scale0/image"
+    assert level0.to_dask().shape == SHAPE
+
+
+@pytest.mark.parametrize("ngff_version", VERSIONS)
+def test_regions_written_through_the_handle_read_back(tmp_path, ngff_version):
+    path = str(tmp_path / "image.ome.zarr")
+    values = np.random.default_rng(0).random(SHAPE).astype(np.float32)
+    level0 = open_array(path, _empty_store(path, ngff_version))
+    for start in range(0, SHAPE[1], 16):
+        level0[:, start : start + 16] = values[:, start : start + 16]
+
+    np.testing.assert_array_equal(level0[:, 16:32], values[:, 16:32])
+    np.testing.assert_array_equal(from_ome_zarr(path).images[0].data.compute(), values)
+    np.testing.assert_array_equal(
+        zarr.open_array(path, path="scale0/image", mode="r")[:], values
+    )
+
+
+def test_scalars_and_integer_indices_follow_numpy(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    level0 = open_array(path, _empty_store(path))
+    level0[:, 3] = 7.0
+    level0[0, 0:2, 0:2, 0:2] = np.full((2, 2, 2), 1.5, dtype=np.float32)
+
+    plane = level0[:, 3]
+    assert plane.shape == (1, 32, 32)
+    assert plane.min() == 7.0
+    np.testing.assert_array_equal(level0[0, 0:2, 0:2, 0:2], 1.5)
+    assert level0[0, 4:8].max() == 0.0
+
+
+@needs_zarr_v3
+def test_sharded_store_reports_the_inner_chunks(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    level0 = open_array(path, _empty_store(path, "0.5", chunks_per_shard=2))
+    assert level0.chunks == CHUNKS
+    assert zarr.open_array(path, path="scale0/image", mode="r").shards == SHAPE
+
+
+def test_missing_and_group_paths_are_refused(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    _empty_store(path)
+    with pytest.raises(FileNotFoundError, match="No array"):
+        open_array(path, "scale7/image")
+    with pytest.raises(ValueError, match="group, not an array"):
+        open_array(path, "scale0")

--- a/py/test/test_root_attributes.py
+++ b/py/test/test_root_attributes.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import dask.array as da
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import (
+    NgffImage,
+    from_ome_zarr,
+    to_multiscales,
+    to_ngff_image,
+    to_ome_zarr,
+    update_root_attributes,
+)
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+needs_zarr_v3 = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
+VERSIONS = ["0.4", pytest.param("0.5", marks=needs_zarr_v3)]
+DIRECTION = {"acquisition": {"direction": [0, -1, 0, 1, 0, 0, 0, 0, 1]}}
+
+
+def _multiscales(scale_factors=()):
+    data = np.random.default_rng(0).random((1, 32, 32, 32)).astype(np.float32)
+    image = to_ngff_image(
+        data,
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+    return to_multiscales(
+        image, scale_factors=list(scale_factors), chunks=(1, 16, 16, 16), cache=False
+    )
+
+
+@pytest.mark.parametrize("ngff_version", VERSIONS)
+def test_root_attributes_are_written_beside_the_ome_keys(tmp_path, ngff_version):
+    path = str(tmp_path / "image.ome.zarr")
+    multiscales = _multiscales()
+    multiscales.root_attributes = dict(DIRECTION)
+    to_ome_zarr(path, multiscales, version=ngff_version)
+
+    attrs = dict(zarr.open_group(path, mode="r").attrs)
+    assert attrs["acquisition"] == DIRECTION["acquisition"]
+    assert ("ome" in attrs) == (ngff_version != "0.4")
+    assert from_ome_zarr(path).root_attributes == DIRECTION
+
+
+def test_root_attributes_follow_a_round_trip(tmp_path):
+    source = str(tmp_path / "source.ome.zarr")
+    multiscales = _multiscales()
+    multiscales.root_attributes = dict(DIRECTION)
+    to_ome_zarr(source, multiscales, version="0.4")
+
+    read = from_ome_zarr(source)
+    assert read.root_attributes == DIRECTION
+    assert "multiscales" not in read.root_attributes
+
+    copy = str(tmp_path / "copy.ome.zarr")
+    to_ome_zarr(copy, read, version="0.4")
+    assert from_ome_zarr(copy).root_attributes == DIRECTION
+
+
+def test_a_store_without_foreign_keys_reads_back_none(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, _multiscales(), version="0.4")
+    assert from_ome_zarr(path).root_attributes is None
+
+
+def test_ome_keys_are_refused(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    multiscales = _multiscales()
+    multiscales.root_attributes = {"multiscales": []}
+    with pytest.raises(ValueError, match="root_attributes cannot set"):
+        to_ome_zarr(path, multiscales, version="0.4")
+
+    to_ome_zarr(path, _multiscales(), version="0.4")
+    with pytest.raises(ValueError, match="root_attributes cannot set"):
+        update_root_attributes(path, {"ome": {}})
+
+
+@pytest.mark.parametrize("ngff_version", VERSIONS)
+def test_update_merges_and_refreshes_the_consolidated_metadata(tmp_path, ngff_version):
+    path = str(tmp_path / "image.ome.zarr")
+    multiscales = _multiscales()
+    multiscales.root_attributes = {"a": 1, "b": 2}
+    to_ome_zarr(path, multiscales, version=ngff_version)
+
+    update_root_attributes(path, {"b": 3, "c": 4})
+
+    assert from_ome_zarr(path).root_attributes == {"a": 1, "b": 3, "c": 4}
+    # zarr-python reads the consolidated copy first.
+    attrs = dict(zarr.open_group(path, mode="r").attrs)
+    assert (attrs["a"], attrs["b"], attrs["c"]) == (1, 3, 4)
+    assert len(from_ome_zarr(path).images) == 1
+
+
+def test_update_needs_a_store(tmp_path):
+    with pytest.raises(ValueError, match="root group"):
+        update_root_attributes(str(tmp_path / "missing.ome.zarr"), {"a": 1})
+
+
+def test_explicit_attributes_win_over_the_kept_ones(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    multiscales = _multiscales()
+    multiscales.root_attributes = {"a": 1, "keep": True}
+    to_ome_zarr(path, multiscales, version="0.4")
+
+    again = _multiscales()
+    again.root_attributes = {"a": 2}
+    to_ome_zarr(path, again, overwrite=True, version="0.4")
+
+    assert from_ome_zarr(path).root_attributes == {"a": 2, "keep": True}
+
+
+def test_metadata_only_store_carries_them_and_an_append_keeps_them(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    image = NgffImage(
+        da.zeros((1, 32, 32, 32), dtype=np.float32, chunks=(1, 16, 16, 16)),
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+    multiscales = to_multiscales(
+        image, scale_factors=[], chunks=(1, 16, 16, 16), cache=False
+    )
+    multiscales.root_attributes = dict(DIRECTION)
+    to_ome_zarr(path, multiscales, version="0.4", metadata_only=True)
+    assert from_ome_zarr(path).root_attributes == DIRECTION
+
+    base = from_ome_zarr(path).images[0]
+    pyramid = to_multiscales(
+        base, scale_factors=[2], chunks=(1, 16, 16, 16), cache=False
+    )
+    to_ome_zarr(path, pyramid, version="0.4", overwrite=False, start_level=1)
+
+    read = from_ome_zarr(path)
+    assert read.root_attributes == DIRECTION
+    assert len(read.images) == 2

--- a/py/test/test_to_ngff_zarr_metadata_only.py
+++ b/py/test/test_to_ngff_zarr_metadata_only.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import time
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import (
+    Methods,
+    NgffImage,
+    from_ome_zarr,
+    to_multiscales,
+    to_ngff_image,
+    to_ome_zarr,
+)
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+needs_zarr_v3 = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
+_METADATA_FILES = {".zarray", ".zattrs", ".zgroup", ".zmetadata", "zarr.json"}
+
+
+def _image(data):
+    return to_ngff_image(
+        data,
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+
+
+def _chunk_files(path):
+    return [
+        file
+        for file in Path(path).rglob("*")
+        if file.is_file() and file.name not in _METADATA_FILES
+    ]
+
+
+@pytest.mark.parametrize(
+    "ngff_version",
+    [
+        "0.4",
+        pytest.param("0.5", marks=needs_zarr_v3),
+        pytest.param("0.6", marks=needs_zarr_v3),
+    ],
+)
+def test_terabyte_store_is_created_without_computing(tmp_path, ngff_version):
+    data = da.zeros((1, 4096, 8192, 8192), dtype=np.float32, chunks=(1, 512, 512, 512))
+    multiscales = to_multiscales(
+        _image(data),
+        scale_factors=[2, 4],
+        chunks=(1, 512, 512, 512),
+        method=Methods.ITKWASM_BIN_SHRINK,
+        cache=False,
+    )
+    path = str(tmp_path / "image.ome.zarr")
+
+    start = time.perf_counter()
+    to_ome_zarr(path, multiscales, version=ngff_version, metadata_only=True)
+    assert time.perf_counter() - start < 10.0
+
+    assert _chunk_files(path) == []
+    root = zarr.open_group(path, mode="r")
+    for level, image in enumerate(multiscales.images):
+        array = root[f"scale{level}/image"]
+        assert array.shape == image.data.shape
+        assert array.dtype == np.float32
+        assert array.chunks == (1, 512, 512, 512)
+    assert len(from_ome_zarr(path).images) == 3
+
+
+def test_requested_chunks_are_kept(tmp_path):
+    data = da.zeros((2, 40, 96, 96), dtype=np.uint16, chunks=(1, 8, 32, 32))
+    multiscales = to_multiscales(
+        _image(data), scale_factors=[2], chunks=(1, 8, 32, 32), cache=False
+    )
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, multiscales, version="0.4", metadata_only=True)
+
+    root = zarr.open_group(path, mode="r")
+    assert root["scale0/image"].chunks == (1, 8, 32, 32)
+    assert root["scale1/image"].chunks == (1, 8, 32, 32)
+    assert root["scale1/image"].shape == (2, 20, 48, 48)
+
+
+def test_regions_filled_afterwards_round_trip(tmp_path):
+    shape = (1, 64, 64, 64)
+    values = np.random.default_rng(0).random(shape).astype(np.float32)
+    data = da.zeros(shape, dtype=np.float32, chunks=(1, 16, 64, 64))
+    multiscales = to_multiscales(
+        _image(data), scale_factors=[2], chunks=(1, 16, 64, 64), cache=False
+    )
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, multiscales, version="0.4", metadata_only=True)
+
+    level0 = zarr.open_array(path, path="scale0/image", mode="r+")
+    for start in range(0, shape[1], 16):
+        level0[:, start : start + 16] = values[:, start : start + 16]
+
+    read = from_ome_zarr(path)
+    np.testing.assert_array_equal(read.images[0].data.compute(), values)
+    assert read.images[1].data.shape == (1, 32, 32, 32)
+    assert read.images[1].data.compute().max() == 0.0
+
+
+@needs_zarr_v3
+def test_sharding_and_compression_are_applied(tmp_path):
+    from zarr.codecs import BloscCodec
+
+    data = da.zeros((1, 64, 128, 128), dtype=np.uint8, chunks=(1, 32, 32, 32))
+    multiscales = to_multiscales(
+        _image(data), scale_factors=[], chunks=(1, 32, 32, 32), cache=False
+    )
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(
+        path,
+        multiscales,
+        version="0.5",
+        metadata_only=True,
+        chunks_per_shard=2,
+        compressors=[BloscCodec(cname="lz4")],
+    )
+
+    array = zarr.open_array(path, path="scale0/image", mode="r")
+    assert array.shards == (1, 64, 64, 64)
+    assert array.chunks == (1, 32, 32, 32)
+    assert any(isinstance(codec, BloscCodec) for codec in array.compressors)
+    assert _chunk_files(path) == []
+
+
+def test_ozx_output_is_refused(tmp_path):
+    data = da.zeros((1, 8, 8, 8), dtype=np.uint8, chunks=(1, 8, 8, 8))
+    multiscales = to_multiscales(_image(data), scale_factors=[], cache=False)
+    with pytest.raises(ValueError, match="metadata_only"):
+        to_ome_zarr(
+            str(tmp_path / "image.ozx"), multiscales, version="0.5", metadata_only=True
+        )
+
+
+def test_default_still_writes_data(tmp_path):
+    values = np.random.default_rng(0).random((1, 16, 16, 16)).astype(np.float32)
+    multiscales = to_multiscales(_image(values), scale_factors=[], cache=False)
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, multiscales, version="0.4")
+    assert _chunk_files(path) != []
+
+
+@needs_zarr_v3
+def test_displacement_field_store(tmp_path):
+    data = da.zeros((2, 4096, 4096), dtype=np.float32, chunks=(2, 512, 512))
+    image = NgffImage(
+        data,
+        dims=["c", "y", "x"],
+        scale={"c": 1.0, "y": 0.5, "x": 0.5},
+        translation={"c": 0.0, "y": 0.0, "x": 0.0},
+        name="displacement_field",
+        axes_types={"c": "displacement"},
+    )
+    multiscales = to_multiscales(image, scale_factors=[], cache=False)
+    path = str(tmp_path / "field.ome.zarr")
+    to_ome_zarr(path, multiscales, version="0.6", metadata_only=True)
+
+    assert _chunk_files(path) == []
+    read = from_ome_zarr(path)
+    axes = read.metadata.intrinsic_coordinate_system.axes
+    assert [axis.type for axis in axes] == ["displacement", "space", "space"]
+    assert read.images[0].data.shape == (2, 4096, 4096)

--- a/py/test/test_to_ngff_zarr_overwrite_guard.py
+++ b/py/test/test_to_ngff_zarr_overwrite_guard.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import from_ome_zarr, to_multiscales, to_ngff_image, to_ome_zarr
+from ngff_zarr._zarrista_utils import open_lazy_array
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+
+
+def _multiscales(rng_seed=0, scale_factors=()):
+    data = np.random.default_rng(rng_seed).random((1, 64, 64, 64)).astype(np.float32)
+    image = to_ngff_image(
+        data,
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+    return to_multiscales(
+        image, scale_factors=list(scale_factors), chunks=(1, 32, 32, 32), cache=False
+    )
+
+
+@pytest.mark.parametrize(
+    "ngff_version",
+    [
+        "0.4",
+        pytest.param(
+            "0.5",
+            marks=pytest.mark.skipif(
+                zarr_version < version.parse("3.0.0b1"),
+                reason="zarr version < 3.0.0b1",
+            ),
+        ),
+    ],
+)
+def test_overwrite_of_read_store_raises(tmp_path, ngff_version):
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, _multiscales(), version=ngff_version)
+
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(
+        base, scale_factors=[2], chunks=(1, 32, 32, 32), cache=False
+    )
+    with pytest.raises(ValueError, match="reads its data from that store"):
+        to_ome_zarr(path, multiscales, overwrite=True, version=ngff_version)
+
+    group = "scale0/image"
+    assert zarr.open_group(path, mode="r")[group][:].max() > 0.0
+
+
+def test_read_store_written_to_other_path(tmp_path):
+    source = str(tmp_path / "source.ome.zarr")
+    to_ome_zarr(source, _multiscales(), version="0.4")
+
+    base = from_ome_zarr(source).images[0]
+    multiscales = to_multiscales(
+        base, scale_factors=[2], chunks=(1, 32, 32, 32), cache=False
+    )
+    destination = str(tmp_path / "destination.ome.zarr")
+    to_ome_zarr(destination, multiscales, overwrite=True, version="0.4")
+
+    written = zarr.open_group(destination, mode="r")["scale0/image"][:]
+    original = zarr.open_group(source, mode="r")["scale0/image"][:]
+    np.testing.assert_array_equal(written, original)
+
+
+def test_in_memory_multiscales_overwrites_in_place(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    multiscales = _multiscales()
+    to_ome_zarr(path, multiscales, version="0.4")
+    to_ome_zarr(path, multiscales, overwrite=True, version="0.4")
+
+    assert zarr.open_group(path, mode="r")["scale0/image"][:].max() > 0.0
+
+
+def test_materialized_data_overwrites_in_place(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, _multiscales(), version="0.4")
+
+    base = from_ome_zarr(path).images[0]
+    base.data = base.data.persist()
+    multiscales = to_multiscales(base, scale_factors=[], cache=False)
+    to_ome_zarr(path, multiscales, overwrite=True, version="0.4")
+
+    assert zarr.open_group(path, mode="r")["scale0/image"][:].max() > 0.0
+
+
+def test_image_opened_from_the_array_path_raises(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, _multiscales(), version="0.4")
+    image = to_ngff_image(
+        open_lazy_array(f"{path}/scale0/image"),
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+    multiscales = to_multiscales(image, scale_factors=[], cache=False)
+    with pytest.raises(ValueError, match="reads its data from that store"):
+        to_ome_zarr(path, multiscales, overwrite=True, version="0.4")

--- a/py/test/test_to_ngff_zarr_overwrite_guard.py
+++ b/py/test/test_to_ngff_zarr_overwrite_guard.py
@@ -100,3 +100,18 @@ def test_image_opened_from_the_array_path_raises(tmp_path):
     multiscales = to_multiscales(image, scale_factors=[], cache=False)
     with pytest.raises(ValueError, match="reads its data from that store"):
         to_ome_zarr(path, multiscales, overwrite=True, version="0.4")
+
+
+def test_level_alone_in_reading_the_store_raises(tmp_path):
+    """A level reading the store is caught even when no other level shares it.
+
+    The walk skips a layer another level already carried it past, so a level
+    whose read is its own has to be reached on its own turn.
+    """
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, _multiscales(scale_factors=[2]), version="0.4")
+
+    multiscales = _multiscales(rng_seed=1, scale_factors=[2])
+    multiscales.images[1].data = open_lazy_array(f"{path}/scale1/image")
+    with pytest.raises(ValueError, match=r"images\[1\] reads its data"):
+        to_ome_zarr(path, multiscales, overwrite=True, version="0.4")

--- a/py/test/test_to_ngff_zarr_root_attrs.py
+++ b/py/test/test_to_ngff_zarr_root_attrs.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import from_ome_zarr, to_multiscales, to_ngff_image, to_ome_zarr
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+needs_zarr_v3 = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
+
+
+def _multiscales(scale_factors=()):
+    data = np.random.default_rng(0).random((1, 64, 64, 64)).astype(np.float32)
+    image = to_ngff_image(
+        data,
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+    return to_multiscales(
+        image, scale_factors=list(scale_factors), chunks=(1, 32, 32, 32), cache=False
+    )
+
+
+@pytest.mark.parametrize(
+    "ngff_version", ["0.4", pytest.param("0.5", marks=needs_zarr_v3)]
+)
+def test_foreign_root_attrs_survive_overwrite(tmp_path, ngff_version):
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, _multiscales(), version=ngff_version)
+    zarr.open_group(path, mode="r+").attrs["mine"] = {"k": 1}
+
+    to_ome_zarr(path, _multiscales(), overwrite=True, version=ngff_version)
+
+    attrs = dict(zarr.open_group(path, mode="r").attrs)
+    assert attrs["mine"] == {"k": 1}
+    assert len(from_ome_zarr(path).images) == 1
+
+
+@needs_zarr_v3
+def test_version_change_drops_stale_ome_keys(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, _multiscales(), version="0.4")
+    zarr.open_group(path, mode="r+").attrs["mine"] = {"k": 1}
+
+    to_ome_zarr(path, _multiscales(), overwrite=True, version="0.5")
+
+    attrs = dict(zarr.open_group(path, mode="r").attrs)
+    assert attrs["mine"] == {"k": 1}
+    assert "ome" in attrs
+    assert "multiscales" not in attrs
+
+
+def test_overwrite_still_clears_previous_arrays(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, _multiscales(scale_factors=[2]), version="0.4")
+    assert "scale1" in zarr.open_group(path, mode="r")
+
+    to_ome_zarr(path, _multiscales(), overwrite=True, version="0.4")
+
+    assert "scale1" not in zarr.open_group(path, mode="r")
+
+
+def test_overwrite_of_missing_store_creates_it(tmp_path):
+    path = str(tmp_path / "new.ome.zarr")
+    to_ome_zarr(path, _multiscales(), overwrite=True, version="0.4")
+    assert len(from_ome_zarr(path).images) == 1

--- a/py/test/test_to_ngff_zarr_start_level.py
+++ b/py/test/test_to_ngff_zarr_start_level.py
@@ -7,6 +7,8 @@ import numpy as np
 import pytest
 import zarr
 from ngff_zarr import (
+    Methods,
+    NgffImage,
     from_ome_zarr,
     to_multiscales,
     to_ngff_image,
@@ -247,3 +249,35 @@ def test_interrupted_repeated_append_leaves_the_store_readable(tmp_path, monkeyp
     read = from_ome_zarr(path)
     assert len(read.images) == 1
     assert read.images[0].data.compute().max() > 0.0
+
+
+@needs_zarr_v3
+def test_displacement_field_keeps_its_axis_type_when_appending(tmp_path):
+    values = np.random.default_rng(0).random((2, 64, 64)).astype(np.float32)
+    image = NgffImage(
+        da.from_array(values, chunks=(2, 32, 32)),
+        dims=["c", "y", "x"],
+        scale={"c": 1.0, "y": 0.5, "x": 0.5},
+        translation={"c": 0.0, "y": 0.0, "x": 0.0},
+        name="displacement_field",
+        axes_types={"c": "displacement"},
+    )
+    path = str(tmp_path / "field.ome.zarr")
+    to_ome_zarr(
+        path, to_multiscales(image, scale_factors=[], cache=False), version="0.6"
+    )
+
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(
+        base,
+        scale_factors=[2],
+        method=Methods.DASK_BIN_SHRINK,
+        chunks=(2, 32, 32),
+        cache=False,
+    )
+    to_ome_zarr(path, multiscales, version="0.6", overwrite=False, start_level=1)
+
+    read = from_ome_zarr(path)
+    axes = read.metadata.intrinsic_coordinate_system.axes
+    assert [axis.type for axis in axes] == ["displacement", "space", "space"]
+    assert len(read.images) == 2

--- a/py/test/test_to_ngff_zarr_start_level.py
+++ b/py/test/test_to_ngff_zarr_start_level.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import (
+    from_ome_zarr,
+    to_multiscales,
+    to_ngff_image,
+    to_ome_zarr,
+)
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+needs_zarr_v3 = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
+CHUNKS = (1, 32, 32, 32)
+
+
+def _image(data):
+    return to_ngff_image(
+        data,
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+
+
+def _level0_store(path, ngff_version="0.4", shape=(1, 64, 64, 64)):
+    values = np.random.default_rng(0).random(shape).astype(np.float32)
+    multiscales = to_multiscales(
+        _image(values), scale_factors=[], chunks=CHUNKS, cache=False
+    )
+    to_ome_zarr(path, multiscales, version=ngff_version)
+    return values
+
+
+def _chunk_mtimes(path, level="scale0"):
+    return {
+        file: file.stat().st_mtime_ns
+        for file in (Path(path) / level).rglob("*")
+        if file.is_file() and not file.name.startswith(".") and file.name != "zarr.json"
+    }
+
+
+@pytest.mark.parametrize(
+    "ngff_version", ["0.4", pytest.param("0.5", marks=needs_zarr_v3)]
+)
+def test_append_level_leaves_level0_untouched(tmp_path, ngff_version):
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path, ngff_version)
+    zarr.open_group(path, mode="r+").attrs["mine"] = {"k": 1}
+    before = _chunk_mtimes(path)
+    assert before
+
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    expected = multiscales.images[1].data.compute()
+    to_ome_zarr(path, multiscales, version=ngff_version, overwrite=False, start_level=1)
+
+    assert _chunk_mtimes(path) == before
+    read = from_ome_zarr(path)
+    assert len(read.images) == 2
+    np.testing.assert_allclose(
+        read.images[1].data.compute(), expected, rtol=1e-5, atol=1e-6
+    )
+    assert read.images[1].scale["z"] == 2.0
+    assert dict(zarr.open_group(path, mode="r").attrs)["mine"] == {"k": 1}
+
+
+def test_append_two_levels_chains_from_disk(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2, 4], chunks=CHUNKS, cache=False)
+    to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+
+    read = from_ome_zarr(path)
+    assert [image.data.shape for image in read.images] == [
+        (1, 64, 64, 64),
+        (1, 32, 32, 32),
+        (1, 16, 16, 16),
+    ]
+
+
+def test_rerun_replaces_the_appended_levels(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+    to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+
+    read = from_ome_zarr(path)
+    assert len(read.images) == 2
+    assert read.images[1].data.compute().max() > 0.0
+
+
+def test_metadata_only_creates_only_the_new_levels(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    values = _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    to_ome_zarr(
+        path,
+        multiscales,
+        version="0.4",
+        overwrite=False,
+        start_level=1,
+        metadata_only=True,
+    )
+
+    read = from_ome_zarr(path)
+    np.testing.assert_array_equal(read.images[0].data.compute(), values)
+    assert read.images[1].data.shape == (1, 32, 32, 32)
+    assert read.images[1].data.compute().max() == 0.0
+
+
+def test_overwrite_with_start_level_is_refused(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    with pytest.raises(ValueError, match="overwrite=False"):
+        to_ome_zarr(path, multiscales, version="0.4", overwrite=True, start_level=1)
+    with pytest.raises(ValueError, match="out of range"):
+        to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=2)
+
+
+def test_missing_or_mismatched_level_is_refused(tmp_path):
+    values = np.random.default_rng(0).random((1, 64, 64, 64)).astype(np.float32)
+    multiscales = to_multiscales(
+        _image(values), scale_factors=[2], chunks=CHUNKS, cache=False
+    )
+    empty = str(tmp_path / "empty.ome.zarr")
+    with pytest.raises(ValueError, match="no readable array"):
+        to_ome_zarr(empty, multiscales, version="0.4", overwrite=False, start_level=1)
+
+    smaller = str(tmp_path / "smaller.ome.zarr")
+    _level0_store(smaller, shape=(1, 32, 32, 32))
+    with pytest.raises(ValueError, match="shape"):
+        to_ome_zarr(smaller, multiscales, version="0.4", overwrite=False, start_level=1)
+
+
+def test_level_read_from_the_array_it_replaces_is_refused(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+
+    stored = from_ome_zarr(path)
+    multiscales.images[1] = stored.images[1]
+    with pytest.raises(ValueError, match="replaces before its data is computed"):
+        to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+    assert zarr.open_group(path, mode="r")["scale1/image"][:].max() > 0.0
+
+
+def test_existing_store_without_start_level_names_the_options(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    with pytest.raises(ValueError, match="start_level"):
+        to_ome_zarr(path, multiscales, version="0.4", overwrite=False)
+
+
+def test_start_level_two_appends_from_level_one(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    first = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    to_ome_zarr(path, first, version="0.4", overwrite=False, start_level=1)
+
+    base = from_ome_zarr(path).images[0]
+    both = to_multiscales(base, scale_factors=[2, 4], chunks=CHUNKS, cache=False)
+    to_ome_zarr(path, both, version="0.4", overwrite=False, start_level=2)
+
+    read = from_ome_zarr(path)
+    assert [image.data.shape for image in read.images] == [
+        (1, 64, 64, 64),
+        (1, 32, 32, 32),
+        (1, 16, 16, 16),
+    ]
+    assert read.images[2].scale["x"] == 4.0
+
+
+def test_supplied_level_is_written_beside_the_existing_one(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    multiscales.images[1].data = da.full(
+        (1, 32, 32, 32), 7.0, chunks=CHUNKS, dtype=np.float32
+    )
+    to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+
+    level1 = zarr.open_group(path, mode="r")["scale1/image"][:]
+    np.testing.assert_array_equal(level1, 7.0)
+
+
+def test_interrupted_append_leaves_the_store_readable(tmp_path, monkeypatch):
+    import sys
+
+    writer_module = sys.modules["ngff_zarr.to_ngff_zarr"]
+
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+
+    def fail(*args, **kwargs):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(writer_module, "_write_array_with_zarrista", fail)
+    with pytest.raises(OSError):
+        to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+
+    read = from_ome_zarr(path)
+    assert len(read.images) == 1
+    assert read.images[0].data.compute().max() > 0.0
+
+
+def test_interrupted_repeated_append_leaves_the_store_readable(tmp_path, monkeypatch):
+    import sys
+
+    writer_module = sys.modules["ngff_zarr.to_ngff_zarr"]
+
+    path = str(tmp_path / "image.ome.zarr")
+    _level0_store(path)
+    base = from_ome_zarr(path).images[0]
+    multiscales = to_multiscales(base, scale_factors=[2], chunks=CHUNKS, cache=False)
+    to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+    assert len(from_ome_zarr(path).images) == 2
+
+    def fail(*args, **kwargs):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(writer_module, "_write_array_with_zarrista", fail)
+    with pytest.raises(OSError):
+        to_ome_zarr(path, multiscales, version="0.4", overwrite=False, start_level=1)
+
+    read = from_ome_zarr(path)
+    assert len(read.images) == 1
+    assert read.images[0].data.compute().max() > 0.0

--- a/py/test/test_to_ngff_zarr_supplied_levels.py
+++ b/py/test/test_to_ngff_zarr_supplied_levels.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import dataclasses
+
+import dask.array as da
+import numpy as np
+import zarr
+from ngff_zarr import from_ome_zarr, to_multiscales, to_ngff_image, to_ome_zarr
+
+
+def _multiscales():
+    data = np.random.default_rng(0).random((1, 64, 64, 64)).astype(np.float32)
+    image = to_ngff_image(
+        data,
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1, "z": 1, "y": 1, "x": 1},
+        translation={"c": 0, "z": 0, "y": 0, "x": 0},
+    )
+    return to_multiscales(image, scale_factors=[2], chunks=(1, 32, 32, 32), cache=False)
+
+
+def _constant_level(shape=(1, 32, 32, 32), value=7.0):
+    return da.full(shape, value, chunks=(1, 32, 32, 32), dtype=np.float32)
+
+
+def test_replaced_level_is_written_as_given(tmp_path):
+    multiscales = _multiscales()
+    multiscales.images[1] = dataclasses.replace(
+        multiscales.images[1], data=_constant_level()
+    )
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, multiscales, version="0.4")
+
+    level1 = zarr.open_group(path, mode="r")["scale1/image"][:]
+    np.testing.assert_array_equal(level1, 7.0)
+
+
+def test_level_data_assigned_in_place_is_written_as_given(tmp_path):
+    multiscales = _multiscales()
+    multiscales.images[1].data = _constant_level()
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, multiscales, version="0.4")
+
+    level1 = zarr.open_group(path, mode="r")["scale1/image"][:]
+    np.testing.assert_array_equal(level1, 7.0)
+
+
+def test_generated_levels_still_match_the_pipeline(tmp_path):
+    multiscales = _multiscales()
+    expected = multiscales.images[1].data.compute()
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, multiscales, version="0.4")
+
+    level1 = zarr.open_group(path, mode="r")["scale1/image"][:]
+    np.testing.assert_allclose(level1, expected, rtol=1e-5, atol=1e-6)
+    assert len(from_ome_zarr(path).images) == 2
+
+
+def test_hand_built_multiscales_has_no_generated_keys(tmp_path):
+    multiscales = _multiscales()
+    rebuilt = dataclasses.replace(multiscales, generated_data_keys=None)
+    rebuilt.images[1] = dataclasses.replace(rebuilt.images[1], data=_constant_level())
+    path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(path, rebuilt, version="0.4")
+
+    level1 = zarr.open_group(path, mode="r")["scale1/image"][:]
+    np.testing.assert_array_equal(level1, 7.0)


### PR DESCRIPTION
Closes #650.

Ten commits, one per change, in the order they were discussed in the issue. The writer changes are built on the zarrista backend of #654.

Bugs

- `to_ome_zarr(store, ms, overwrite=True)` where `ms` still read from `store` cleared the root before dask computed a chunk and wrote zeros without an error. The writer now scans each image's dask graph for the arrays it reads from a local store and refuses when one of them lies at or below the destination, with a message naming the alternatives. Materialized data (`persist()`) passes.
- Levels the caller replaced in a `to_multiscales` result were silently re-derived with the pipeline's method. `to_multiscales` records the dask key of each level it generates (`NgffMultiscales.generated_data_keys`); the writer re-derives only a level that still carries its key, and writes anything else as passed. The from-disk chaining that keeps the task graph shallow is unchanged for the canonical pipeline.
- Root attributes the writer does not own were dropped by `overwrite=True`. They are read from the existing root document and written back with the new metadata; the owned set is `{multiscales, omero, ome}` across versions, so a version change leaves no stale key. Only an absent store or root group yields nothing to keep; any other failure to read the root propagates, so an unreadable store is never cleared.
- `ITKWASM_BIN_SHRINK` aborted inside the wasm sandbox with no message on two inputs: a block past the heap limit, and an axis extent no chunking divides (the trailing block shrank to zero voxels). Block sizes are now checked when the graph is built (limits 1.25 GiB for the Gaussian and label filters, 1.75 GiB for BinShrink; measured aborts at 1.5 and 2.0 GiB; integer input to the Gaussian filter counts as float32, and chunks smaller than the Gaussian overlap count at the size `map_overlap` merges them to), and the source is trimmed to a multiple of the factor before blocks are mapped, which is BinShrink's own trim semantics.
- `from_ome_zarr` returned images without `axes_types`, so a displacement field appended to came back as a channel image. Both readers now pass non-default axis types on.

Features

- `Methods.DASK_BIN_SHRINK`: `dask.array.coarsen` with the remainder trimmed and integer means rounded half up. Bit-exact against itkwasm BinShrink on uint8, uint16, int16 and float32, including mixed per-axis factors; no native or wasm dependency, any chunk layout, no block-size limit; 64-bit integers take an integer-arithmetic path, so no bit is lost to float64.
- `to_ome_zarr(..., metadata_only=True)` writes the OME metadata and creates every scale array (shape, dtype, chunks, shards, codecs) without evaluating a dask graph or writing a chunk. A terabyte-sized `da.zeros` store is created in 0.3 s. Array creation is factored into `_create_scale_array`, which resolves chunks, shards and compression the way the region writer does, so a metadata-only array is configured exactly like one the writer fills. Not available for `.ozx`.
- `to_ome_zarr(..., overwrite=False, start_level=k)` appends levels to a store holding levels 0 to k-1: those are validated (shape, dtype), bound to their on-disk arrays and never rewritten; level k derives from level k-1 as stored; while the new arrays are written the root names only the levels it keeps, and receives the full multiscales entry once they are in place, so an interrupted call, first or repeated, leaves a store that reads as the levels it still holds; appended levels are replaced on rerun, and a level to be written that still reads the array it replaces is refused. An existing store written with `start_level=0` and `overwrite=False` now raises a ValueError naming both options instead of rewriting its arrays in place.
- Root attributes beside the OME metadata (a direction matrix, provenance, a processing log) are read into `NgffMultiscales.root_attributes` by `from_ome_zarr`, written back beside the OME keys by `to_ome_zarr`, over the ones an overwrite keeps, and merged into an existing store by `update_root_attributes`, which refreshes the consolidated metadata. The OME keys are derived from the multiscales and are refused.
- `open_array(store, path)` returns the handle of an array in a local store with `shape`, `dtype`, `chunks` and numpy-style reads and writes through zarrista (scalars and smaller arrays broadcast, an integer index drops its axis, values are cast to the stored dtype). A producer creates its store with `metadata_only=True` and fills the arrays through this handle with no other Zarr library.

Documentation: a "Create the store before its data" section in the Python guide covering the producer workflow (`cache=False`, chunk grid aligned with the regions each writer produces, whole shards when sharding), appending levels, and the `DASK_BIN_SHRINK` entry in the methods page.

Measurements (4.3 GB float32, NVMe, before the zarrista backend): metadata-only creation 15 ms against 4.3 s for the `da.zeros` stand-in (13.7 GB: 17 ms against 13.9 s); producer region fill 2.8 s against 6.4 s through `to_ome_zarr`; appending one bin-shrink level 11.9 s against 19.2 s for a full rewrite to a second path, which was the only correct route before.

Verified: full Python suite on Python 3.14 with zarrista 0.1.0 and zarr-python 3.2 as the test dependency (1189 passed), and the new test files under `test-zarr2` (zarr-python 2.18, Python 3.11). TypeScript is unaffected: its writer neither implements overwrite nor re-derives levels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Dask-based local-mean (`dask_bin_shrink`) downsampling without native or WebAssembly dependencies.
  - Added metadata-only store creation and support for appending or replacing multiscale levels.
  - Added root-level application metadata preservation and updates.
  - Added direct array access with NumPy-style reads and writes.
  - Improved axis metadata, displacement-field handling, sharding, compression, and chunk configuration.

- **Bug Fixes**
  - Added validation for oversized processing blocks and safer overwrite protection.
  - Improved incomplete downsampling-window handling and integer rounding.

- **Documentation**
  - Updated usage guidance and documented `use_tensorstore` deprecation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->