### PR TITLE
docs: add the v0.43 → v0.44 zarrista migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ The main Python package provides:
 - Writes OME-Zarr v0.4 to v0.6
 - v0.6 adds RFC-5 coordinate systems and transformations
 - [Sharded Zarr] stores
-- Optional writing via zarr-python 2, zarr-python 3, [zarrista] or zarrita (TypeScript)
+- Zarr I/O backed by [zarrista] / Rust [zarrs] (Python) or zarrita
+  (TypeScript) -- no zarr-python dependency; OME-Zarr 0.4 (Zarr v2) outputs
+  stay readable by zarr-python 2 and 3, and 0.5+ (Zarr v3) by zarr-python 3
 - [Anatomical orientation metadata](./docs/rfc4.md) (RFC-4)
 - **OME-Zarr Zip (.ozx) file support** for single-file OME-Zarr datasets (RFC-9)
 - **High Content Screening (HCS) support** for plate and well data
@@ -114,3 +116,4 @@ usage instructions.
 
 [Sharded Zarr]: https://zarr.dev/zeps/accepted/ZEP0002.html
 [zarrista]: https://github.com/developmentseed/zarrista
+[zarrs]: https://zarrs.dev/

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -89,7 +89,10 @@ The same patterns work for other cloud providers (GCS, Azure) with their
 respective `storage_options`.
 
 **Remote writes** are not supported: write to a local directory and upload
-afterwards (for example with `aws s3 sync` or `rclone`).
+afterwards (for example with `aws s3 sync` or `rclone`). Passing a remote URL
+as a write target raises `TypeError: ngff-zarr writes to local directory
+paths; got str.` -- see
+[Remote writes are not supported](./migration_guides/v0-43_to_v0-44.md#remote-writes-are-not-supported).
 
 ## Zarr Backend and zarr-python Compatibility
 
@@ -102,9 +105,36 @@ zarr-python is not a dependency of ngff-zarr, and the two can be installed
 side by side without conflict.
 
 The stores ngff-zarr writes are standard OME-Zarr: version 0.4 uses the Zarr
-v2 format and versions 0.5+ use Zarr v3. They remain readable by zarr-python
-2 and 3 and by the other OME-Zarr implementations; ngff-zarr's test suite
-verifies round-trips against both zarr-python majors.
+v2 format and versions 0.5+ use Zarr v3. They remain readable by the other
+OME-Zarr implementations, and by zarr-python -- 0.4 stores by zarr-python 2
+and 3, and 0.5+ stores by zarr-python 3, since reading the Zarr v3 format
+requires the 3.x major. ngff-zarr's test suite verifies round-trips against
+both zarr-python majors.
+
+The switch happened in v0.44. See the
+[v0.43 to v0.44 Migration Guide](./migration_guides/v0-43_to_v0-44.md) for
+what it changes for you.
+
+### Which errors should I expect after upgrading to v0.44?
+
+v0.44 replaced zarr-python and tensorstore with the
+[zarrista](https://github.com/developmentseed/zarrista) backend. These are
+the errors that change signals, with a link to the full explanation and the
+migration for each:
+
+| Error | Cause | Full explanation |
+| --- | --- | --- |
+| `Package 'ngff-zarr' requires a different Python: 3.10.x not in '>=3.11'` | zarrista does not support Python 3.10 | [Python 3.11 or newer is required](./migration_guides/v0-43_to_v0-44.md#python-311-or-newer-is-required) |
+| `ModuleNotFoundError: No module named 'zarr'` | zarr-python is no longer a dependency of ngff-zarr | [zarr-python is no longer installed](./migration_guides/v0-43_to_v0-44.md#zarr-python-is-no-longer-installed) |
+| `TypeError: ngff-zarr reads from local directory paths, ...` | A zarr-python store object was passed for reading | [zarr-python store objects are no longer accepted](./migration_guides/v0-43_to_v0-44.md#zarr-python-store-objects-are-no-longer-accepted) |
+| `TypeError: ngff-zarr writes to local directory paths; got ...` | A zarr-python store object, in-memory mapping, or remote URL was passed as a write target | [Writing](./migration_guides/v0-43_to_v0-44.md#writing) and [Remote writes are not supported](./migration_guides/v0-43_to_v0-44.md#remote-writes-are-not-supported) |
+| `TypeError: config.cache_store must be a local directory path; got ...` | `config.cache_store` is now a cache directory path | [The cache store setting](./migration_guides/v0-43_to_v0-44.md#the-cache-store-setting) |
+| `ValueError: zarrista cannot write into zip archives (.zip/.ozx)` | A `.zip` write target. Only `.zip` reaches this check -- `to_ome_zarr` still writes `.ozx` through the RFC-9 path, despite the message naming both | [Writing](./migration_guides/v0-43_to_v0-44.md#writing) |
+| `TypeError: chunk_store is no longer supported` | Chunks and metadata always share one store | [The chunk_store argument is removed](./migration_guides/v0-43_to_v0-44.md#the-chunk-store-argument-is-removed) |
+| `DeprecationWarning: use_tensorstore is deprecated` | The fast direct-write path is always on now | [The tensorstore extra is removed](./migration_guides/v0-43_to_v0-44.md#the-tensorstore-extra-is-removed) |
+| `WARNING: ngff-zarr 0.44.0 does not provide the extra 'tensorstore'` | The `tensorstore` extra no longer exists | [The tensorstore extra is removed](./migration_guides/v0-43_to_v0-44.md#the-tensorstore-extra-is-removed) |
+| `ArrayCreateError: configuration is unsupported: data did not match any variant of untagged enum BloscCodecConfiguration` | A non-spec `nthreads` key in an array's blosc codec metadata | [Zarr metadata is validated more strictly on read](./migration_guides/v0-43_to_v0-44.md#zarr-metadata-is-validated-more-strictly-on-read) |
+| `ValueError: Unsupported zarr format 3 array-to-bytes codec 'sharding_indexed' in a mapping store` | Sharded stores cannot be read from an in-memory mapping | [In-memory mapping reads cover fewer stores](./migration_guides/v0-43_to_v0-44.md#in-memory-mapping-reads-cover-fewer-stores) |
 
 ### Why does passing a zarr-python store object raise `TypeError`?
 
@@ -125,17 +155,23 @@ Writing targets local directory paths (or `.ozx` archive paths); reading
 additionally accepts remote URLs and in-memory key-to-bytes mappings (a
 plain `dict` works). See
 [Read an OME-Zarr](./python.md#read-an-ome-zarr) for the full list of
-accepted store types.
+accepted store types, and
+[zarr-python store objects are no longer accepted](./migration_guides/v0-43_to_v0-44.md#zarr-python-store-objects-are-no-longer-accepted)
+for the full explanation and more migration examples.
 
 ### Why can't ngff-zarr read a Zarr v3 store with `nthreads` in its blosc codec metadata?
 
-Some tools wrote deprecated `nthreads`/`blocksize` keys into the blosc codec
-configuration of Zarr v3 array metadata. When these keys appear in a store's
-*consolidated* metadata (the root `zarr.json`), ngff-zarr tolerates and
-ignores them. When they appear in an individual array's `zarr.json`, the
-zarrista backend rejects the store as out-of-spec. To repair such a store,
-remove the two keys from the `blosc` codec `configuration` object in each
-array-level `zarr.json` document.
+Some tools wrote an `nthreads` key into the blosc codec configuration of Zarr
+v3 array metadata; it is a local decoding hint, not part of the spec. When it
+appears in a store's *consolidated* metadata (the root `zarr.json`),
+ngff-zarr tolerates and ignores it. When it appears in an individual array's
+`zarr.json`, the zarrista backend rejects the store as out-of-spec with
+`ArrayCreateError: configuration is unsupported: data did not match any
+variant of untagged enum BloscCodecConfiguration`. To repair such a store,
+remove the key from the `blosc` codec `configuration` object in each
+array-level `zarr.json` document; see
+[Zarr metadata is validated more strictly on read](./migration_guides/v0-43_to_v0-44.md#zarr-metadata-is-validated-more-strictly-on-read)
+for a script that does this.
 
 ## File Formats
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,8 +31,8 @@ A lean and kind
 - v0.6 adds RFC-5 coordinate systems and transformations
 - [Sharded Zarr] stores
 - Zarr I/O backed by [zarrista] / Rust [zarrs] (Python) or zarrita
-  (TypeScript) -- no zarr-python dependency; outputs stay readable by
-  zarr-python 2 and 3
+  (TypeScript) -- no zarr-python dependency; OME-Zarr 0.4 (Zarr v2) outputs
+  stay readable by zarr-python 2 and 3, and 0.5+ (Zarr v3) by zarr-python 3
 - [Anatomical orientation metadata](./rfc4.md) (RFC-4)
 - [Coordinate systems and transformations](./rfc5.md) (RFC-5)
 - **OME-Zarr Zip (.ozx) file support** for single-file OME-Zarr datasets (RFC-9)
@@ -58,6 +58,13 @@ itk.md
 methods.md
 faq.md
 development.md
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: 🔀 Migration Guides
+
+migration_guides/v0-43_to_v0-44.md
 ```
 
 ```{toctree}

--- a/docs/migration_guides/v0-43_to_v0-44.md
+++ b/docs/migration_guides/v0-43_to_v0-44.md
@@ -185,6 +185,7 @@ An in-memory `MemoryStore` becomes a plain mapping of the store's contents:
 ```python
 # Before
 from zarr.storage import MemoryStore
+from ngff_zarr import from_ome_zarr
 
 store = MemoryStore()
 # ... store populated elsewhere ...

--- a/docs/migration_guides/v0-43_to_v0-44.md
+++ b/docs/migration_guides/v0-43_to_v0-44.md
@@ -1,0 +1,566 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+# 🔀 v0.43 to v0.44
+
+## Purpose
+
+ngff-zarr v0.44 replaces [zarr-python] and [tensorstore] with [zarrista] --
+a Python Zarr implementation built on the Rust [zarrs] library -- as the
+engine behind writes and behind reads of paths, URLs, and archives. Reads
+from in-memory mappings use a small pure-Python reader instead, described in
+[In-memory mapping reads cover fewer stores](#in-memory-mapping-reads-cover-fewer-stores).
+After this release no module in `ngff_zarr` imports `zarr`, and
+`pip install ngff-zarr` no longer installs zarr-python or tensorstore.
+
+The motivation is a leaner, conflict-free install with one engine instead of
+three. Reads previously went through zarr-python, the fast write path went
+through tensorstore, and the two disagreed on codec metadata details.
+zarr-python was also the heaviest part of the dependency tree and the usual
+source of environment conflicts; it is now a *test-only* dependency whose
+sole job is verifying that zarrista-written stores are readable by the
+reference implementation.
+
+This guide covers what that swap means for you: what keeps working
+untouched, what breaks, the errors you will see, and the code change for
+each one.
+
+Most users need to change nothing. If your code writes to local paths with
+`to_ome_zarr` and reads local paths or remote URLs with `from_ome_zarr`, it
+already works on v0.44. The changes below matter if you pass zarr-python
+store objects, write to a remote URL, rely on zarr-python arriving
+transitively, or run Python 3.10.
+
+## What is compatible
+
+Nothing about the OME-Zarr data itself changed. The stores v0.44 writes were
+verified byte-equivalent to those written by v0.43 -- same file sets, same
+metadata documents, same pixels.
+
+| Area | Status |
+| --- | --- |
+| Stores written by earlier ngff-zarr releases | Read unchanged |
+| Stores written by v0.44 | Standard OME-Zarr, readable by other implementations. 0.4 is Zarr v2, readable by zarr-python 2 and 3; 0.5+ is Zarr v3, which requires zarr-python 3 |
+| Path-based `to_ome_zarr` / `from_ome_zarr` / `to_multiscales` calls | Unchanged |
+| Remote reads (`s3://`, `gs://`, `azure://`, `http(s)://`) and `storage_options` | Unchanged call surface -- fsspec-style option names still accepted |
+| `.ozx` archives (RFC-9) | Unchanged, read and write. `.zip` archives are read-only |
+| HCS plates and wells | Unchanged for path, URL, and `.ozx` stores |
+| RFC-4 anatomical orientation, RFC-5 coordinate systems, metadata validation | Unchanged |
+| Sharding (`chunks_per_shard`), chunking, compressor and codec arguments | Unchanged |
+| CLI flags and the `ngff-zarr` command | Unchanged |
+| Downsampling methods | Unchanged |
+| Installing zarr-python alongside ngff-zarr | Supported -- the two no longer conflict |
+
+## What is not compatible
+
+| Change | You hit it if... | Section |
+| --- | --- | --- |
+| Python >= 3.11 required | You run Python 3.10 | [Python 3.11 or newer is required](#python-311-or-newer-is-required) |
+| zarr-python is not installed as a dependency | Your code does `import zarr` without declaring it | [zarr-python is no longer installed](#zarr-python-is-no-longer-installed) |
+| zarr-python store objects rejected | You pass `LocalStore`, `MemoryStore`, `DirectoryStore`, ... | [zarr-python store objects are no longer accepted](#zarr-python-store-objects-are-no-longer-accepted) |
+| Remote writes unsupported | You write to an `s3://` / `gs://` / `azure://` URL | [Remote writes are not supported](#remote-writes-are-not-supported) |
+| `remote` extra is now just `obstore` | You relied on `ngff-zarr[remote]` to install `fsspec`, `s3fs`, ... | [The remote extra no longer pulls in fsspec](#the-remote-extra-no-longer-pulls-in-fsspec) |
+| `tensorstore` extra removed | You install `ngff-zarr[tensorstore]` or pass `use_tensorstore=True` | [The tensorstore extra is removed](#the-tensorstore-extra-is-removed) |
+| `chunk_store` removed | You pass `chunk_store=` to `to_ome_zarr` | [The chunk_store argument is removed](#the-chunk-store-argument-is-removed) |
+| Stricter Zarr metadata parsing | You read a store with out-of-spec codec metadata | [Zarr metadata is validated more strictly on read](#zarr-metadata-is-validated-more-strictly-on-read) |
+| Narrower in-memory mapping reads | You read a sharded store from a `dict` | [In-memory mapping reads cover fewer stores](#in-memory-mapping-reads-cover-fewer-stores) |
+
+## Python 3.11 or newer is required
+
+**What changed and why.** `requires-python` moved from `>=3.10` to `>=3.11`
+for both `ngff-zarr` and `ngff-zarr-mcp`. zarrista does not support Python
+3.10.
+
+**Error you will see.** `pip` refuses to install rather than failing at
+runtime:
+
+```text
+ERROR: Ignored the following versions that require a different python version: 0.44.0 Requires-Python >=3.11
+ERROR: Could not find a version that satisfies the requirement ngff-zarr==0.44.0
+```
+
+Or, when resolving in place:
+
+```text
+ERROR: Package 'ngff-zarr' requires a different Python: 3.10.14 not in '>=3.11'
+```
+
+**Migration.** Upgrade the interpreter to 3.11 or newer. Python 3.11, 3.12,
+3.13, and 3.14 are tested in CI. If you pin an interpreter in CI or a
+container image, bump it there too:
+
+```yaml
+# GitHub Actions, before
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.10"
+
+# After
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.11"
+```
+
+Staying on Python 3.10 means staying on ngff-zarr v0.43.
+
+## zarr-python is no longer installed
+
+**What changed and why.** `zarr` was a required runtime dependency in v0.43
+and is not a dependency at all in v0.44. zarrista handles Zarr I/O, and
+`numcodecs` -- previously a transitive dependency of zarr-python -- is now
+declared directly for the pure-Python mapping reader.
+
+This is what removes the environment conflicts: zarr-python and ngff-zarr can
+be installed side by side, in either version, without ngff-zarr constraining
+the resolution.
+
+**Error you will see.** Code that used zarr-python transitively now fails at
+import:
+
+```text
+ModuleNotFoundError: No module named 'zarr'
+```
+
+**Migration.** If you use zarr-python in your own code, declare it. It is a
+supported, conflict-free co-installation -- ngff-zarr's own test suite
+installs it to verify round-trips:
+
+```shell
+pip install ngff-zarr zarr
+```
+
+```toml
+# pyproject.toml
+dependencies = [
+  "ngff-zarr",
+  "zarr",
+]
+```
+
+If you only used zarr-python to hand a store object to ngff-zarr, you do not
+need it at all -- see the next section.
+
+## zarr-python store objects are no longer accepted
+
+**What changed and why.** `to_ome_zarr`, `from_ome_zarr`, `to_hcs_zarr`,
+`write_hcs_well_image`, and `upgrade_ome_zarr` no longer accept zarr-python
+store instances (`LocalStore`, `MemoryStore`, `DirectoryStore`,
+`FSStore`, ...). ngff-zarr has no zarr-python to construct or interpret them,
+so it takes the path or URL a store wraps and dispatches on that.
+
+### Reading
+
+`from_ome_zarr` accepts:
+
+- a local directory path (`str`, `pathlib.Path`, or `os.PathLike`)
+- a remote URL string (`s3://`, `gs://`, `azure://`, `http://`, `https://`),
+  with the `remote` extra installed
+- a `.ozx` / `.zip` archive path
+- an in-memory key-to-bytes `MutableMapping` -- a plain `dict` works
+
+Anything else raises `TypeError`:
+
+```text
+TypeError: ngff-zarr reads from local directory paths, remote URL strings, zip
+archive paths, and key-to-bytes mappings; got LocalStore. Pass a path instead
+of a zarr-python store object.
+```
+
+**Migration.** Pass the path the store wraps:
+
+```python
+# Before
+from zarr.storage import LocalStore
+from ngff_zarr import from_ome_zarr
+
+multiscales = from_ome_zarr(LocalStore("image.ome.zarr"))
+
+# After
+from ngff_zarr import from_ome_zarr
+
+multiscales = from_ome_zarr("image.ome.zarr")
+```
+
+An in-memory `MemoryStore` becomes a plain mapping of the store's contents:
+
+```python
+# Before
+from zarr.storage import MemoryStore
+
+store = MemoryStore()
+# ... store populated elsewhere ...
+multiscales = from_ome_zarr(store)
+
+# After: any key-to-bytes mapping works, including a plain dict
+store = {}  # keys are store-relative paths, values are the raw bytes
+multiscales = from_ome_zarr(store)
+```
+
+See [In-memory mapping reads cover fewer stores](#in-memory-mapping-reads-cover-fewer-stores)
+for the limits of the mapping reader.
+
+### Writing
+
+`to_ome_zarr` writes to a local directory path or a `.ozx` archive path.
+In-memory mappings, remote URLs, and zarr-python store objects raise
+`TypeError`:
+
+```text
+TypeError: ngff-zarr writes to local directory paths; got LocalStore. Pass a
+str, pathlib.Path, or os.PathLike directory path (write to a local directory
+and upload afterwards for remote targets). In-memory mappings and zarr-python
+store objects are no longer accepted.
+```
+
+**Migration.**
+
+```python
+# Before
+from zarr.storage import LocalStore
+from ngff_zarr import to_ome_zarr
+
+to_ome_zarr(LocalStore("image.ome.zarr"), multiscales)
+
+# After
+from ngff_zarr import to_ome_zarr
+
+to_ome_zarr("image.ome.zarr", multiscales)
+```
+
+Writing directly into a `.zip` is a separate error, because zarrista can only
+read zip archives:
+
+```text
+ValueError: zarrista cannot write into zip archives (.zip/.ozx). Write to a
+directory and zip it afterwards (see ngff_zarr.rfc9_zip).
+```
+
+The message names both extensions because it comes from the low-level store
+check, but only `.zip` reaches it. `.ozx` paths are handled earlier by the
+RFC-9 write path, which stages a directory and zips it for you, so they keep
+working:
+
+```python
+to_ome_zarr("image.ozx", multiscales, version="0.5")
+```
+
+To convert an existing directory store to an archive without recomputing,
+use `write_store_to_zip`:
+
+```python
+from ngff_zarr.rfc9_zip import write_store_to_zip
+
+write_store_to_zip("image.ome.zarr", "image.ozx", version="0.5")
+```
+
+### The cache store setting
+
+`config.cache_store` is now the cache *directory path*; large-image cache
+arrays are written into it through zarrista. A zarr-python store object
+raises:
+
+```text
+TypeError: config.cache_store must be a local directory path; got LocalStore.
+```
+
+**Migration.**
+
+```python
+# Before
+from zarr.storage import LocalStore
+from ngff_zarr import config
+
+config.cache_store = LocalStore("/fast/scratch/ngff-cache")
+
+# After
+from pathlib import Path
+from ngff_zarr import config
+
+config.cache_store = Path("/fast/scratch/ngff-cache")
+```
+
+The CLI equivalent, `--cache-dir`, is unchanged.
+
+## Remote writes are not supported
+
+**What changed and why.** v0.43 could write to remote stores through fsspec.
+The zarrista/obstore backend covers remote *reads* only, so remote write
+targets are rejected. Reads from http(s), S3, Google Cloud Storage, and Azure
+Blob Storage are unaffected, including `storage_options` authentication.
+
+**Error you will see.** A remote URL passed as a write target is handled by
+the same check as any other non-directory store:
+
+```text
+TypeError: ngff-zarr writes to local directory paths; got str. Pass a str,
+pathlib.Path, or os.PathLike directory path (write to a local directory and
+upload afterwards for remote targets). In-memory mappings and zarr-python
+store objects are no longer accepted.
+```
+
+**Migration.** Write locally, then upload:
+
+```python
+# Before
+to_ome_zarr("s3://my-bucket/image.ome.zarr", multiscales, version="0.5")
+
+# After
+to_ome_zarr("image.ome.zarr", multiscales, version="0.5")
+```
+
+```shell
+aws s3 sync image.ome.zarr s3://my-bucket/image.ome.zarr
+# or: rclone copy image.ome.zarr remote:my-bucket/image.ome.zarr
+```
+
+A single `.ozx` archive is often a better upload unit than a directory of many
+small objects:
+
+```python
+to_ome_zarr("image.ozx", multiscales, version="0.5")
+```
+
+```shell
+aws s3 cp image.ozx s3://my-bucket/image.ozx
+```
+
+## The remote extra no longer pulls in fsspec
+
+**What changed and why.** Remote reads route through zarrista's async API
+backed by [obstore] instead of fsspec. The `remote` extra shrank
+accordingly:
+
+| | v0.43 | v0.44 |
+| --- | --- | --- |
+| `remote` extra | `fsspec`, `aiohttp`, `requests`, `s3fs`, `gcsfs`, `adlfs` | `obstore` |
+
+**Migration.** Installation is unchanged:
+
+```shell
+pip install "ngff-zarr[remote]"
+```
+
+Read calls are unchanged too -- fsspec-style `storage_options` names (`key`,
+`secret`, `anon`, `token`, `endpoint_url`, `region_name`, ...) are translated
+to their obstore equivalents, and obstore-native names pass through as-is:
+
+```python
+from ngff_zarr import from_ome_zarr
+
+multiscales = from_ome_zarr(
+    "s3://ome-zarr-scivis/v0.5/96x2/carp.ome.zarr",
+    storage_options={"anon": True},
+)
+```
+
+If your own code imports `fsspec`, `s3fs`, `gcsfs`, or `adlfs`, declare them
+directly -- they no longer arrive with `ngff-zarr[remote]`:
+
+```shell
+pip install "ngff-zarr[remote]" s3fs
+```
+
+## The tensorstore extra is removed
+
+**What changed and why.** The fast direct-write path used to be opt-in via
+tensorstore. zarrista provides it natively, so the path is always on and the
+optional dependency is gone. The keyword and CLI flag survive as deprecated
+no-ops so existing callers keep running.
+
+**Errors and warnings you will see.** The extra no longer exists:
+
+```text
+WARNING: ngff-zarr 0.44.0 does not provide the extra 'tensorstore'
+```
+
+Passing the keyword warns:
+
+```text
+DeprecationWarning: use_tensorstore is deprecated; the fast direct-write path
+now uses the zarrista backend instead of tensorstore.
+```
+
+And on the command line:
+
+```text
+Warning: --use-tensorstore is deprecated; using the zarrista backend.
+```
+
+**Migration.** Drop the extra and the argument. There is no replacement to
+opt into -- the behavior it selected is now the default.
+
+```shell
+# Before
+pip install "ngff-zarr[tensorstore]"
+
+# After
+pip install ngff-zarr
+```
+
+```python
+# Before
+to_ome_zarr("image.ome.zarr", multiscales, use_tensorstore=True)
+
+# After
+to_ome_zarr("image.ome.zarr", multiscales)
+```
+
+```shell
+# Before
+ngff-zarr --use-tensorstore -i input.tif -o output.ome.zarr
+
+# After
+ngff-zarr -i input.tif -o output.ome.zarr
+```
+
+The MCP server's `use_tensorstore` option behaves the same way; see
+[MCP server changes](#mcp-server-changes).
+
+## The chunk store argument is removed
+
+**What changed and why.** `to_ome_zarr(..., chunk_store=...)` let chunks and
+metadata land in different zarr-python stores. The zarrista write path targets
+one local directory, so the argument no longer has a meaning and is rejected
+explicitly rather than silently ignored.
+
+**Error you will see.**
+
+```text
+TypeError: chunk_store is no longer supported: chunks and metadata are always
+written to the same local directory store.
+```
+
+**Migration.** Remove the argument:
+
+```python
+# Before
+to_ome_zarr("image.ome.zarr", multiscales, chunk_store="chunks")
+
+# After
+to_ome_zarr("image.ome.zarr", multiscales)
+```
+
+## Zarr metadata is validated more strictly on read
+
+**What changed and why.** zarrs parses Zarr v3 codec configurations against
+the specification. Some tools wrote an `nthreads` key into blosc codec
+configurations -- a local decoding hint that is not part of the Zarr v3 blosc
+codec spec. zarr-python tolerated it; zarrista rejects the array as
+out-of-spec. (The `blocksize` key often written alongside it *is* in the spec
+and is accepted.)
+
+ngff-zarr tolerates and ignores the key when it appears only in a store's
+*consolidated* metadata (the root `zarr.json`), which is read as a plain JSON
+document. When it appears in an individual array's `zarr.json`, the read
+fails.
+
+**Error you will see.**
+
+```text
+ArrayCreateError: configuration is unsupported: data did not match any variant
+of untagged enum BloscCodecConfiguration
+```
+
+**Migration.** Repair the store by removing the offending key from the
+`blosc` codec `configuration` object in each array-level `zarr.json`:
+
+```python
+import json
+from pathlib import Path
+
+for doc_path in Path("image.ome.zarr").rglob("zarr.json"):
+    doc = json.loads(doc_path.read_text())
+    changed = False
+    for codec in doc.get("codecs") or []:
+        if codec.get("name") == "blosc":
+            configuration = codec.get("configuration", {})
+            if "nthreads" in configuration:
+                del configuration["nthreads"]
+                changed = True
+    if changed:
+        doc_path.write_text(json.dumps(doc))
+```
+
+Re-writing the store with v0.44 also produces spec-conformant metadata.
+
+## In-memory mapping reads cover fewer stores
+
+**What changed and why.** Key-to-bytes mappings are still accepted by
+`from_ome_zarr`, but they are read by a pure-Python reader rather than by
+zarr-python. zarrista's `SyncStore` is a closed union with no hook for a
+custom mapping, so ngff-zarr ships its own reader for this case. It covers
+Zarr v2 fully, and Zarr v3 for *unsharded* arrays whose codec chain is the
+`bytes` codec plus gzip, zstd, or blosc compression.
+
+**Errors you will see.**
+
+```text
+ValueError: Unsupported zarr format 3 array-to-bytes codec 'sharding_indexed'
+in a mapping store; only the 'bytes' codec is supported. Sharded stores must
+be read through zarrista.
+```
+
+```text
+ValueError: Unsupported zarr format 3 codec 'lz4' in a mapping store.
+Supported bytes-to-bytes codecs: gzip, zstd, blosc; sharded stores must be
+read through zarrista.
+```
+
+**Migration.** Read the store from a path or URL instead of materializing it
+into a mapping -- that route goes through zarrista and handles sharding and
+the full codec set natively:
+
+```python
+# Sharded store as a mapping: unsupported
+multiscales = from_ome_zarr(mapping_of_store_contents)
+
+# As a directory path or .ozx archive: fully supported
+multiscales = from_ome_zarr("image.ome.zarr")
+multiscales = from_ome_zarr("image.ozx")
+```
+
+## MCP server changes
+
+`ngff-zarr-mcp` moves to the zarrista-backed core with a backward-compatible
+option surface:
+
+- **Python >= 3.11 is required**, as for `ngff-zarr`.
+- **`use_tensorstore` is still accepted** by `convert_to_ome_zarr` and is a
+  deprecated no-op. Its `DeprecationWarning` is suppressed so MCP responses
+  stay clean; remove the option at your convenience.
+- **zarr-python is no longer used at runtime.** Store inspection reads
+  metadata documents directly. `validate_ome_zarr` now also reports the
+  version of v0.5 stores, and `is_zarr_store` recognizes Zarr v3.
+- **Output paths must be local.** As with the Python API, write locally and
+  upload afterwards.
+
+## Migration checklist
+
+- [ ] Interpreter is Python 3.11 or newer, in dev environments and in CI.
+- [ ] `zarr` is declared as a direct dependency if your code imports it.
+- [ ] No zarr-python store objects are passed to `to_ome_zarr`,
+      `from_ome_zarr`, `to_hcs_zarr`, `write_hcs_well_image`, or
+      `upgrade_ome_zarr` -- pass paths or URLs.
+- [ ] `config.cache_store` is a directory path, not a store object.
+- [ ] Remote write targets are replaced by a local write plus an upload step.
+- [ ] `ngff-zarr[tensorstore]` is dropped from install commands and
+      requirement files.
+- [ ] `use_tensorstore=` / `--use-tensorstore` are removed from calls and
+      scripts.
+- [ ] `chunk_store=` is removed from `to_ome_zarr` calls.
+- [ ] `fsspec`, `s3fs`, `gcsfs`, and `adlfs` are declared directly if your
+      code imports them.
+
+## Further reading
+
+- [Frequently Asked Questions](../faq.md) -- short answers to the errors above
+- [Python Interface](../python.md) -- accepted store types and the zarrista
+  backend
+- [Installation](../installation.md) -- current optional dependency extras
+- [Pull request #654](https://github.com/fideus-labs/ngff-zarr/pull/654) --
+  the full implementation and rationale
+
+[zarr-python]: https://zarr.readthedocs.io/
+[tensorstore]: https://google.github.io/tensorstore/
+[zarrista]: https://github.com/developmentseed/zarrista
+[zarrs]: https://zarrs.dev/
+[obstore]: https://developmentseed.org/obstore/latest/

--- a/docs/python.md
+++ b/docs/python.md
@@ -319,9 +319,10 @@ The multiscales will be computed and written out-of-core, limiting memory usage.
 
 Writing (and local reading) is backed by [zarrista], a Python Zarr
 implementation built on the Rust [zarrs] library, which writes arrays through
-a fast direct-write path. Outputs remain fully spec-compliant: OME-Zarr 0.4
-(Zarr v2) and 0.5+ (Zarr v3) stores stay readable by zarr-python 2 and 3 and
-by other OME-Zarr implementations.
+a fast direct-write path. Outputs remain fully spec-compliant and readable by
+other OME-Zarr implementations: OME-Zarr 0.4 (Zarr v2) stores stay readable by
+zarr-python 2 and 3, and 0.5+ (Zarr v3) stores by zarr-python 3, which is the
+major that reads the Zarr v3 format.
 
 The `use_tensorstore` keyword is a deprecated no-op kept for backwards
 compatibility: the fast direct-write path it used to enable (first via

--- a/py/README.md
+++ b/py/README.md
@@ -29,8 +29,8 @@ implementation.
 - v0.6 adds RFC-5 coordinate systems and transformations
 - [Sharded Zarr] stores
 - Zarr I/O backed by [zarrista] / Rust [zarrs] (Python) or zarrita
-  (TypeScript) -- no zarr-python dependency; outputs stay readable by
-  zarr-python 2 and 3
+  (TypeScript) -- no zarr-python dependency; OME-Zarr 0.4 (Zarr v2) outputs
+  stay readable by zarr-python 2 and 3, and 0.5+ (Zarr v3) by zarr-python 3
 - [Anatomical orientation metadata][rfc4] (RFC-4)
 - **OME-Zarr Zip (.ozx) file support** for single-file OME-Zarr datasets (RFC-9)
 - **High Content Screening (HCS) support** for plate and well data

--- a/py/test/test_migration_guide_v0_44.py
+++ b/py/test/test_migration_guide_v0_44.py
@@ -38,6 +38,7 @@ BLOSC_COMPRESSOR = {
 
 
 def _multiscales():
+    """A single-scale 8x8 image, the smallest valid write payload."""
     return to_multiscales(np.zeros((8, 8), dtype=np.uint8), scale_factors=[])
 
 
@@ -71,6 +72,7 @@ class TestWriteTargetRejection:
     """`to_ome_zarr` writes to local directory and .ozx paths only."""
 
     def test_rejects_zarr_python_store_object(self, tmp_path):
+        """A zarr-python store object names itself in the write TypeError."""
         zarr_storage = pytest.importorskip("zarr.storage")
         if not hasattr(zarr_storage, "LocalStore"):
             pytest.skip("zarr-python 2.x stores are MutableMappings")
@@ -96,6 +98,7 @@ class TestWriteTargetRejection:
         assert "upload afterwards" in str(exc_info.value)
 
     def test_rejects_in_memory_mapping(self):
+        """Mappings are a read-only input form; writes reject them."""
         with pytest.raises(
             TypeError, match="ngff-zarr writes to local directory paths"
         ) as exc_info:
@@ -157,6 +160,7 @@ class TestArrayLevelNthreads:
     """Array-level `nthreads` is rejected, and the guide's script repairs it."""
 
     def test_array_level_nthreads_rejected(self, tmp_path):
+        """An array-level `nthreads` key fails the read the guide describes."""
         store_path = tmp_path / "nthreads.ome.zarr"
         _write_blosc_store(store_path)
         assert _inject_array_level_nthreads(store_path)

--- a/py/test/test_migration_guide_v0_44.py
+++ b/py/test/test_migration_guide_v0_44.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Pin the breaking-change contracts quoted in the v0.43 -> v0.44 guide.
+
+``docs/migration_guides/v0-43_to_v0-44.md`` quotes verbatim error messages
+and ships a repair script for stores carrying a non-spec ``nthreads`` blosc
+key. Users match on those strings to find the right section, so a reworded
+message silently invalidates the guide -- and the FAQ error table in
+``docs/faq.md`` that links into it.
+
+These tests assert the substrings the guide leads with. If one fails, update
+the guide, the FAQ table, and this module together.
+
+The read-side store-object rejection and the ``use_tensorstore`` deprecation
+warning are already pinned by ``test_from_ngff_zarr.py`` and
+``test_to_ngff_zarr_zarrista.py``; the consolidated-metadata tolerance for
+the legacy blosc keys is pinned by
+``test_from_ngff_zarr_reads_with_nthreads``. This module covers the
+documented behaviors those leave untested.
+"""
+
+import json
+
+import numpy as np
+import pytest
+from ngff_zarr import config, from_ome_zarr, to_multiscales, to_ome_zarr
+
+BLOSC_COMPRESSOR = {
+    "name": "blosc",
+    "configuration": {
+        "cname": "zstd",
+        "clevel": 5,
+        "shuffle": "shuffle",
+        "typesize": 1,
+        "blocksize": 0,
+    },
+}
+
+
+def _multiscales():
+    return to_multiscales(np.zeros((8, 8), dtype=np.uint8), scale_factors=[])
+
+
+def _write_blosc_store(path):
+    """Write a v0.5 store whose arrays use the blosc codec."""
+    to_ome_zarr(
+        str(path),
+        _multiscales(),
+        version="0.5",
+        compressors=[BLOSC_COMPRESSOR],
+    )
+
+
+def _inject_array_level_nthreads(root):
+    """Add the non-spec ``nthreads`` key to every array-level blosc codec."""
+    injected = False
+    for doc_path in root.rglob("zarr.json"):
+        doc = json.loads(doc_path.read_text())
+        changed = False
+        for codec in doc.get("codecs") or []:
+            if codec.get("name") == "blosc":
+                codec["configuration"]["nthreads"] = 4
+                changed = True
+        if changed:
+            doc_path.write_text(json.dumps(doc))
+            injected = True
+    return injected
+
+
+class TestWriteTargetRejection:
+    """`to_ome_zarr` writes to local directory and .ozx paths only."""
+
+    def test_rejects_zarr_python_store_object(self, tmp_path):
+        zarr_storage = pytest.importorskip("zarr.storage")
+        if not hasattr(zarr_storage, "LocalStore"):
+            pytest.skip("zarr-python 2.x stores are MutableMappings")
+
+        with pytest.raises(
+            TypeError, match="ngff-zarr writes to local directory paths"
+        ) as exc_info:
+            to_ome_zarr(
+                zarr_storage.LocalStore(str(tmp_path / "out.ome.zarr")),
+                _multiscales(),
+            )
+
+        message = str(exc_info.value)
+        assert "zarr-python store objects are no longer accepted" in message
+
+    def test_rejects_remote_url(self):
+        """Remote writes are unsupported; the guide says upload afterwards."""
+        with pytest.raises(
+            TypeError, match="ngff-zarr writes to local directory paths"
+        ) as exc_info:
+            to_ome_zarr("s3://my-bucket/image.ome.zarr", _multiscales())
+
+        assert "upload afterwards" in str(exc_info.value)
+
+    def test_rejects_in_memory_mapping(self):
+        with pytest.raises(
+            TypeError, match="ngff-zarr writes to local directory paths"
+        ) as exc_info:
+            to_ome_zarr({}, _multiscales())
+
+        assert "In-memory mappings" in str(exc_info.value)
+
+    def test_rejects_zip_target(self, tmp_path):
+        """.zip is read-only; .ozx goes through the RFC-9 staging path."""
+        with pytest.raises(
+            ValueError, match="cannot write into zip archives"
+        ) as exc_info:
+            to_ome_zarr(str(tmp_path / "image.zip"), _multiscales())
+
+        assert "rfc9_zip" in str(exc_info.value)
+
+    def test_accepts_ozx_target(self, tmp_path):
+        """The .ozx counterexample the guide gives must keep working."""
+        ozx_path = tmp_path / "image.ozx"
+        to_ome_zarr(str(ozx_path), _multiscales(), version="0.5")
+
+        assert ozx_path.is_file()
+
+
+def test_chunk_store_rejected(tmp_path):
+    """`chunk_store` is rejected explicitly, not silently ignored."""
+    with pytest.raises(
+        TypeError, match="chunk_store is no longer supported"
+    ) as exc_info:
+        to_ome_zarr(
+            str(tmp_path / "out.ome.zarr"),
+            _multiscales(),
+            chunk_store=str(tmp_path / "chunks"),
+        )
+
+    assert "always written to the same local directory store" in str(exc_info.value)
+
+
+def test_cache_store_must_be_a_directory_path(tmp_path):
+    """`config.cache_store` is a directory path, not a store object."""
+    zarr_storage = pytest.importorskip("zarr.storage")
+    if not hasattr(zarr_storage, "LocalStore"):
+        pytest.skip("zarr-python 2.x stores are MutableMappings")
+
+    original = config.cache_store
+    config.cache_store = zarr_storage.LocalStore(str(tmp_path / "cache"))
+    try:
+        from ngff_zarr.to_multiscales import _CacheTarget
+
+        with pytest.raises(
+            TypeError, match="config.cache_store must be a local directory path"
+        ):
+            _CacheTarget.from_config()
+    finally:
+        config.cache_store = original
+
+
+class TestArrayLevelNthreads:
+    """Array-level `nthreads` is rejected, and the guide's script repairs it."""
+
+    def test_array_level_nthreads_rejected(self, tmp_path):
+        store_path = tmp_path / "nthreads.ome.zarr"
+        _write_blosc_store(store_path)
+        assert _inject_array_level_nthreads(store_path)
+
+        # zarrista raises ArrayCreateError from the Rust binding; it is not
+        # exported from the package namespace, so match on the message the
+        # guide and the FAQ table quote instead of the type.
+        with pytest.raises(Exception) as exc_info:
+            from_ome_zarr(str(store_path))
+
+        assert "BloscCodecConfiguration" in str(exc_info.value)
+
+    def test_blocksize_alone_is_accepted(self, tmp_path):
+        """`blocksize` is in the spec; only `nthreads` breaks the read.
+
+        The guide says so explicitly, so an over-broad repair that also
+        stripped `blocksize` would be unnecessary.
+        """
+        store_path = tmp_path / "blocksize.ome.zarr"
+        _write_blosc_store(store_path)
+        for doc_path in store_path.rglob("zarr.json"):
+            doc = json.loads(doc_path.read_text())
+            for codec in doc.get("codecs") or []:
+                if codec.get("name") == "blosc":
+                    codec["configuration"]["blocksize"] = 0
+            doc_path.write_text(json.dumps(doc))
+
+        assert from_ome_zarr(str(store_path)) is not None
+
+    def test_documented_repair_script_restores_readability(self, tmp_path):
+        """Run the guide's repair snippet verbatim and read the store back."""
+        store_path = tmp_path / "repair.ome.zarr"
+        _write_blosc_store(store_path)
+        assert _inject_array_level_nthreads(store_path)
+
+        # --- as published in the migration guide ---
+        for doc_path in store_path.rglob("zarr.json"):
+            doc = json.loads(doc_path.read_text())
+            changed = False
+            for codec in doc.get("codecs") or []:
+                if codec.get("name") == "blosc":
+                    configuration = codec.get("configuration", {})
+                    if "nthreads" in configuration:
+                        del configuration["nthreads"]
+                        changed = True
+            if changed:
+                doc_path.write_text(json.dumps(doc))
+        # --- end of published snippet ---
+
+        multiscales = from_ome_zarr(str(store_path))
+        np.testing.assert_array_equal(
+            multiscales.images[0].data.compute(),
+            np.zeros((8, 8), dtype=np.uint8),
+        )


### PR DESCRIPTION
## Summary

Adds `docs/migration_guides/v0-43_to_v0-44.md`, a user-facing migration guide for the zarrista swap landed in #654, so that someone upgrading can go from an error they hit to the change that caused it and the code that fixes it.

v0.44 replaces zarr-python and tensorstore with [zarrista](https://github.com/developmentseed/zarrista) for all Zarr I/O. The stores on disk are unchanged, but the *call surface* moved in several places at once — store objects, Python floor, extras, remote writes. Those breaks were documented in the #654 description for reviewers; this puts them where upgraders will actually look.

Closes #683.

## What's in the guide

Purpose first, then a two-table overview of what is and isn't compatible, then one section per break — each written as **what changed and why → the error it raises → the migration**, with before/after code:

| Section | Trigger |
| --- | --- |
| Python 3.11 or newer is required | Running Python 3.10 |
| zarr-python is no longer installed | `import zarr` without declaring it |
| zarr-python store objects are no longer accepted | `LocalStore`, `MemoryStore`, …, incl. reads, writes, and `config.cache_store` |
| Remote writes are not supported | Writing to an `s3://` / `gs://` / `azure://` URL |
| The remote extra no longer pulls in fsspec | Relying on `ngff-zarr[remote]` for `s3fs`, `gcsfs`, … |
| The tensorstore extra is removed | `ngff-zarr[tensorstore]`, `use_tensorstore=True`, `--use-tensorstore` |
| The chunk store argument is removed | `to_ome_zarr(..., chunk_store=...)` |
| Zarr metadata is validated more strictly on read | A non-spec `nthreads` key in array-level blosc metadata |
| In-memory mapping reads cover fewer stores | Reading a sharded store from a `dict` |

It closes with MCP server changes, a migration checklist, and further reading.

**FAQ error index.** `docs/faq.md` gains a table of the 11 errors that change signal in v0.44, each with a one-line cause and a link into the section that explains it — the "brief mention plus link" the issue asked for. The three existing zarrista FAQ entries now link into the guide too.

## Every error message was reproduced, not transcribed

The guide's value depends on its quoted strings matching what users actually see, so each one was produced by running the code rather than copied from the #654 description: the read/write `TypeError`s, the `use_tensorstore` `DeprecationWarning`, the `.zip` write `ValueError`, the `chunk_store` `TypeError`, and the blosc `ArrayCreateError`. The `nthreads` repair snippet was run against a deliberately broken store and confirmed to restore readability.

That exercise corrected one detail carried over from the existing FAQ, which named `nthreads` **and** `blocksize` as out-of-spec. Only `nthreads` triggers rejection — `blocksize` is part of the Zarr v3 blosc codec spec and reads fine on its own, so the published repair script no longer strips it.

## Drive-by fix: the zarr-python compatibility claim

Five files stated that ngff-zarr outputs "stay readable by zarr-python 2 and 3". That is true only for OME-Zarr 0.4 (Zarr v2); 0.5+ is Zarr v3 and needs zarr-python 3. This repo's own suite already encodes the distinction — `test_issue_488.py` skips with `reason="OME-Zarr 0.5 requires zarr v3"`.

Corrected in `README.md`, `py/README.md`, `docs/index.md`, `docs/python.md`, and `docs/faq.md`. The root `README.md` was additionally still advertising *"Optional writing via zarr-python 2, zarr-python 3, tensorstore"* — pre-existing text from `9794456` that #654 updated in `py/README.md` and `docs/index.md` but missed at the root, and which directly contradicts this guide.

## Tests

`py/test/test_migration_guide_v0_44.py` (10 tests) pins the contracts the guide quotes. Users match on these strings to find the right section, so a reworded message silently invalidates both the guide and the FAQ table that links to it; the module's docstring says to update all three together.

An audit against the existing 103 test files found the read-side store rejection, the `use_tensorstore` warning, and the consolidated-metadata `nthreads` tolerance already covered. These five were not:

- write-target `TypeError` for store objects, remote URLs, and in-memory mappings
- `.zip` write `ValueError`, plus the `.ozx` counterexample the guide gives as the fix
- `chunk_store` rejection
- `config.cache_store` rejection
- array-level `nthreads` rejection — including running the guide's published repair snippet **verbatim** and reading the store back, so the snippet cannot silently rot

The assertions were mutation-checked: rewording an error message in `to_ngff_zarr.py` made the corresponding test fail, confirming they are not vacuous.

One test catches bare `Exception`. That is deliberate and commented — zarrista raises `ArrayCreateError` from the Rust binding and does not export it from the package namespace, so the message is matched instead of the type.

## Verification

- 143 tests pass across the new module plus the seven adjacent zarrista/read/write/cache suites
- Sphinx `build-docs` completes with no warnings; a script over the built HTML confirms every inter-document anchor resolves to a real `id`
- All reference-style Markdown links resolve across the six touched files
- `prek run` passes on every changed file with no modifications
- CodeRabbit: five review passes, every finding verified against the source and fixed (compatibility claim, a `to_ome_zarr`-accepts-URLs self-contradiction, legacy `to_ngff_zarr` aliases in the new test per `AGENTS.md`, untagged code fences, an overstated "every read and write" claim, and `.zip`/`.ozx` ambiguity)

## Note on scope

This covers the zarrista migration only, per the issue. It does not cover the other post-v0.43 breaking change on this branch — `65a0e10`, the OME-Zarr 0.6rc0 `byDimension` and top-level transform output. If v0.44 ships with that included, it likely warrants its own section here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive v0.43–v0.44 migration guidance, including compatibility requirements, changed errors, rejected write targets, and migration examples.
  * Clarified Zarr and OME-Zarr interoperability across versions, including supported Python versions and backend behavior.
  * Documented remote-write limitations, store guidance, Blosc metadata validation, and repair instructions.

* **Tests**
  * Added coverage for migration behaviors, invalid write configurations, metadata errors, supported output formats, and repair workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->