### PR TITLE
docs: make docs/development.md the single contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@ This is a multi-language implementation of the OME Next Generation File Format
 - **`ts/`** - TypeScript/Deno implementation for web/Node environments
   (@fideus-labs/ngff-zarr)
 
+The human-facing contributor guide lives in `docs/development.md`, rendered at
+<https://ngff-zarr.readthedocs.io/en/latest/development.html>; `CONTRIBUTING.md`
+is a short pointer to it. When workflow, commit, or tooling conventions change,
+update `docs/development.md` alongside this file so the two stay in sync.
+
 ## Core Architecture Patterns
 
 ### Data Flow: The Multiscale Pipeline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ cd ts && pixi run --as-is test          # Deno test suite
 cd ts && pixi run --as-is lint          # Deno lint
 cd ts && pixi run --as-is fmt           # Deno format
 cd ts && pixi run --as-is build         # Full build pipeline
-cd ts && pixi run --as-is test:browser  # Browser compatibility tests
+cd ts && pixi run --as-is test-browser  # Browser compatibility tests
 cd ts && pixi run --as-is check         # Type checking
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,207 +6,31 @@ Welcome! 👋 We're glad you're interested in contributing to ngff-zarr. Whether
 you're fixing bugs, adding features, improving documentation, or helping with
 testing, your contributions are greatly appreciated. 🎉
 
+## 📖 Development guide
+
+The contributor documentation lives on ReadTheDocs:
+
+**➡️ [Development guide](https://ngff-zarr.readthedocs.io/en/latest/development.html)**
+
+It covers:
+
+- 🚀 Getting started: prerequisites, source checkout, and dependency setup
+- 🔄 The contributing workflow and pull request guidelines
+- 📝 Conventional Commit messages and version management
+- 🛠️ Development commands for the `py/`, `mcp/`, and `ts/` packages
+- 🧪 Testing, code style, building the docs, and updating the test data
+
+The page is generated from [`docs/development.md`](docs/development.md), so
+edits to the contributor documentation belong there.
+
 ## 📜 Code of Conduct
 
 Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). We are
 committed to providing a welcoming and inclusive environment for everyone.
 
-## 🚀 Getting Started
-
-### Prerequisites
-
-Install [pixi](https://pixi.sh) for environment management.
-
-### ⚙️ Setup
-
-1. Fork and clone the repository
-2. Install the Git hooks (managed by [prek](https://prek.j178.dev/)):
-   ```bash
-   cd py && pixi run prek-install
-   ```
-
-## 🔄 Contributing Workflow
-
-We use the standard GitHub pull request workflow:
-
-1. 💬 **Open an Issue First** - For significant changes, open a GitHub Issue to
-   discuss your proposal before starting work
-2. 🍴 **Fork the Repository** - Create your own fork
-3. 🌿 **Create a Branch** - Create a feature branch from `main`
-4. ✏️ **Make Changes** - Implement your changes with tests
-5. 💾 **Commit** - Use Conventional Commit messages
-6. 📤 **Push** - Push to your fork
-7. 📬 **Open a Pull Request** - Submit a PR against `main`
-
-### 📋 Pull Request Guidelines
-
-- ✅ **CI must pass** - All checks must be green before merge
-- 💬 **Be responsive** - Please respond to review comments in a timely manner
-- ⏳ **Be patient** - Reviews may take time; we appreciate your patience
-- 🤖 **Copilot reviews** - GitHub Copilot may flag false positives; if you
-  believe a suggestion is incorrect, leave a comment explaining why and
-  resolve as appropriate
-
-## 📝 Commit Messages
-
-We follow the [Conventional Commits](https://www.conventionalcommits.org/)
-standard. All commit messages are validated by Commitizen hooks (run via prek).
-
-### 📐 Format
-
-```
-<type>(<scope>): <description>
-
-[optional body]
-
-[optional footer]
-```
-
-### 🏷️ Types
-
-- ✨ `feat` - New feature
-- 🐛 `fix` - Bug fix
-- 📖 `docs` - Documentation changes
-- 🎨 `style` - Code style changes (formatting, etc.)
-- ♻️ `refactor` - Code refactoring
-- ⚡ `perf` - Performance improvements
-- 🧪 `test` - Adding or updating tests
-- 🏗️ `build` - Build system changes
-- 🔧 `ci` - CI/CD changes
-- 🧹 `chore` - Maintenance tasks
-
-### 🎯 Scopes (optional but recommended)
-
-- 🐍 `py` - Python package (ngff-zarr)
-- 🔌 `mcp` - MCP server package (ngff-zarr-mcp)
-- 🟦 `ts` - TypeScript package (@fideus-labs/ngff-zarr)
-
-### 💡 Examples
-
-```bash
-feat(py): add support for zarr v3 sharding
-fix(mcp): handle missing metadata gracefully
-docs: update installation instructions
-chore(ts): update dependencies
-```
-
-### 🧙 Interactive Commit Helper
-
-If you need help writing compliant commit messages, use the interactive CLI:
-
-```bash
-cd py && pixi run commit
-# or from other directories:
-cd ts && pixi run commit
-cd mcp && pixi run commit
-```
-
-This will guide you through creating a properly formatted commit message.
-
-### 🏷️ Version Management
-
-Check the current version of a package:
-
-```bash
-cd py && pixi run version-check   # Shows Python package version
-cd ts && pixi run version-check   # Shows TypeScript package version
-cd mcp && pixi run version-check  # Shows MCP package version
-```
-
-### 🛡️ Commit Message Validation
-
-The Git hooks will automatically validate your commit messages. If a
-commit message doesn't follow the Conventional Commits format, the commit will
-be rejected with helpful error messages.
-
-## 🗂️ Project Overview
-
-ngff-zarr is a multi-language implementation of the OME-NGFF Zarr
-specification:
-
-```
-ngff-zarr/
-├── py/          # Python package (ngff-zarr)
-├── mcp/         # Model Context Protocol server (ngff-zarr-mcp)
-├── ts/          # TypeScript/Deno package (@fideus-labs/ngff-zarr)
-└── docs/        # Documentation
-```
-
-### 🏛️ Core Architecture
-
-The central workflow follows this pattern across all implementations:
-
-1. **Input → NgffImage** - Convert various formats to `NgffImage`
-2. **NgffImage → NgffMultiscales** - Generate resolution levels via `to_multiscales()`
-3. **NgffMultiscales → OME-Zarr** - Write to zarr stores via `to_ngff_zarr()`
-4. **OME-Zarr → NgffMultiscales** - Read back via `from_ngff_zarr()`
-
-## 🛠️ Development Commands
-
-All development uses pixi for consistent environments.
-
-### 🐍 Python (`py/`)
-
-```bash
-cd py
-pixi install                    # Install dependencies
-pixi run test                   # Run test suite
-pixi run lint                   # Run linting
-pixi run build-docs             # Build documentation
-```
-
-### 🔌 MCP Server (`mcp/`)
-
-```bash
-cd mcp
-pixi install                    # Install dependencies
-pixi run test                   # Run tests
-pixi run typecheck              # Type checking (mypy)
-pixi run format                 # Format code
-pixi run lint                   # Run linting
-```
-
-### 🟦 TypeScript (`ts/`)
-
-```bash
-cd ts
-pixi run test                   # Deno test suite
-pixi run lint                   # Deno lint
-pixi run fmt                    # Deno format
-pixi run check                  # Type checking
-pixi run build                  # Full build
-pixi run test-browser           # Browser tests
-```
-
-## 🎨 Code Style
-
-### 🐍 Python
-
-- 📏 **Line length**: 88 characters (Black/Ruff standard)
-- 📦 **Imports**: Absolute imports, grouped by standard/third-party/local
-- 🔤 **Types**: Use type hints for public APIs
-- 🏷️ **Naming**: `snake_case` for functions/variables, `PascalCase` for classes
-- 📝 **Docstrings**: Required for public functions and classes
-
-Pre-commit hooks enforce style automatically via Ruff and Black.
-
-### 🟦 TypeScript
-
-- 🎨 **Style**: Deno standard (80 char width, 2 space indent, semicolons)
-- 🔤 **Types**: Strict TypeScript compiler options
-- 📦 **Imports**: JSR imports (`@std/assert`) and `npm:` prefix for npm packages
-
-## 🧪 Testing
-
-- 🐍 **Python**: Uses pytest with fixtures in `conftest.py`
-- 🟦 **TypeScript**: Uses Deno's built-in test runner
-- 🔌 **MCP**: Uses pytest with async patterns
-
-Run tests before submitting PRs to ensure nothing is broken. ✅
-
 ## ❓ Questions?
 
 If you have questions, please open a
-[GitHub Issue](https://github.com/thewtex/ngff-zarr/issues).
+[GitHub issue](https://github.com/fideus-labs/ngff-zarr/issues).
 
 Thank you for contributing! 💖

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ The main Python package provides:
 
 📖 **Documentation**
 
-More information about command line usage, the Python API, library features, and
-how to contribute can be found in
-[our documentation](https://ngff-zarr.readthedocs.io/).
+More information about command line usage, the Python API, and library features
+can be found in [our documentation](https://ngff-zarr.readthedocs.io/).
 
 ## TypeScript/JavaScript Package (`ts/`)
 
@@ -96,6 +95,13 @@ The Model Context Protocol server enables AI assistants like Claude to interact
 with NGFF-Zarr files. See the [MCP documentation](./mcp/README.md) for setup and
 usage instructions.
 
+## Contributing
+
+Contributions are welcome and appreciated! 🎉 The [development guide] covers
+environment setup, the pull request workflow, commit message conventions, and
+the development commands for each package. Please also read our
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
 ## See also
 
 - [ome-zarr-py](https://github.com/ome/ome-zarr-py)
@@ -113,4 +119,5 @@ usage instructions.
 [MIT](https://spdx.org/licenses/MIT.html) license.
 
 [Sharded Zarr]: https://zarr.dev/zeps/accepted/ZEP0002.html
+[development guide]: https://ngff-zarr.readthedocs.io/en/latest/development.html
 [zarrista]: https://github.com/developmentseed/zarrista

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,60 +2,280 @@
 <!-- SPDX-License-Identifier: MIT -->
 # 🔨 Development
 
-Contributions are welcome and appreciated!
+Welcome! 👋 We're glad you're interested in contributing to ngff-zarr. Whether
+you're fixing bugs, adding features, improving documentation, or helping with
+testing, your contributions are greatly appreciated. 🎉
 
-We are glad you are here and appreciate your contribution. Please keep in mind
-our
-[community participation guidelines](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CODE_OF_CONDUCT.md).
+## 📜 Code of Conduct
 
-## Get the source code
+Please read and follow our [Code of Conduct]. We are committed to providing a
+welcoming and inclusive environment for everyone.
+
+## 🗂️ Project overview
+
+ngff-zarr is a multi-language implementation of the OME-NGFF Zarr
+specification:
+
+```text
+ngff-zarr/
+├── py/          # Python package (ngff-zarr)
+├── mcp/         # Model Context Protocol server (ngff-zarr-mcp)
+├── ts/          # TypeScript/Deno package (@fideus-labs/ngff-zarr)
+└── docs/        # Documentation
+```
+
+### 🏛️ Core architecture
+
+The central workflow follows this pattern across all implementations:
+
+1. **Input → NgffImage** - Convert various formats to `NgffImage`
+2. **NgffImage → NgffMultiscales** - Generate resolution levels via
+   `to_multiscales()`
+3. **NgffMultiscales → OME-Zarr** - Write to Zarr stores via `to_ome_zarr()`
+4. **OME-Zarr → NgffMultiscales** - Read back via `from_ome_zarr()`
+
+## 🚀 Getting started
+
+### Prerequisites
+
+Install [pixi] for environment management.
+
+### Get the source code
 
 ```shell
-git clone https://github.com/thewtex/ngff-zarr
+git clone https://github.com/fideus-labs/ngff-zarr
 cd ngff-zarr
 ```
 
-## Install dependencies
+### ⚙️ Install dependencies
 
-First install [pixi]. Then, install project dependencies:
+Each package directory (`py/`, `ts/`, `mcp/`) carries its own pixi manifest.
+Install the Python environments and the Git hooks, which are managed by
+[prek]:
 
 ```shell
+cd py
 pixi install -a
 pixi run prek-install
 ```
 
-## Run the test suite
+`prek install` reads `default_install_hook_types` from
+`.pre-commit-config.yaml`, so it installs shims for both `pre-commit`
+(linting and formatting) and `commit-msg` (commit message validation).
 
-```shell
-pixi run test
+## 🔄 Contributing workflow
+
+We use the standard [GitHub flow]:
+
+1. 💬 **Open an issue first** - For significant changes, open a GitHub issue to
+   discuss your proposal before starting work
+2. 🍴 **Fork the repository** - Create your own fork
+3. 🌿 **Create a branch** - Create a feature branch from `main`
+4. ✏️ **Make changes** - Implement your changes with tests
+5. 💾 **Commit** - Use Conventional Commit messages
+6. 📤 **Push** - Push to your fork
+7. 📬 **Open a pull request** - Submit a PR against `main`
+
+### 📋 Pull request guidelines
+
+- ✅ **CI must pass** - All checks must be green before merge
+- 💬 **Be responsive** - Please respond to review comments in a timely manner
+- ⏳ **Be patient** - Reviews may take time; we appreciate your patience
+- 🤖 **Copilot reviews** - GitHub Copilot may flag false positives; if you
+  believe a suggestion is incorrect, leave a comment explaining why and
+  resolve as appropriate
+
+## 📝 Commit messages
+
+We follow the [Conventional Commits] standard. All commit messages are
+validated by Commitizen hooks, which run via prek.
+
+### 📐 Format
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
 ```
 
-## Build the documentation
+### 🏷️ Types
 
-If needed, build and update the documentation:
+- ✨ `feat` - New feature
+- 🐛 `fix` - Bug fix
+- 📖 `docs` - Documentation changes
+- 🎨 `style` - Code style changes (formatting, etc.)
+- ♻️ `refactor` - Code refactoring
+- ⚡ `perf` - Performance improvements
+- 🧪 `test` - Adding or updating tests
+- 🏗️ `build` - Build system changes
+- 🔧 `ci` - CI/CD changes
+- 🧹 `chore` - Maintenance tasks
+
+### 🎯 Scopes (optional but recommended)
+
+- 🐍 `py` - Python package (ngff-zarr)
+- 🔌 `mcp` - MCP server package (ngff-zarr-mcp)
+- 🟦 `ts` - TypeScript package (@fideus-labs/ngff-zarr)
+
+### 💡 Examples
+
+```bash
+feat(py): add support for zarr v3 sharding
+fix(mcp): handle missing metadata gracefully
+docs: update installation instructions
+chore(ts): update dependencies
+```
+
+### 🧙 Interactive commit helper
+
+If you need help writing compliant commit messages, use the interactive CLI:
+
+```bash
+# From the repository root, for whichever package you are committing:
+(cd py && pixi run commit)
+(cd ts && pixi run commit)
+(cd mcp && pixi run commit)
+```
+
+This will guide you through creating a properly formatted commit message.
+
+### 🛡️ Commit message validation
+
+The Git hooks automatically validate your commit messages. If a commit message
+doesn't follow the Conventional Commits format, the commit is rejected with a
+helpful error message.
+
+### 🏷️ Version management
+
+Each package is versioned independently. Check the current version of a
+package with:
+
+```bash
+(cd py && pixi run version-check)   # Python package version
+(cd ts && pixi run version-check)   # TypeScript package version
+(cd mcp && pixi run version-check)  # MCP package version
+```
+
+## 🛠️ Development commands
+
+All development uses pixi for consistent environments. Run the commands from
+the corresponding package directory.
+
+### 🐍 Python (`py/`)
+
+```bash
+cd py
+pixi install -a                 # Install all environments
+pixi run test                   # Run the test suite
+pixi run lint                   # Run the prek hooks (ruff, codespell, ...)
+pixi run build-docs             # Build the documentation
+```
+
+Run a single test with pytest directly:
+
+```bash
+pixi run -e test pytest test/test_to_multiscales.py::test_downsamples_when_size_is_exactly_double_chunk
+```
+
+### 🔌 MCP server (`mcp/`)
+
+```bash
+cd mcp
+pixi install -e dev             # Install the development environment
+pixi run test                   # Run tests
+pixi run typecheck              # Type checking (mypy)
+pixi run format                 # Format code
+pixi run lint                   # Run linting
+```
+
+### 🟦 TypeScript (`ts/`)
+
+```bash
+cd ts
+pixi run test                   # Deno test suite
+pixi run lint                   # Deno lint
+pixi run fmt                    # Deno format
+pixi run check                  # Type checking
+pixi run build                  # Full build
+pixi run test-browser           # Browser tests
+```
+
+## 🧪 Testing
+
+- 🐍 **Python**: pytest, with fixtures in `py/test/conftest.py`
+- 🟦 **TypeScript**: Deno's built-in test runner
+- 🔌 **MCP**: pytest with async patterns
+
+Run the tests before submitting a pull request to ensure nothing is broken. ✅
+
+## 🎨 Code style
+
+### 🐍 Python
+
+- 📏 **Line length**: 88 characters (Ruff standard)
+- 📦 **Imports**: Absolute imports, grouped by standard/third-party/local
+- 🔤 **Types**: Use type hints for public APIs
+- 🏷️ **Naming**: `snake_case` for functions/variables, `PascalCase` for classes
+- 📝 **Docstrings**: Required for public functions and classes
+
+Ruff, via the prek hooks, enforces the style automatically. Run
+`cd py && pixi run lint` before committing.
+
+### 🟦 TypeScript
+
+- 🎨 **Style**: Deno standard (80 char width, 2 space indent, semicolons)
+- 🔤 **Types**: Strict TypeScript compiler options
+- 📦 **Imports**: JSR imports (`@std/assert`) and the `npm:` prefix for npm
+  packages
+
+## 📖 Build the documentation
+
+If needed, build and update the documentation. This serves the docs locally
+and rebuilds them as you edit:
 
 ```shell
+cd py
 pixi run dev-docs
 ```
 
-## Update test data
+To build the HTML once, without the auto-reloading server:
+
+```shell
+cd py
+pixi run build-docs
+```
+
+## 🗃️ Update the test data
 
 If needed, update the testing data.
 
-1. Generate new test data tarball and compute its sha256 hash
+1. Add the new data to _py/test/data_, then generate a new tarball and compute
+   its sha256 hash:
 
-```shell
-pixi run hash-data
-```
+   ```shell
+   cd py
+   pixi run hash-data
+   ```
 
-2. Upload the data to [web3.storage](https://web3.storage)
+2. Upload the resulting `data.tar.gz` as an asset on the
+   [`testing-data` release], renamed with the next
+   `ngff-zarr-testing-data-v<version>.tar.gz` version.
 
-3. Upload the `test_data_ipfs_cid` (from web3.storage web UI) and
-   `test_data_sha256` (`sh256sum ../data.tar.gz`) variables in _test/\_data.py_.
+3. Update the `url` and `test_data_sha256` variables in _py/test/\_data.py_ to
+   point at the new asset and its hash.
 
-## Submit the patch
+## ❓ Questions?
 
-We use the standard [GitHub flow].
+If you have questions, please open a [GitHub issue].
 
-[pixi]: https://pixi.sh
+Thank you for contributing! 💖
+
+[Code of Conduct]: https://github.com/fideus-labs/ngff-zarr/blob/main/CODE_OF_CONDUCT.md
+[Conventional Commits]: https://www.conventionalcommits.org/
 [GitHub flow]: https://docs.github.com/en/get-started/using-github/github-flow
+[GitHub issue]: https://github.com/fideus-labs/ngff-zarr/issues
+[pixi]: https://pixi.sh
+[prek]: https://prek.j178.dev/
+[`testing-data` release]: https://github.com/fideus-labs/ngff-zarr/releases/tag/testing-data


### PR DESCRIPTION
Closes #678.

## Why

The contributor documentation lived in two places that had drifted apart.
`CONTRIBUTING.md` carried the workflow, commit conventions, and per-package
commands but is only visible on GitHub, while `docs/development.md` — the page
published at
[ngff-zarr.readthedocs.io/en/latest/development.html](https://ngff-zarr.readthedocs.io/en/latest/development.html)
and listed in the docs toctree — held a much thinner version of the same
material. Contributors arriving from the rendered documentation got the
shorter, staler guide.

This makes `docs/development.md` the single source and turns `CONTRIBUTING.md`
into a pointer at the rendered page.

## What changed

**`docs/development.md`** (61 → 291 lines) absorbs the `CONTRIBUTING.md`
content and keeps the material that only lived here (building the docs,
refreshing the test data), organized as: Code of Conduct → project overview and
core architecture → getting started → contributing workflow and pull request
guidelines → commit messages, interactive helper, validation, version
management → per-package development commands → testing → code style →
building the documentation → updating the test data → questions.

**`CONTRIBUTING.md`** (212 → 37 lines) is now a welcome, a prominent link to
the development guide with a summary of what it covers, a note that edits
belong in `docs/development.md`, the Code of Conduct link, and where to ask
questions.

**`README.md`** gains a top-level `## Contributing` section linking to the
rendered guide and the Code of Conduct. "How to contribute" had been buried in
the Python package's documentation blurb with no direct link, so that phrase is
dropped from there.

**`AGENTS.md`** notes that `docs/development.md` is the human-facing
counterpart and should be updated alongside it when workflow, commit, or
tooling conventions change. It previously had no reference to the contributor
docs at all, despite duplicating those conventions.

## Corrections made while merging

Several instructions in the old text no longer matched the repository:

- `pixi install -a` and `pixi run prek-install` now run from `py/`. There is no
  pixi manifest at the repository root, so the previous root-level invocation
  would have failed for anyone following it.
- The architecture summary uses `to_ome_zarr()` / `from_ome_zarr()` instead of
  the legacy `to_ngff_zarr()` / `from_ngff_zarr()` aliases, matching the naming
  rule in `AGENTS.md`.
- Ruff is named as the sole Python formatter. The old text said "Black/Ruff",
  but the prek hooks are `ruff` and `ruff-format`, with no Black anywhere.
- The test-data steps point at the
  [`testing-data` release](https://github.com/fideus-labs/ngff-zarr/releases/tag/testing-data),
  which is what `py/test/_data.py` actually downloads from. The previous
  web3.storage and IPFS steps described URLs that are commented out in that
  file. The `sh256sum` typo is fixed and "Upload the ... variables" is now
  "Update".
- The Code of Conduct links to this repository's own `CODE_OF_CONDUCT.md`
  rather than ITK's, and repository URLs use `fideus-labs/ngff-zarr` to match
  the badges in `docs/index.md`.
- The MCP install is `pixi install -e dev`, since the MCP tasks are defined in
  the `dev` feature.
- The multi-package `commit` and `version-check` examples are wrapped in
  subshells, e.g. `(cd py && pixi run commit)`, so each line runs independently
  from the repository root. As a bare sequence, `cd ts` would have failed from
  inside `py/`.

Every pixi task named in the guide was checked against `py/pyproject.toml`,
`ts/pixi.toml`, and `mcp/pyproject.toml`.

No changelog impact: `.commitizen/cz_ngff_zarr.py` already treats both
`CONTRIBUTING.md` and `docs/` as ambiguous (all-package) paths, so moving
content between them does not change filtering.

## Verification

- `sphinx-build -b html docs docs/_build/html` succeeds with no warnings, and
  `development.html` renders all eleven sections in order.
- Parsing the built HTML confirms all seven reference-style links resolve to
  real anchors, with no leftover literal `[Code of Conduct]`-style text. The
  only remaining brackets are `[optional body]` / `[optional footer]` inside
  the commit-message template, which is intended.
- Every documented URL returns HTTP 200, including the `testing-data` release
  and the ReadTheDocs development page.
- `prek run --files` passes on all four changed files.
- CodeRabbit review is clean; it raised untagged code fences and the
  non-runnable `cd` sequence noted above, both fixed here.

`docs/typescript.md` already linked to `./development.md`, so that link now
lands on the fuller page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the development guide with project structure, setup, workflows, pull-request guidance, commit conventions, testing, code style, documentation builds, and test-data procedures.
  - Updated the contribution guide to direct readers to centralized development documentation.
  - Added clearer contribution links and Code of Conduct references to the README.
  - Added guidance to keep contributor instructions synchronized across documentation.
  - Updated the browser test command name in contributor guidance for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->