### PR TITLE
fix(py): keep the requested factor when it reaches the target size

### DIFF
--- a/py/ngff_zarr/methods/_support.py
+++ b/py/ngff_zarr/methods/_support.py
@@ -133,6 +133,30 @@ def _channel_dim_last(ngff_image: NgffImage) -> NgffImage:
     return result
 
 
+def _incremental_factor(previous_size: int, target_size: int, nominal: int) -> int:
+    """The integer factor that shrinks ``previous_size`` to ``target_size``.
+
+    ``nominal`` is the requested factor relative to the previous level, floored
+    when the ladder step is not an integer: a ``[2, 5]`` ladder steps by 2.5
+    and floors to 2. It is kept whenever ``floor(previous_size / nominal)`` is
+    the target, so a level asked for at 4x is shrunk 4x. Flooring the step can
+    only leave the level larger than the target, and the guard keeps it only
+    when it lands on the target exactly, so a floored step never shrinks past
+    the requested size. The search below runs only when the nominal factor
+    misses the target, which happens on ladders such as ``[2, 3]``.
+    """
+    if target_size <= 0:
+        return 1
+    if nominal >= 1 and int(previous_size / nominal) == target_size:
+        return nominal
+    factor = int(np.ceil(previous_size / (target_size + 0.5)))
+    if int(previous_size / factor) != target_size:
+        factor = max(1, int(previous_size / target_size))
+        if int(previous_size / factor) != target_size:
+            factor = max(1, int(np.ceil(previous_size / target_size)))
+    return max(1, factor)
+
+
 def _dim_scale_factors(
     dims, scale_factor, previous_dim_factors, original_image=None, previous_image=None
 ):
@@ -156,25 +180,10 @@ def _dim_scale_factors(
                     prev_dim_index = previous_image.dims.index(dim)
                     previous_size = previous_image.data.shape[prev_dim_index]
 
-                    # Calculate factor such that floor(previous_size / factor) = target_size
-                    if target_size > 0:
-                        # Start with the theoretical factor
-                        factor = int(np.ceil(previous_size / (target_size + 0.5)))
-                        # Verify this gives us the right size
-                        actual_size = int(previous_size / factor)
-                        if actual_size != target_size:
-                            # Adjust factor to get exact target
-                            factor = max(1, int(previous_size / target_size))
-                            actual_size = int(previous_size / factor)
-                            # If still not exact, try factor+1
-                            if actual_size != target_size:
-                                factor = max(
-                                    1, int(np.ceil(previous_size / target_size))
-                                )
-                        incremental_factor = max(1, factor)
-                    else:
-                        incremental_factor = 1
-                    result_scale_factors[dim] = incremental_factor
+                    nominal = int(scale_factor // previous_dim_factors.get(dim, 1))
+                    result_scale_factors[dim] = _incremental_factor(
+                        previous_size, target_size, nominal
+                    )
         else:
             # Fallback to old behavior when images not provided
             result_scale_factors = {
@@ -193,18 +202,10 @@ def _dim_scale_factors(
                 prev_dim_index = previous_image.dims.index(d)
                 previous_size = previous_image.data.shape[prev_dim_index]
 
-                if target_size > 0:
-                    factor = int(np.ceil(previous_size / (target_size + 0.5)))
-                    actual_size = int(previous_size / factor)
-                    if actual_size != target_size:
-                        factor = max(1, int(previous_size / target_size))
-                        actual_size = int(previous_size / factor)
-                        if actual_size != target_size:
-                            factor = max(1, int(np.ceil(previous_size / target_size)))
-                    incremental_factor = max(1, factor)
-                else:
-                    incremental_factor = 1
-                result_scale_factors[d] = incremental_factor
+                nominal = int(scale_factor[d] // previous_dim_factors.get(d, 1))
+                result_scale_factors[d] = _incremental_factor(
+                    previous_size, target_size, nominal
+                )
         else:
             result_scale_factors = {
                 d: int(scale_factor[d] / previous_dim_factors[d]) for d in scale_factor

--- a/py/test/test_incremental_scale_factors.py
+++ b/py/test/test_incremental_scale_factors.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import dask.array as da
+import numpy as np
+from ngff_zarr import Methods, NgffImage, to_multiscales
+from ngff_zarr.methods._support import _dim_scale_factors, _incremental_factor
+
+DIMS = ("c", "z", "y", "x")
+
+
+def _image(shape):
+    return NgffImage(
+        da.zeros(shape, dtype=np.uint8, chunks=shape),
+        DIMS,
+        dict.fromkeys(DIMS, 1.0),
+        dict.fromkeys(DIMS, 0.0),
+    )
+
+
+def test_requested_factor_is_kept_when_it_reaches_the_target():
+    # 15 / 4 floors to 3, and 4 already gets there: 5 would too, but was not asked for.
+    assert _incremental_factor(15, 3, 4) == 4
+    assert _incremental_factor(61, 15, 4) == 4
+    assert _incremental_factor(514, 128, 4) == 4
+
+
+def test_a_floored_ladder_step_is_used_only_when_it_lands_on_the_target():
+    # A [2, 5] ladder steps by 2.5 and floors to 2. A floored step is smaller
+    # than the exact ratio, so it can only leave the level larger than the
+    # target; it is used only when it lands on the target exactly, and the
+    # search answers whenever it misses.
+    for original in range(4, 400):
+        for previous_absolute, absolute in ((2, 5), (3, 7), (4, 10), (2, 11)):
+            previous = int(original / previous_absolute)
+            target = int(original / absolute)
+            if previous < 1 or target < 1:
+                continue
+            nominal = absolute // previous_absolute
+            if int(previous / nominal) == target:
+                assert _incremental_factor(previous, target, nominal) == nominal
+
+
+def test_search_runs_only_when_the_requested_factor_misses():
+    # A [2, 3] ladder: level 1 holds 7 of 15 samples and level 2 must hold 5;
+    # no integer factor gets there and the search answers as before.
+    assert _incremental_factor(7, 5, 1) == 2
+    assert _incremental_factor(15, 0, 4) == 1
+
+
+def test_odd_extents_keep_the_requested_factor():
+    image = _image((2, 15, 17, 19))
+    previous = dict.fromkeys(DIMS, 1)
+    factors = _dim_scale_factors(
+        DIMS, 4, previous, original_image=image, previous_image=image
+    )
+    assert factors == {"z": 4, "y": 4, "x": 4}
+    factors = _dim_scale_factors(
+        DIMS, {"z": 4, "y": 2}, previous, original_image=image, previous_image=image
+    )
+    assert factors == {"z": 4, "y": 2, "c": 1, "x": 1}
+
+
+def test_pyramid_scales_follow_the_requested_factors():
+    multiscales = to_multiscales(
+        _image((1, 61, 64, 64)),
+        scale_factors=[4, 16],
+        method=Methods.ITKWASM_BIN_SHRINK,
+        cache=False,
+    )
+    assert [image.data.shape for image in multiscales.images] == [
+        (1, 61, 64, 64),
+        (1, 15, 16, 16),
+        (1, 3, 4, 4),
+    ]
+    assert [image.scale["z"] for image in multiscales.images] == [1.0, 4.0, 16.0]
+    assert multiscales.images[2].translation["z"] == 7.5

--- a/ts/src/methods/itkwasm-shared.ts
+++ b/ts/src/methods/itkwasm-shared.ts
@@ -36,15 +36,34 @@ export interface DimFactors {
 }
 
 /**
- * Calculate the incremental factor needed to reach the target size from the previous size.
- * This ensures exact target sizes when downsampling incrementally.
+ * Calculate the incremental factor needed to reach the target size from the
+ * previous size, so downsampling incrementally lands on exact target sizes.
+ *
+ * `nominal` is the requested factor relative to the previous level, floored
+ * when the ladder step is not an integer: a `[2, 5]` ladder steps by 2.5 and
+ * floors to 2. It is kept whenever `floor(previousSize / nominal)` is the
+ * target, so a level asked for at 4x is shrunk 4x. Flooring the step can only
+ * leave the level larger than the target, and the guard keeps it only when it
+ * lands on the target exactly, so a floored step never shrinks past the
+ * requested size. The search below runs only when the nominal factor misses
+ * the target, which happens on ladders such as `[2, 3]`.
+ *
+ * Mirrors the Python port's `_incremental_factor`.
  */
 export function calculateIncrementalFactor(
   previousSize: number,
   targetSize: number,
+  nominal?: number,
 ): number {
   if (targetSize <= 0) {
     return 1;
+  }
+
+  if (
+    nominal !== undefined && nominal >= 1 &&
+    Math.floor(previousSize / nominal) === targetSize
+  ) {
+    return nominal;
   }
 
   // Start with the theoretical factor
@@ -97,9 +116,13 @@ export function dimScaleFactors(
           const prevDimIndex = previousImage.dims.indexOf(dim);
           const previousSize = previousImage.data.shape[prevDimIndex];
 
+          const nominal = Math.floor(
+            scaleFactor / (previousDimFactors[dim] || 1),
+          );
           dimFactors[dim] = calculateIncrementalFactor(
             previousSize,
             targetSize,
+            nominal,
           );
         } else {
           dimFactors[dim] = 1;
@@ -129,7 +152,14 @@ export function dimScaleFactors(
         const prevDimIndex = previousImage.dims.indexOf(dim);
         const previousSize = previousImage.data.shape[prevDimIndex];
 
-        dimFactors[dim] = calculateIncrementalFactor(previousSize, targetSize);
+        const nominal = Math.floor(
+          scaleFactor[dim] / (previousDimFactors[dim] || 1),
+        );
+        dimFactors[dim] = calculateIncrementalFactor(
+          previousSize,
+          targetSize,
+          nominal,
+        );
       }
     } else {
       // Fallback to old behavior when images not provided

--- a/ts/test/incremental_scale_factors_test.ts
+++ b/ts/test/incremental_scale_factors_test.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * The incremental factor keeps the requested one when it reaches the target.
+ *
+ * Mirrors `py/test/test_incremental_scale_factors.py`, so the two ports pick
+ * the same factor for the same ladder.
+ */
+
+import { assertEquals } from "@std/assert";
+import { calculateIncrementalFactor } from "../src/methods/itkwasm-shared.ts";
+
+Deno.test("the requested factor is kept when it reaches the target", () => {
+  // 15 / 4 floors to 3, and 4 already gets there: 5 would too, but was not
+  // asked for.
+  assertEquals(calculateIncrementalFactor(15, 3, 4), 4);
+  assertEquals(calculateIncrementalFactor(61, 15, 4), 4);
+  assertEquals(calculateIncrementalFactor(514, 128, 4), 4);
+});
+
+Deno.test("a floored ladder step is used only when it lands on the target", () => {
+  // A [2, 5] ladder steps by 2.5 and floors to 2. A floored step is smaller
+  // than the exact ratio, so it can only leave the level larger than the
+  // target; it is used only when it lands on the target exactly, and the
+  // search answers whenever it misses.
+  for (let original = 4; original < 400; original++) {
+    for (
+      const [previousAbsolute, absolute] of [[2, 5], [3, 7], [4, 10], [
+        2,
+        11,
+      ]]
+    ) {
+      const previous = Math.floor(original / previousAbsolute);
+      const target = Math.floor(original / absolute);
+      if (previous < 1 || target < 1) continue;
+      const nominal = Math.floor(absolute / previousAbsolute);
+      if (Math.floor(previous / nominal) === target) {
+        assertEquals(
+          calculateIncrementalFactor(previous, target, nominal),
+          nominal,
+        );
+      }
+    }
+  }
+});
+
+Deno.test("without a nominal factor the search still lands on the target", () => {
+  for (const [previous, target] of [[15, 3], [61, 15], [514, 128], [100, 33]]) {
+    const factor = calculateIncrementalFactor(previous, target);
+    assertEquals(Math.floor(previous / factor), target);
+  }
+});


### PR DESCRIPTION
`_dim_scale_factors` chooses the incremental factor of a level from the target size alone, and its search starts at `ceil(previous_size / (target_size + 0.5))`. That start overshoots the requested factor whenever the extent is a few voxels short of a multiple: 15 voxels at 4x gives a target of 3, the search starts at `ceil(15 / 3.5) = 5`, `floor(15 / 5)` is 3, and 5 is accepted although 4 reaches the same 3. The level is then shrunk 5x on that axis with a scale of 5 in its metadata, while the pyramid was asked for 4x.

Enumerated over extents up to 400: at 2x the search never deviates; at 3x it picks another factor for extents 3, 5 and 8; at 4x for 4 (factor 3), 7, 11 and 15 (factor 5); at 8x for 24 extents between 8 and 63. It compounds through a pyramid because each level derives from the previous one: a 61-slice volume with `scale_factors=[4, 16]` comes out with z scales `[1, 4, 20]`, since level 1 has 15 slices and 15 at 4x is the case above.

```python
image = NgffImage(da.zeros((1, 61, 64, 64), dtype=np.uint8), ["c", "z", "y", "x"], ...)
multiscales = to_multiscales(image, scale_factors=[4, 16], method=Methods.ITKWASM_BIN_SHRINK)
[i.scale["z"] for i in multiscales.images]  # [1, 4, 20] before, [1, 4, 16] after
```

Every method that downsamples incrementally goes through this helper, so `ITKWASM_GAUSSIAN`, `ITKWASM_BIN_SHRINK` and the writer's from-disk chaining were all affected the same way, and the affected levels were self-consistent: the data and the scale both said 5x, only the request said 4x.

The factor is now the requested one, relative to the previous level, whenever `floor(previous_size / requested)` is the target; the search runs only when the requested factor misses the target, which happens on ladders such as `[2, 3]`. The exact-size guarantee from a1a00cd is unchanged, since a level only keeps the requested factor when that factor already produces the exact size.

Tests cover the helper directly (15 at 4x, 61 at 4x, 514 at 4x keep 4; a `[2, 3]` ladder still searches), the per-axis form, and the 61-slice pyramid with its shapes, scales and translations. Found while checking `DASK_BIN_SHRINK` from #676 against a block mean computed with `dask.array.coarsen` on odd extents: the values differed because the factor did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved incremental downsampling to preserve requested scale factors when they match the target size.
  - Added more reliable fallback behavior for scalar and per-dimension scaling, including odd-sized images.
  - Improved consistency of multiscale pyramid shapes, scales, and translations.

- **Tests**
  - Added coverage for scale-factor selection, fallback behavior, odd-sized images, and multiscale pyramid generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->