### PR TITLE
feat(py): validate 0.9.dev1 stores against the bundled schemas

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,9 +197,8 @@ ngff-zarr upgrade src.zarr -o dst.zarr --to 0.5
 
 The target version is selected with `--to` (alias `--version`), one of `0.4`,
 `0.5`, `0.6`, or `0.9.dev1` (default `0.6`). `0.9.dev1` is the development
-version that adopts RFC-3; OME publishes no JSON Schema for it yet, so
-`--validate` cannot check a store at that version. Add `--validate` to validate
-the source metadata against the NGFF schema while reading. For the write-to-new-store mode,
+version that adopts RFC-3. Add `--validate` to validate the source metadata
+against the NGFF schema while reading. For the write-to-new-store mode,
 `--overwrite` (the default) replaces any pre-existing data at the output store,
 while `--no-overwrite` refuses to; both flags are ignored for an in-place
 upgrade, which never overwrites array data.

--- a/docs/spec_features.md
+++ b/docs/spec_features.md
@@ -40,9 +40,9 @@ supported by `ngff-zarr`.
   and transformations.
 - **OME-Zarr 0.9.dev1**: Reads and writes the development version that adopts
   RFC-3, which extends support for the number, names, types and order
-  of axes. It is opt-in: pass `version="0.9.dev1"` explicitly. The default
-  target is unchanged, and OME publishes no JSON Schema for it yet, so schema
-  validation is unavailable at that version.
+  of axes. It is opt-in: pass `version="0.9.dev1"` explicitly, the default
+  target is unchanged. The schemas of the `0.9.dev1` release are bundled, so
+  `validate=True` checks a store at that version as it does at any other.
 
 ## High Content Screening (HCS)
 

--- a/docs/validation/api.md
+++ b/docs/validation/api.md
@@ -44,9 +44,10 @@ from ngff_zarr import (
 `validate_structural(metadata, options=None, version=None)` runs the
 image/multiscales rules. When `options` is `None` it uses `ValidateOptions()`,
 i.e. `ValidationLevel.STRICT`. `version` is the OME-Zarr version the metadata
-declares; the axis rules are inert for the versions that adopt the RFC-3 axis
-model (see [[parity]]), so omitting it holds every store to the v0.4 axis
-caps. A `ValidationError` carries `.rule` (a `SpecRule`),
+declares; the axis count, type and order rules are inert for the versions that
+adopt the RFC-3 axis model (see [[parity]]), so omitting it holds every store to
+the v0.4 axis caps. `axis-names-unique` is never inert: RFC-3 states it and no
+released schema carries it. A `ValidationError` carries `.rule` (a `SpecRule`),
 `.message` (str), and `.location` (`str | None`); `str(exc)` is
 `Spec rule [<rule>] violated: <message>`.
 

--- a/py/ngff_zarr/spec/0.9/schemas/_version.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/_version.schema
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/_version.schema",
+  "title": "OME-Zarr version",
+  "description": "OME-Zarr version.",
+  "type": "string",
+  "enum": [
+    "0.9.dev1"
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/axes.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/axes.schema
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/axes.schema",
+  "title": "Axes",
+  "description": "OME-Zarr Axes.",
+  "type": "array",
+  "uniqueItems": true,
+  "minItems": 1,
+  "items": {
+    "$ref": "#/$defs/axis"
+  },
+  "$defs": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the axis. Must be unique within the coordinate system."
+        },
+        "longName": {
+          "type": "string",
+          "description": "Longer name or description of the axis."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the axis. Can be a predefined type or custom type."
+        },
+        "discrete": {
+          "type": "boolean",
+          "description": "Whether the dimension is discrete"
+        },
+        "unit": {
+          "type": "string",
+          "description": "Unit for the axis"
+        },
+        "orientation": {
+          "$ref": "axis_orientation.schema"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  }
+}

--- a/py/ngff_zarr/spec/0.9/schemas/axis_orientation.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/axis_orientation.schema
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/axis_orientation.schema",
+  "title": "Axis Orientation",
+  "description": "Controlled vocabulary for orientation of each spatial axis according to subject or subject-global reference.",
+  "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["anatomical"]
+        },
+        "value": {
+          "enum": [
+            "left-to-right",
+            "right-to-left",
+            "anterior-to-posterior",
+            "posterior-to-anterior",
+            "inferior-to-superior",
+            "superior-to-inferior",
+            "dorsal-to-ventral",
+            "ventral-to-dorsal",
+            "dorsal-to-palmar",
+            "palmar-to-dorsal",
+            "dorsal-to-plantar",
+            "plantar-to-dorsal",
+            "rostral-to-caudal",
+            "caudal-to-rostral",
+            "cranial-to-caudal",
+            "caudal-to-cranial",
+            "proximal-to-distal",
+            "distal-to-proximal",
+            "superficial-to-deep",
+            "deep-to-superficial",
+            "apical-to-basal",
+            "basal-to-apical",
+            "apex-to-base",
+            "base-to-apex"
+          ]
+        }
+      },
+      "required": ["type", "value"]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/bf2raw.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/bf2raw.schema
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/bf2raw.schema",
+  "title": "bioformats2raw",
+  "description": "OME-Zarr bioformats2raw metadata.",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "bioformats2raw.layout": {
+          "description": "The top-level identifier metadata added by bioformats2raw",
+          "type": "number",
+          "enum": [
+            3
+          ]
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "bioformats2raw.layout",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/coordinate_systems.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/coordinate_systems.schema
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_systems.schema",
+  "title": "Coordinate systems",
+  "description": "OME-Zarr coordinate system.",
+  "type": "array",
+  "uniqueItems": true,
+  "items": {
+    "$ref": "#/$defs/coordinateSystem"
+  },
+  "$defs": {
+    "coordinateSystem": {
+      "description": "Coordinate Systems for OME-NGFF",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of coordinate system. Must be unique among all coordinate systems."
+        },
+        "axes": {
+          "$ref": "axes.schema"
+        }
+      },
+      "required": [
+        "name",
+        "axes"
+      ]
+    }
+  }
+}

--- a/py/ngff_zarr/spec/0.9/schemas/coordinate_transformations.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/coordinate_transformations.schema
@@ -1,0 +1,433 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema",
+  "title": "Coordinate Transformations",
+  "description": "OME-Zarr Coordinate transforms.",
+  "type": "array",
+  "uniqueItems": true,
+  "minItems": 1,
+  "items": {
+    "allOf": [
+      {
+        "$ref": "#/$defs/coordinateTransformation"
+      },
+      {
+        "type": "object",
+        "properties": {
+          "input": {
+            "allOf": [
+              {"$ref": "#/$defs/inputOutput"},
+              {"required": ["path"]}
+            ]
+          },
+          "output": {
+            "allOf": [
+              {"$ref": "#/$defs/inputOutput"},
+              {"required": ["name"]}
+            ]
+          }
+        },
+        "required": [
+          "input",
+          "output"
+        ]
+      }
+    ]
+  },
+  "$defs": {
+    "inputOutput": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "path": {"type": "string"}
+      }
+    },
+    "coordinateTransformation": {
+      "description": "OME-NGFF coordinate transformation.",
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/identity"
+            },
+            {
+              "$ref": "#/$defs/mapAxis"
+            },
+            {
+              "$ref": "#/$defs/projectAxis"
+            },
+            {
+              "$ref": "#/$defs/scale"
+            },
+            {
+              "$ref": "#/$defs/translation"
+            },
+            {
+              "$ref": "#/$defs/affine"
+            },
+            {
+              "$ref": "#/$defs/rotation"
+            },
+            {
+              "$ref": "#/$defs/bijection"
+            },
+            {
+              "$ref": "#/$defs/sequence"
+            },
+            {
+              "$ref": "#/$defs/byDimension"
+            },
+            {
+              "$ref": "#/$defs/displacements"
+            },
+            {
+              "$ref": "#/$defs/coordinates"
+            }
+          ]
+        }
+      ]
+    },
+    "identity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "identity"
+        }
+      },
+      "title": "Identity Transformation",
+      "description": "Identity transformation that maps input coordinates directly to output coordinates without modification."
+    },
+    "mapAxis": {
+      "type": "object",
+      "title": "Map Axis Transformation",
+      "description": "Permute axes by mapping input axes to output axes.",
+      "properties": {
+        "type": {
+          "const": "mapAxis"
+        },
+        "mapAxis": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "uniqueItems": true,
+          "description": "An array of integers representing the new axis order as zero-based indices of the input axes."
+        }
+      },
+      "required": [
+        "mapAxis"
+      ]
+    },
+    "projectAxis": {
+      "type": "object",
+      "title": "projectAxis transformation",
+      "description": "Add or drop axes from a coordinate vector.",
+      "allOf": [
+        {
+          "properties": {
+            "type": {
+              "const": "projectAxis"
+            },
+            "droppedInputs": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "uniqueItems": true,
+              "description": "An array of integers representing the indices of the input axes to drop."
+            },
+            "createdOutputs": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "uniqueItems": true,
+              "description": "An array of integers representing the indices where zeros are inserted in the output coordinate vector."
+            }
+          }
+        },
+        {
+          "anyOf": [
+            {"required": ["droppedInputs"]},
+            {"required": ["createdOutputs"]}
+          ]
+        }
+      ]
+
+    },
+    "scale": {
+      "type": "object",
+      "title": "Scale Transformation",
+      "description": "Scale transformation that scales coordinates by specified factors along each axis.",
+      "properties": {
+        "type": {
+          "const": "scale"
+        },
+        "scale": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        }
+      },
+      "required": [
+        "scale"
+      ]
+    },
+    "translation": {
+      "type": "object",
+      "title": "Translation Transformation",
+      "description": "Translation transformation that shifts coordinates by specified offsets along each axis.",
+      "properties": {
+        "type": {
+          "const": "translation"
+        },
+        "translation": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "required": [
+        "translation"
+      ]
+    },
+    "affine": {
+      "type": "object",
+      "title": "Affine Transformation",
+      "description": "Affine transformation represented by a transformation matrix.",
+      "properties": {
+        "type": {
+          "const": "affine"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "Path to a zarr array containing the affine matrix."
+            }
+          },
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "properties": {
+            "affine": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "required": [
+            "affine"
+          ]
+        }
+      ]
+    },
+    "rotation": {
+      "type": "object",
+      "title": "Rotation Transformation",
+      "description": "Rotation transformation represented by a rotation matrix.",
+      "properties": {
+        "type": {
+          "const": "rotation"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "Path to a zarr array containing the rotation matrix."
+            }
+          },
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "properties": {
+            "rotation": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "number" } }
+                },
+                {
+                  "type": "array",
+                  "minItems": 3,
+                  "maxItems": 3,
+                  "items": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "number" } }
+                },
+                {
+                  "type": "array",
+                  "minItems": 4,
+                  "maxItems": 4,
+                  "items": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
+                },
+                {
+                  "type": "array",
+                  "minItems": 5,
+                  "maxItems": 5,
+                  "items": { "type": "array", "minItems": 5, "maxItems": 5, "items": { "type": "number" } }
+                }
+              ]
+            }
+          },
+          "required": [
+            "rotation"
+          ]
+        }
+      ]
+    },
+    "bijection": {
+      "type": "object",
+      "title": "Bijection Transformation",
+      "description": "A pair of forward and inverse coordinate transformations.",
+      "properties": {
+        "type": {
+          "const": "bijection"
+        },
+        "forward": {
+          "$ref": "#/$defs/coordinateTransformation"
+        },
+        "inverse": {
+          "$ref": "#/$defs/coordinateTransformation"
+        }
+      },
+      "required": [
+        "forward", "inverse"
+      ]
+    },
+    "sequence": {
+      "title": "Sequence Transformation",
+      "description": "A sequence of transformations applied in order.",
+      "type": "object",
+      "properties": {
+        "type": { "const": "sequence" },
+        "transformations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/coordinateTransformation"
+          }
+        }
+      },
+      "required": [
+        "transformations"
+      ]
+    },
+    "byDimension": {
+      "type": "object",
+      "title": "By Dimension Transformation",
+      "description": "A set of transformations applied independently to each dimension.",
+      "properties": {
+        "type": { "const": "byDimension" },
+        "transformations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "transformation": {
+                "$ref": "#/$defs/coordinateTransformation"
+              },
+              "inputAxes": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "description": "Names of the input axes for this transformation."
+              },
+              "outputAxes": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "description": "Names of the output axes for this transformation."
+              }
+            },
+            "required": [
+              "transformation",
+              "inputAxes",
+              "outputAxes"
+            ]
+          }
+        }
+      },
+      "required": [
+        "transformations"
+      ]
+    },
+    "displacements": {
+      "type": "object",
+      "title": "Displacement Field Transformation",
+      "description": "Transformation defined by a displacement field stored in a zarr array.",
+      "properties": {
+        "type": { "const": "displacements" },
+        "path": {
+          "type": "string",
+          "description": "Path to the zarr array containing the displacement field."
+        },
+        "interpolation": {
+          "type": "string",
+          "enum": ["nearest", "linear", "cubic"],
+          "default": "linear",
+          "description": "Interpolation method to use when applying the displacement field."
+        }
+      },
+      "required": [
+        "path"
+      ]
+    },
+    "coordinates": {
+      "type": "object",
+      "title": "Coordinate Field Transformation",
+      "description": "Transformation defined by a coordinate field stored in a zarr array.",
+      "properties": {
+        "type": { "const": "coordinates" },
+        "path": {
+          "type": "string",
+          "description": "Path to the zarr array containing the coordinate field."
+        },
+        "interpolation": {
+          "type": "string",
+          "enum": ["nearest", "linear", "cubic"],
+          "default": "linear",
+          "description": "Interpolation method to use when applying the coordinate field."
+        }
+      },
+      "required": [
+        "path"
+      ]
+    }
+  }
+}

--- a/py/ngff_zarr/spec/0.9/schemas/image.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/image.schema
@@ -1,0 +1,265 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/image.schema",
+  "title": "Image",
+  "description": "OME-Zarr image.",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "omero": {
+          "$ref": "#/$defs/omero"
+        },
+        "multiscales": {
+          "$ref": "#/$defs/multiscales"
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "multiscales",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ],
+  "$defs": {
+    "multiscales": {
+      "description": "The multiscale datasets for this image",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "datasets": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "coordinateTransformations": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "oneOf": [
+                      {
+                        "description": "A single scale transformation",
+                        "allOf": [
+                          {
+                            "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/scale"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "allOf": [
+                                  {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                                  {
+                                    "required": ["path"]
+                                  }
+                                ]
+                              },
+                              "output": {
+                                "allOf": [
+                                  {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                                  {
+                                    "required": ["name"]
+                                  }
+                                ]
+                              },
+                              "name": {"type": "string"}
+                            },
+                            "required": ["input", "output"]
+                          }
+                        ]
+                      },
+                      {
+                        "description": "A single identity transformation",
+                        "allOf": [
+                          {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/identity"},
+                          {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "allOf": [
+                                  {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                                  {
+                                    "required": ["path"]
+                                  }
+                                ]
+                              },
+                              "output": {
+                                "allOf": [
+                                  {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                                  {
+                                    "required": ["name"]
+                                  }
+                                ]
+                              },
+                              "name": {"type": "string"}
+                            },
+                            "required": ["input", "output"]
+                          }
+                        ]
+                      },
+                      {
+                        "description": "A sequence of a ingle scale followed by a single translation",
+                        "type": "object",
+                        "properties": {
+                          "type": {"const": "sequence"},
+                          "transformations": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/scale"},
+                                {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/translation"}
+                              ]
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "input": {
+                            "allOf": [
+                              {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                              {
+                                "required": ["path"]
+                              }
+                            ]
+                          },
+                          "output": {
+                            "allOf": [
+                              {"$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                              {
+                                "required": ["name"]
+                              }
+                            ]
+                          },
+                          "name": {"type": "string"}
+                        },
+                        "required": ["type", "transformations", "input", "output"]
+                      }
+                    ]
+                  },
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "description": "Multiscale transformations (identity/scale/sequence of scale and translation) from this dataset to the coordinate system specified by 'output'."
+                }
+              },
+              "required": [
+                "path",
+                "coordinateTransformations"
+              ]
+            }
+          },
+          "coordinateSystems": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_systems.schema#/$defs/coordinateSystem"
+            }
+          },
+          "coordinateTransformations": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/coordinate_transformations.schema#/$defs/coordinateTransformation",
+                  "description": "Parameters of any possible transform"
+                },
+                {
+                  "type": "object",
+                  "description": "Transformations between two named coordinate systems same metadata document or in a child labels group",
+                  "properties": {
+                    "input": {
+                      "type": "object",
+                      "properties": {
+                        "name": {"type": "string"}
+                      },
+                      "required": ["name"],
+                      "description": "Reference to named coordinate system in the same metadata document (path empty) or in a child labels group (path to the labels group)"
+                    },
+                    "output": {
+                      "type": "object",
+                      "properties": {
+                        "name": {"type": "string"}
+                      },
+                      "required": ["name"],
+                      "description": "Reference to named coordinate system in the same metadata document (path empty) or in a child labels group (path to the labels group)"
+                    }
+                  },
+                  "required": ["input", "output"]
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "datasets",
+          "coordinateSystems"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "omero": {
+      "type": "object",
+      "properties": {
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "window": {
+                "type": "object",
+                "properties": {
+                  "end": {
+                    "type": "number"
+                  },
+                  "max": {
+                    "type": "number"
+                  },
+                  "min": {
+                    "type": "number"
+                  },
+                  "start": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "start",
+                  "end"
+                ]
+              },
+              "label": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "active": {
+                "type": "boolean"
+              },
+              "inverted": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "channels"
+      ]
+    }
+  }
+}

--- a/py/ngff_zarr/spec/0.9/schemas/label.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/label.schema
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/label.schema",
+  "title": "Label",
+  "description": "OME-Zarr label.",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "image-label": {
+          "$ref": "#/$defs/image-label"
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "image-label",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ],
+  "$defs": {
+    "image-label": {
+      "type": "object",
+      "properties": {
+        "colors": {
+          "description": "The colors for this label image",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label-value": {
+                "description": "The value of the label",
+                "type": "number"
+              },
+              "rgba": {
+                "description": "The RGBA color stored as an array of four integers between 0 and 255",
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 255
+                },
+                "minItems": 4,
+                "maxItems": 4
+              }
+            },
+            "required": [
+              "label-value"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "properties": {
+          "description": "The properties for this label image",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label-value": {
+                "description": "The pixel value for this label",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "label-value"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "source": {
+          "description": "The source of this label image",
+          "type": "object",
+          "properties": {
+            "image": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/py/ngff_zarr/spec/0.9/schemas/ome.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/ome.schema
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/ome.schema",
+  "title": "OME",
+  "description": "OME-Zarr OME metadata.",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "series": {
+          "description": "An array of the same length and the same order as the images defined in the OME-XML",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minContains": 1
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "series",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/ome_zarr.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/ome_zarr.schema
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/ome_zarr.schema",
+  "title": "OME-Zarr",
+  "description": "Any OME-Zarr dataset.",
+  "anyOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/bf2raw.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/image.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/label.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/ome.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/plate.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/well.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/scene.schema"
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/plate.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/plate.schema
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/plate.schema",
+  "title": "Plate",
+  "description": "OME-Zarr plate.",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "plate": {
+          "type": "object",
+          "properties": {
+            "acquisitions": {
+              "description": "The acquisitions for this plate",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "description": "A unique identifier within the context of the plate",
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "maximumfieldcount": {
+                    "description": "The maximum number of fields of view for the acquisition",
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "name": {
+                    "description": "The name of the acquisition",
+                    "type": "string"
+                  },
+                  "description": {
+                    "description": "The description of the acquisition",
+                    "type": "string"
+                  },
+                  "starttime": {
+                    "description": "The start timestamp of the acquisition, expressed as epoch time i.e. the number seconds since the Epoch",
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "endtime": {
+                    "description": "The end timestamp of the acquisition, expressed as epoch time i.e. the number seconds since the Epoch",
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            },
+            "field_count": {
+              "description": "The maximum number of fields per view across all wells",
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "name": {
+              "description": "The name of the plate",
+              "type": "string"
+            },
+            "columns": {
+              "description": "The columns of the plate",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The column name",
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9]+$"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "rows": {
+              "description": "The rows of the plate",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The row name",
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9]+$"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "wells": {
+              "description": "The wells of the plate",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "The path to the well subgroup",
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9]+/[A-Za-z0-9]+$"
+                  },
+                  "rowIndex": {
+                    "description": "The index of the well in the rows list",
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "columnIndex": {
+                    "description": "The index of the well in the columns list",
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "path",
+                  "rowIndex",
+                  "columnIndex"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "required": [
+            "columns",
+            "rows",
+            "wells"
+          ]
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "plate",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/scene.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/scene.schema
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/scene.schema",
+  "title": "Scene",
+  "description": "Scene metadata combining coordinate systems and coordinate transformations to define spatial relationships",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/_version.schema"
+        },
+        "scene":{
+          "properties": {
+            "coordinateSystems": {
+                "$ref": "coordinate_systems.schema",
+                "description": "Coordinate systems to combine with transforms to define spatial relationships"
+            },
+            "coordinateTransformations": {
+              "$comment": "Merge general coordinate transformations with constraints for scene metadata",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "coordinate_transformations.schema#/$defs/coordinateTransformation",
+                    "description": "Parameters of any possible transform"
+                  },
+                  {
+                    "type": "object",
+                    "description": "Transformations between two referenced coordinate systems",
+                    "properties": {
+                      "input": {
+                        "type": "object",
+                        "properties": {
+                          "name": {"type": "string"},
+                          "path": {"type": "string"}
+                        },
+                        "required": ["name"],
+                        "additionalProperties": false,
+                        "description": "Must reference a coordinate system defined in the same metadata document (path empty) or in a subgroup (path provided)"
+                      },
+                      "output": {
+                        "type": "object",
+                        "properties": {
+                          "name": {"type": "string"},
+                          "path": {"type": "string"}
+                        },
+                        "required": ["name"],
+                        "additionalProperties": false,
+                        "description": "Must reference a coordinate system defined in the same metadata document (path empty) or in a subgroup (path provided)"
+                      }
+                    },
+                    "required": ["input", "output"]
+                  }
+                ]
+              }
+            }
+          },
+          "type": "object",
+          "required": ["coordinateTransformations"]
+        }
+      },
+    "required": ["scene", "version"]
+    }
+  },
+  "required": ["ome"]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/strict_axes.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/strict_axes.schema
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_axes.schema",
+  "title": "NGFF Strict Axes",
+  "description": "JSON from OME-NGFF .zattrs",
+  "allOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/axes.schema"
+    },
+    {
+      "items": {
+        "type": "object",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [
+                  "array",
+                  "channel",
+                  "time",
+                  "space",
+                  "displacement",
+                  "coordinate",
+                  "frequency"
+                ]
+            }
+        }
+      }
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/strict_coordinate_systems.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/strict_coordinate_systems.schema
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_coordinate_systems.schema",
+  "allOf" : [
+    {
+      "$ref": "coordinate_systems.schema"
+    },
+    {
+      "items": {
+        "type": "object",
+        "properties": {
+          "axes": {
+            "$ref": "strict_axes.schema"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/strict_image.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/strict_image.schema
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_image.schema",
+  "allOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/image.schema"
+    },
+    {
+      "properties": {
+        "ome": {
+          "properties": {
+            "multiscales": {
+              "items": {
+                "required": [
+                  "metadata",
+                  "type",
+                  "name"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/strict_label.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/strict_label.schema
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_label.schema",
+  "allOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/label.schema"
+    },
+    {
+      "properties": {
+        "ome": {
+          "properties": {
+            "image-label": {
+              "required": [
+                "colors"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/strict_ome_zarr.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/strict_ome_zarr.schema
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_ome_zarr.schema",
+  "anyOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/bf2raw.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_image.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_label.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/ome.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_plate.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_well.schema"
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/strict_plate.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/strict_plate.schema
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_plate.schema",
+  "allOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/plate.schema"
+    },
+    {
+      "properties": {
+        "ome": {
+          "properties": {
+            "plate": {
+              "properties": {
+                "acquisitions": {
+                  "items": {
+                    "required": [
+                      "name",
+                      "maximumfieldcount"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "name"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.9/schemas/strict_well.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/strict_well.schema
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/strict_well.schema",
+  "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/well.schema"
+}

--- a/py/ngff_zarr/spec/0.9/schemas/well.schema
+++ b/py/ngff_zarr/spec/0.9/schemas/well.schema
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/well.schema",
+  "title": "Well",
+  "description": "OME-Zarr well.",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "well": {
+          "type": "object",
+          "properties": {
+            "images": {
+              "description": "The fields of view for this well",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "acquisition": {
+                    "description": "A unique identifier within the context of the plate",
+                    "type": "integer"
+                  },
+                  "path": {
+                    "description": "The path for this field of view subgroup",
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^[A-Za-z0-9_.-]+$",
+                    "not": {
+                      "anyOf": [
+                        { "pattern": "^\\.+$" },
+                        { "pattern": "^__" }
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "required": [
+            "images"
+          ]
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.9.dev1/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "well",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ]
+}

--- a/py/ngff_zarr/v09/zarr_metadata.py
+++ b/py/ngff_zarr/v09/zarr_metadata.py
@@ -335,8 +335,11 @@ class Metadata:
         Dataset transform parsing and ``NgffImage`` construction are delegated
         to the v0.6 reader. Handled here first:
 
-        1. ``validate=True`` is refused: no ``0.9.dev1`` JSON Schema is
-           published, so no ``spec/0.9.dev1/schemas`` tree is bundled.
+        1. ``validate=True`` runs the schema pass against the bundled
+           ``spec/0.9`` tree, which holds the schemas of the ``0.9.dev1``
+           release. The delegate then runs with ``validate=False``: it would
+           otherwise measure the document against the schemas of its own
+           version.
         2. A 0.5-shaped entry (flat ``axes``, no ``coordinateSystems``) is
            normalized to a single ``intrinsic`` coordinate system, so either
            shape is readable.
@@ -348,12 +351,13 @@ class Metadata:
         from ..v06.zarr_metadata import Metadata as Metadata_v06
 
         if validate:
-            raise NotImplementedError(
-                "Schema validation is unavailable for OME-Zarr 0.9.dev1: OME has "
-                "published no JSON Schema for it, so ngff-zarr ships no "
-                "spec/0.9.dev1/schemas tree. Read with validate=False and use "
-                "ngff_zarr.validate_structural() for the structural rules."
-            )
+            # The 0.9.dev series records its version on the ``ome`` namespace,
+            # as 0.6 does, and the bundled ``spec/0.9`` tree carries the
+            # ``0.9.dev1`` tag its ``_version.schema`` binds.
+            from ..validate import validate as validate_ngff
+
+            schema_version = str(root_attrs.get("ome", {}).get("version") or "0.9.dev1")
+            validate_ngff(root_attrs, version=schema_version)
 
         if "ome" not in root_attrs or "multiscales" not in root_attrs.get("ome", {}):
             raise ValueError(

--- a/py/test/test_v09_metadata.py
+++ b/py/test/test_v09_metadata.py
@@ -121,6 +121,26 @@ def test_read_flat_axes_shape(tmp_path):
 
 
 @zarr_v3
+def test_the_flat_axes_shape_fails_the_schema_pass(tmp_path):
+    """The flat shape is a read tolerance, not a second valid 0.9.dev1 shape.
+
+    The entry the test above reads breaks the 0.9.dev1 schema twice over: it
+    declares no ``coordinateSystems``, which ``image.schema`` requires, and its
+    dataset transforms name no ``input`` or ``output``. Which of the two the
+    error reports is jsonschema's choice, so this pins the refusal rather than
+    a message. Reading the shape at all is a concession to stores that carry a
+    0.9 version string over a 0.5-shaped entry.
+    """
+    from jsonschema.exceptions import ValidationError
+
+    axes = [{"name": n, "type": "space"} for n in "zyx"]
+    root = _write_v09(tmp_path / "flat-validate.ome.zarr", axes, (2, 3, 4), flat=True)
+
+    with pytest.raises(ValidationError):
+        from_ome_zarr(root, validate=True)
+
+
+@zarr_v3
 @pytest.mark.parametrize("flat", [False, True], ids=["coordinate-systems", "flat-axes"])
 def test_read_axis_without_type(tmp_path, flat):
     """An axis declaring only ``name`` reads back with ``type`` ``None``."""

--- a/py/test/test_v09_metadata.py
+++ b/py/test/test_v09_metadata.py
@@ -206,12 +206,69 @@ def test_axes_property_is_not_a_field():
     assert metadata.axes == metadata.coordinateSystems[0].axes
 
 
-def test_no_bundled_schema_is_reported_explicitly():
-    """``load_schema`` names the missing 0.9.dev1 schema instead of failing on I/O."""
+def test_the_0_9_dev1_schemas_are_bundled():
+    """``spec/0.9`` holds the schemas of the 0.9.dev1 release."""
     from ngff_zarr.validate import load_schema
 
-    with pytest.raises(ValueError, match="0.9.dev1"):
-        load_schema(version="0.9.dev1")
+    assert load_schema(version="0.9.dev1", model="_version")["enum"] == ["0.9.dev1"]
+    assert (
+        load_schema(version="0.9.dev1", model="image")["$id"]
+        == "https://ngff.openmicroscopy.org/0.9.dev1/schemas/image.schema"
+    )
+
+
+def test_a_0_9_dev1_store_reads_with_validate(tmp_path):
+    """The schema pass runs at 0.9.dev1 as it does at every bundled version."""
+    import dask.array as da
+    import ngff_zarr as nz
+    import numpy as np
+
+    image = nz.NgffImage(
+        da.zeros((1, 8, 8), dtype=np.uint8, chunks=(1, 8, 8)),
+        ["c", "y", "x"],
+        {"c": 1.0, "y": 1.0, "x": 1.0},
+        {"c": 0.0, "y": 0.0, "x": 0.0},
+    )
+    store = str(tmp_path / "s.ome.zarr")
+    nz.to_ome_zarr(
+        store,
+        nz.to_multiscales(image, scale_factors=[2], cache=False),
+        version="0.9.dev1",
+    )
+
+    assert len(nz.from_ome_zarr(store, validate=True).images) == 2
+
+
+def test_a_broken_0_9_dev1_store_is_refused(tmp_path):
+    import json
+    from pathlib import Path
+
+    import dask.array as da
+    import ngff_zarr as nz
+    from jsonschema.exceptions import ValidationError
+
+    image = nz.NgffImage(
+        da.zeros((1, 8, 8), dtype=np.uint8, chunks=(1, 8, 8)),
+        ["c", "y", "x"],
+        {"c": 1.0, "y": 1.0, "x": 1.0},
+        {"c": 0.0, "y": 0.0, "x": 0.0},
+    )
+    store = str(tmp_path / "s.ome.zarr")
+    nz.to_ome_zarr(
+        store,
+        nz.to_multiscales(image, scale_factors=[], cache=False),
+        version="0.9.dev1",
+    )
+
+    doc_path = Path(store) / "zarr.json"
+    doc = json.loads(doc_path.read_text())
+    doc["attributes"]["ome"]["multiscales"][0]["coordinateSystems"][0]["axes"][0].pop(
+        "name"
+    )
+    doc_path.write_text(json.dumps(doc, indent=4))
+
+    with pytest.raises(ValidationError):
+        nz.from_ome_zarr(store, validate=True)
 
 
 def test_version_is_supported():


### PR DESCRIPTION
Stacked on #611, which adds the 0.9.dev1 version and its metadata model. Merge that one first.

The 0.9.dev1 release published on 2026-08-25 carries the JSON Schemas that 0.9 lacked, so the reader no longer refuses `validate=True` at that version. The 20 schemas of the tag are vendored under `spec/0.9`, which is where `_schemas_dir` already sends `"0.9.dev1"`: it resolves a prerelease string to its base version, as it does for `"0.6rc0"`.

`axis_orientation.schema` is the one file with no counterpart at 0.6. It constrains an orientation `type` to `["anatomical"]` and its `value` to the 24 vocabulary entries.

The v0.6 delegate runs with `validate=False` afterwards, since it would otherwise measure a 0.9 document against the 0.6 schemas.

Two doc claims are removed with it: `docs/cli.md` and `docs/spec_features.md` both said OME publishes no JSON Schema for the version, which stopped being true with the release.

Verified: the full Python suite on the branch, 1179 passed and 3 skipped, and prek clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive OME-Zarr 0.9.dev1 schemas for metadata, images, labels, plates, wells, coordinate systems, axes, and transformations.
  * Added optional validation for 0.9.dev1 metadata.
  * Added strict schema variants for supported NGFF structures.
* **Bug Fixes**
  * Corrected validation behavior for axis rules and axis-name uniqueness.
* **Documentation**
  * Updated CLI, specification, and validation documentation for 0.9.dev1 schema support and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->