### PR TITLE
feat(py,ts): support the RFC-5 projectAxis transformation

### DIFF
--- a/docs/rfc5.md
+++ b/docs/rfc5.md
@@ -45,12 +45,21 @@ The transformation data classes live in `ngff_zarr.v06.zarr_metadata`:
 | `Coordinates` | `coordinates` | `path: str`, `interpolation: str` |
 | `TransformSequence` | `sequence` | `transformations: list[Transform]` |
 | `MapAxis` | `mapAxis` | `mapAxis: list[int]` |
+| `ProjectAxis` | `projectAxis` | `droppedInputs: list[int]`, `createdOutputs: list[int]` |
 | `ByDimension` | `byDimension` | `transformations: list[ByDimensionItem]` |
 | `Bijection` | `bijection` | `forward: Transform`, `inverse: Transform` |
 
 `MapAxis` stores an axis permutation as a transpose vector: the value at
 position `i` is the input axis that becomes the `i`-th output axis, and every
 zero-based input axis index appears exactly once.
+
+`ProjectAxis` changes the dimensionality of a coordinate vector:
+`droppedInputs` names the indices of the input vector to remove and
+`createdOutputs` the indices of the output vector where a zero is inserted. At
+least one of the two is given, the indices in each are unique, and the output
+dimensionality is the input dimensionality less the dropped axes plus the
+created ones. Dropping an axis loses information, so a projection is not
+invertible in general.
 
 `ByDimension` builds a high dimensional transform from lower dimensional ones;
 each `ByDimensionItem` wraps a transformation with the `inputAxes` and `outputAxes`

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -280,11 +280,17 @@ def _gate_top_level_transforms(metadata, version: str) -> None:
 
     0.9.dev1 is the 0.6 model with the axis restrictions relaxed, so its
     inter-system transforms carry the same requirement and the gate covers it.
+
+    Each transform then runs the reader's ``validate_transform`` against the
+    systems it names, so a store this writes is one it can read back.
     """
     if version not in ("0.6", NgffVersion.V09dev1.value):
         return
     if not metadata.coordinateTransformations:
         return
+    from .v06.zarr_metadata import validate_transform
+
+    systems = getattr(metadata, "coordinateSystems", None)
     for index, transform in enumerate(metadata.coordinateTransformations):
         for side in ("input", "output"):
             reference = getattr(transform, side, None)
@@ -295,6 +301,14 @@ def _gate_top_level_transforms(metadata, version: str) -> None:
                     "OME-Zarr 0.6 requires every multiscale-level transformation "
                     "to name both its input and its output coordinate system"
                 )
+        try:
+            validate_transform(transform, systems)
+        except ValueError as invalid:
+            raise ValueError(
+                f"multiscales coordinateTransformations[{index}] "
+                f"({transform.type}) would be written as a transform this "
+                f"package cannot read back: {invalid}"
+            ) from invalid
 
 
 @dataclass(frozen=True)

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -241,12 +241,9 @@ class MapAxis(BaseTransform):
                 )
 
 
-#: ``projectAxis`` may add or drop at most this many axes at once, which is the
-#: ``maxItems`` its schema sets on ``droppedInputs`` and ``createdOutputs``. The
-#: companion ``maximum: 4`` on each index is deliberately not mirrored here: it
-#: follows from the five-axis cap of 0.4 through 0.6, which RFC-3 lifts at
-#: 0.9.dev1, so an index is bounded by the coordinate system it points into
-#: (checked in ``validate``) rather than by a constant.
+#: The ``maxItems`` the schema sets on ``droppedInputs`` and ``createdOutputs``.
+#: Its companion ``maximum: 4`` is not mirrored: an index is bounded by the
+#: coordinate system it points into, which ``validate`` checks.
 _PROJECT_AXIS_MAX_OPERATIONS = 3
 
 
@@ -254,14 +251,10 @@ _PROJECT_AXIS_MAX_OPERATIONS = 3
 class ProjectAxis(BaseTransform):
     """A projection that drops input axes and inserts zero-valued output axes.
 
-    ``droppedInputs`` holds the indices of the input coordinate vector to
-    remove; ``createdOutputs`` holds the indices of the output vector where a
-    zero is inserted. At least one of the two must be given. Dropping a
-    dimension loses information, so a projection is not invertible in general.
-
-    The output dimensionality is the input dimensionality less the dropped
-    axes plus the created ones, which is what ties the two lists to the
-    ``input`` and ``output`` coordinate systems when those resolve.
+    ``droppedInputs`` are indices of the input vector to remove,
+    ``createdOutputs`` indices of the output vector to zero-fill; at least one
+    is given. Output dimensionality is the input less the dropped plus the
+    created. Dropping loses information, so it is not invertible in general.
     """
 
     droppedInputs: list[int] | None = None

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -241,6 +241,15 @@ class MapAxis(BaseTransform):
                 )
 
 
+#: ``projectAxis`` may add or drop at most this many axes at once, which is the
+#: ``maxItems`` its schema sets on ``droppedInputs`` and ``createdOutputs``. The
+#: companion ``maximum: 4`` on each index is deliberately not mirrored here: it
+#: follows from the five-axis cap of 0.4 through 0.6, which RFC-3 lifts at
+#: 0.9.dev1, so an index is bounded by the coordinate system it points into
+#: (checked in ``validate``) rather than by a constant.
+_PROJECT_AXIS_MAX_OPERATIONS = 3
+
+
 @dataclass(kw_only=True)
 class ProjectAxis(BaseTransform):
     """A projection that drops input axes and inserts zero-valued output axes.
@@ -281,6 +290,11 @@ class ProjectAxis(BaseTransform):
                 )
             if len(set(indices)) != len(indices):
                 raise ValueError(f"{field_name} indices must be unique; got {indices}")
+            if len(indices) > _PROJECT_AXIS_MAX_OPERATIONS:
+                raise ValueError(
+                    f"{field_name} may name at most "
+                    f"{_PROJECT_AXIS_MAX_OPERATIONS} axes; got {indices}"
+                )
 
     def validate(self, coordinateSystems: list[CoordinateSystem] | None = None) -> None:
         self._check_intrinsic()

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -241,6 +241,94 @@ class MapAxis(BaseTransform):
                 )
 
 
+@dataclass(kw_only=True)
+class ProjectAxis(BaseTransform):
+    """A projection that drops input axes and inserts zero-valued output axes.
+
+    ``droppedInputs`` holds the indices of the input coordinate vector to
+    remove; ``createdOutputs`` holds the indices of the output vector where a
+    zero is inserted. At least one of the two must be given. Dropping a
+    dimension loses information, so a projection is not invertible in general.
+
+    The output dimensionality is the input dimensionality less the dropped
+    axes plus the created ones, which is what ties the two lists to the
+    ``input`` and ``output`` coordinate systems when those resolve.
+    """
+
+    droppedInputs: list[int] | None = None
+    createdOutputs: list[int] | None = None
+    type: str = "projectAxis"
+
+    def __post_init__(self) -> None:
+        self._check_intrinsic()
+
+    def _check_intrinsic(self) -> None:
+        if self.droppedInputs is None and self.createdOutputs is None:
+            raise ValueError(
+                "projectAxis must declare droppedInputs, createdOutputs, or both"
+            )
+        for field_name in ("droppedInputs", "createdOutputs"):
+            indices = getattr(self, field_name)
+            if indices is None:
+                continue
+            _require_integer_axes(indices, field_name)
+            if not indices:
+                raise ValueError(f"{field_name} must hold at least one index")
+            if any(index < 0 for index in indices):
+                raise ValueError(
+                    f"{field_name} indices are zero-based positions and must "
+                    f"not be negative; got {indices}"
+                )
+            if len(set(indices)) != len(indices):
+                raise ValueError(f"{field_name} indices must be unique; got {indices}")
+
+    def validate(self, coordinateSystems: list[CoordinateSystem] | None = None) -> None:
+        self._check_intrinsic()
+        dropped = self.droppedInputs or []
+        created = self.createdOutputs or []
+        input_count = _resolved_axis_count(self.input, coordinateSystems)
+        output_count = _resolved_axis_count(self.output, coordinateSystems)
+
+        if input_count is not None:
+            if len(dropped) > input_count:
+                raise ValueError(
+                    f"projectAxis drops {len(dropped)} axes, more than the "
+                    f"{input_count} axes of coordinate system "
+                    f"'{self.input.name}'"
+                )
+            beyond = [index for index in dropped if index >= input_count]
+            if beyond:
+                raise ValueError(
+                    f"droppedInputs indices {beyond} are beyond the "
+                    f"{input_count} axes of coordinate system "
+                    f"'{self.input.name}'"
+                )
+
+        if output_count is not None:
+            if len(created) > output_count:
+                raise ValueError(
+                    f"projectAxis creates {len(created)} axes, more than the "
+                    f"{output_count} axes of coordinate system "
+                    f"'{self.output.name}'"
+                )
+            beyond = [index for index in created if index >= output_count]
+            if beyond:
+                raise ValueError(
+                    f"createdOutputs indices {beyond} are beyond the "
+                    f"{output_count} axes of coordinate system "
+                    f"'{self.output.name}'"
+                )
+
+        if input_count is not None and output_count is not None:
+            expected = input_count - len(dropped) + len(created)
+            if expected != output_count:
+                raise ValueError(
+                    f"projectAxis maps {input_count} input axes to {expected} "
+                    f"output axes, but coordinate system '{self.output.name}' "
+                    f"declares {output_count}"
+                )
+
+
 Transform = Union[
     Identity,
     Scale,
@@ -250,6 +338,7 @@ Transform = Union[
     Coordinates,
     Displacements,
     MapAxis,
+    ProjectAxis,
     "ByDimension",
     "Bijection",
     "TransformSequence",
@@ -930,6 +1019,19 @@ class Metadata:
             elif transform["type"] == "mapAxis":
                 _require_keys(transform, ("mapAxis",), "mapAxis")
                 transformation = MapAxis(mapAxis=list(transform["mapAxis"]))
+            elif transform["type"] == "projectAxis":
+                transformation = ProjectAxis(
+                    droppedInputs=(
+                        list(transform["droppedInputs"])
+                        if "droppedInputs" in transform
+                        else None
+                    ),
+                    createdOutputs=(
+                        list(transform["createdOutputs"])
+                        if "createdOutputs" in transform
+                        else None
+                    ),
+                )
             elif transform["type"] == "byDimension":
                 transformation = ByDimension.from_dict(transform, coordinateSystems)
             elif transform["type"] == "bijection":

--- a/py/test/rfc5_transform_cases.json
+++ b/py/test/rfc5_transform_cases.json
@@ -576,6 +576,190 @@
           "path": "f"
         }
       }
+    },
+    {
+      "name": "projectAxis_remove_valid",
+      "ok": true,
+      "transformation": {
+        "type": "projectAxis",
+        "droppedInputs": [
+          0
+        ],
+        "input": {
+          "name": "s3"
+        },
+        "output": {
+          "name": "s2"
+        }
+      }
+    },
+    {
+      "name": "projectAxis_insert_valid",
+      "ok": true,
+      "transformation": {
+        "type": "projectAxis",
+        "createdOutputs": [
+          0
+        ],
+        "input": {
+          "name": "s2"
+        },
+        "output": {
+          "name": "s3"
+        }
+      }
+    },
+    {
+      "name": "projectAxis_remove_and_insert_valid",
+      "ok": true,
+      "transformation": {
+        "type": "projectAxis",
+        "droppedInputs": [
+          0
+        ],
+        "createdOutputs": [
+          1
+        ],
+        "input": {
+          "name": "s3"
+        },
+        "output": {
+          "name": "s3"
+        }
+      }
+    },
+    {
+      "name": "projectAxis_unresolved_systems_valid",
+      "ok": true,
+      "transformation": {
+        "type": "projectAxis",
+        "droppedInputs": [
+          2
+        ]
+      }
+    },
+    {
+      "name": "projectAxis_missing_op",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis"
+      }
+    },
+    {
+      "name": "projectAxis_remove_non_unique",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis",
+        "droppedInputs": [
+          0,
+          0
+        ]
+      }
+    },
+    {
+      "name": "projectAxis_insert_non_unique",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis",
+        "createdOutputs": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "name": "projectAxis_remove_too_high_dim",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis",
+        "droppedInputs": [
+          3
+        ],
+        "input": {
+          "name": "s3"
+        },
+        "output": {
+          "name": "s2"
+        }
+      }
+    },
+    {
+      "name": "projectAxis_insert_too_high_dim",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis",
+        "createdOutputs": [
+          3
+        ],
+        "input": {
+          "name": "s2"
+        },
+        "output": {
+          "name": "s3"
+        }
+      }
+    },
+    {
+      "name": "projectAxis_remove_too_many",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis",
+        "droppedInputs": [
+          0,
+          1,
+          2
+        ],
+        "input": {
+          "name": "s2"
+        },
+        "output": {
+          "name": "s2"
+        }
+      }
+    },
+    {
+      "name": "projectAxis_insert_too_many",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis",
+        "createdOutputs": [
+          0,
+          1,
+          2
+        ],
+        "input": {
+          "name": "s2"
+        },
+        "output": {
+          "name": "s2"
+        }
+      }
+    },
+    {
+      "name": "projectAxis_dimension_mismatch",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis",
+        "droppedInputs": [
+          0
+        ],
+        "input": {
+          "name": "s3"
+        },
+        "output": {
+          "name": "s3"
+        }
+      }
+    },
+    {
+      "name": "projectAxis_negative_index",
+      "ok": false,
+      "transformation": {
+        "type": "projectAxis",
+        "droppedInputs": [
+          -1
+        ]
+      }
     }
   ]
 }

--- a/py/test/test_coordinate_transformations.py
+++ b/py/test/test_coordinate_transformations.py
@@ -298,6 +298,33 @@ def test_project_axis_roundtrips():
     assert projection.output.name == "plane"
 
 
+@requires_zarr_v3
+def test_the_writer_refuses_a_transform_it_could_not_read_back():
+    """to_ome_zarr checks what from_ome_zarr checks.
+
+    A projection dropping one axis between two systems of equal size does not
+    reconcile them, so it is refused at write rather than on the read that
+    would follow.
+    """
+    array = rng.random(size=(8, 8, 8), dtype=np.float32)
+    image = nz.to_ngff_image(array, dims=["z", "y", "x"])
+    multiscales = nz.to_multiscales(image, scale_factors=[])
+    intrinsic = multiscales.metadata.intrinsic_coordinate_system
+
+    # Drops one of three axes but claims a three-axis output.
+    multiscales.metadata.coordinateTransformations = [
+        ProjectAxis(
+            droppedInputs=[0],
+            input=CoordinateSystemIdentifier(name=intrinsic.name),
+            output=CoordinateSystemIdentifier(name=intrinsic.name),
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValueError, match="cannot read back"):
+            nz.to_ome_zarr(tmpdir, multiscales, version="0.6")
+
+
 def _three_axis_system(name: str = "system") -> CoordinateSystem:
     return CoordinateSystem(
         name=name,

--- a/py/test/test_coordinate_transformations.py
+++ b/py/test/test_coordinate_transformations.py
@@ -17,6 +17,7 @@ from ngff_zarr.v06.zarr_metadata import (
     Displacements,
     Identity,
     MapAxis,
+    ProjectAxis,
     Rotation,
     Scale,
     TransformSequence,
@@ -254,6 +255,47 @@ def test_new_transform_payloads_roundtrip():
 
     assert imported_bijection.forward.path == "forward_field"
     assert imported_bijection.inverse.path == "inverse_field"
+
+
+@requires_zarr_v3
+def test_project_axis_roundtrips():
+    """A projectAxis transform survives a 0.6 write and read by value.
+
+    Before ``projectAxis`` was modelled, a document using it passed the
+    bundled schema and the reader raised ``Unsupported transform type``.
+    """
+    array = rng.random(size=(8, 8, 8), dtype=np.float32)
+    input_image = nz.to_ngff_image(
+        array,
+        dims=["z", "y", "x"],
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+    )
+    multiscales = nz.to_multiscales(input_image, scale_factors=[])
+    intrinsic = multiscales.metadata.intrinsic_coordinate_system
+
+    plane = CoordinateSystem(
+        name="plane",
+        axes=[Axis(name="y", type="space"), Axis(name="x", type="space")],
+    )
+    multiscales.metadata.coordinateSystems.append(plane)
+    multiscales.metadata.coordinateTransformations = [
+        ProjectAxis(
+            droppedInputs=[0],
+            input=CoordinateSystemIdentifier(name=intrinsic.name),
+            output=CoordinateSystemIdentifier(name="plane"),
+            name="drop_z",
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        nz.to_ome_zarr(tmpdir, multiscales, version="0.6")
+        imported = nz.from_ome_zarr(tmpdir)
+
+    (projection,) = imported.metadata.coordinateTransformations
+    assert projection.type == "projectAxis"
+    assert projection.droppedInputs == [0]
+    assert projection.createdOutputs is None
+    assert projection.output.name == "plane"
 
 
 def _three_axis_system(name: str = "system") -> CoordinateSystem:

--- a/ts/src/schemas/coordinate_systems.ts
+++ b/ts/src/schemas/coordinate_systems.ts
@@ -68,7 +68,7 @@ export const ProjectAxisTransformationSchema: z.ZodType<{
   .object({
     type: z.literal("projectAxis"),
     droppedInputs: z
-      .array(z.number().int().nonnegative())
+      .array(z.number().int().nonnegative().max(4))
       .min(1)
       .max(3)
       .refine((indices) => new Set(indices).size === indices.length, {
@@ -76,7 +76,7 @@ export const ProjectAxisTransformationSchema: z.ZodType<{
       })
       .optional(),
     createdOutputs: z
-      .array(z.number().int().nonnegative())
+      .array(z.number().int().nonnegative().max(4))
       .min(1)
       .max(3)
       .refine((indices) => new Set(indices).size === indices.length, {

--- a/ts/src/schemas/coordinate_systems.ts
+++ b/ts/src/schemas/coordinate_systems.ts
@@ -54,6 +54,49 @@ export const MapAxisTransformationSchema: z.ZodType<{
   name: z.string().optional(),
 });
 
+// Project Axis transformation: drops input axes and inserts zero-valued output
+// axes. At least one of droppedInputs and createdOutputs is given, and the
+// indices in each are unique.
+export const ProjectAxisTransformationSchema: z.ZodType<{
+  type: "projectAxis";
+  droppedInputs?: number[] | undefined;
+  createdOutputs?: number[] | undefined;
+  input?: string | string[] | undefined;
+  output?: string | string[] | undefined;
+  name?: string | undefined;
+}> = z
+  .object({
+    type: z.literal("projectAxis"),
+    droppedInputs: z
+      .array(z.number().int().nonnegative())
+      .min(1)
+      .max(3)
+      .refine((indices) => new Set(indices).size === indices.length, {
+        message: "droppedInputs indices must be unique",
+      })
+      .optional(),
+    createdOutputs: z
+      .array(z.number().int().nonnegative())
+      .min(1)
+      .max(3)
+      .refine((indices) => new Set(indices).size === indices.length, {
+        message: "createdOutputs indices must be unique",
+      })
+      .optional(),
+    input: z.union([z.string(), z.array(z.string())]).optional(),
+    output: z.union([z.string(), z.array(z.string())]).optional(),
+    name: z.string().optional(),
+  })
+  .refine(
+    (transform) =>
+      transform.droppedInputs !== undefined ||
+      transform.createdOutputs !== undefined,
+    {
+      message:
+        "projectAxis must declare droppedInputs, createdOutputs, or both",
+    },
+  );
+
 // Translation transformation
 export const TranslationTransformationSchema: z.ZodType<{
   type: "translation";
@@ -189,6 +232,14 @@ export type CoordinateTransformation =
   | ({ type: "mapAxis"; mapAxis: number[] } & TransformationCommon)
   | (
     & {
+      type: "projectAxis";
+      droppedInputs?: number[] | undefined;
+      createdOutputs?: number[] | undefined;
+    }
+    & TransformationCommon
+  )
+  | (
+    & {
       type: "translation";
       translation?: number[] | undefined;
       path?: string | undefined;
@@ -263,6 +314,7 @@ export const CoordinateTransformationSchema: z.ZodType<
   z.union([
     IdentityTransformationSchema,
     MapAxisTransformationSchema,
+    ProjectAxisTransformationSchema,
     TranslationTransformationSchema,
     ScaleTransformationSchema,
     AffineTransformationSchema,

--- a/ts/src/types/zarr_metadata.ts
+++ b/ts/src/types/zarr_metadata.ts
@@ -115,6 +115,23 @@ export interface Displacements {
 }
 
 /**
+ * RFC 5 projectAxis transformation (v0.6): a projection that drops input axes
+ * and inserts zero-valued output axes. `droppedInputs` holds the indices of
+ * the input coordinate vector to remove, `createdOutputs` the indices of the
+ * output vector where a zero is inserted; at least one of the two is given.
+ * Dropping a dimension loses information, so a projection is not invertible in
+ * general.
+ */
+export interface ProjectAxis {
+  droppedInputs?: number[];
+  createdOutputs?: number[];
+  type: "projectAxis";
+  input?: CoordinateSystemIdentifier;
+  output?: CoordinateSystemIdentifier;
+  name?: string;
+}
+
+/**
  * RFC 5 mapAxis transformation (v0.6): an axis permutation stored as a
  * transpose vector of integer indices. The value at position `i` names which
  * input axis becomes the `i`-th output axis; every zero-based input axis
@@ -193,6 +210,7 @@ export type V06Transform =
   | Coordinates
   | Displacements
   | MapAxis
+  | ProjectAxis
   | ByDimension
   | Bijection
   | TransformSequence;

--- a/ts/src/utils/v06_metadata.ts
+++ b/ts/src/utils/v06_metadata.ts
@@ -171,6 +171,14 @@ export function serializeV06Transform(
     case "mapAxis":
       out.mapAxis = transform.mapAxis;
       break;
+    case "projectAxis":
+      if (transform.droppedInputs !== undefined) {
+        out.droppedInputs = transform.droppedInputs;
+      }
+      if (transform.createdOutputs !== undefined) {
+        out.createdOutputs = transform.createdOutputs;
+      }
+      break;
     case "byDimension":
       out.transformations = transform.transformations.map((item) => ({
         transformation: serializeV06Transform(item.transformation),
@@ -271,6 +279,22 @@ function parseV06Transform(
         mapAxis: asIntegerArray(entry.mapAxis, "mapAxis"),
       };
       break;
+    case "projectAxis": {
+      transform = { type: "projectAxis" };
+      if (entry.droppedInputs !== undefined) {
+        transform.droppedInputs = asIntegerArray(
+          entry.droppedInputs,
+          "droppedInputs",
+        );
+      }
+      if (entry.createdOutputs !== undefined) {
+        transform.createdOutputs = asIntegerArray(
+          entry.createdOutputs,
+          "createdOutputs",
+        );
+      }
+      break;
+    }
     case "byDimension": {
       if (!Array.isArray(entry.transformations)) {
         throw new Error(
@@ -435,6 +459,85 @@ export function validateV06Transform(
         throw new Error(
           `mapAxis length ${indices.length} does not match the ${count} ` +
             `axes of coordinate system '${identifier?.name}'`,
+        );
+      }
+    }
+  } else if (transform.type === "projectAxis") {
+    const dropped = transform.droppedInputs;
+    const created = transform.createdOutputs;
+    if (dropped === undefined && created === undefined) {
+      throw new Error(
+        "projectAxis must declare droppedInputs, createdOutputs, or both",
+      );
+    }
+    for (
+      const [name, indices] of [
+        ["droppedInputs", dropped],
+        ["createdOutputs", created],
+      ] as const
+    ) {
+      if (indices === undefined) {
+        continue;
+      }
+      if (!indices.every((axis) => Number.isInteger(axis))) {
+        throw new Error(`${name} axis indices must be integers; got [${indices}]`);
+      }
+      if (indices.length === 0) {
+        throw new Error(`${name} must hold at least one index`);
+      }
+      if (indices.some((axis) => axis < 0)) {
+        throw new Error(
+          `${name} indices are zero-based positions and must not be ` +
+            `negative; got [${indices}]`,
+        );
+      }
+      if (new Set(indices).size !== indices.length) {
+        throw new Error(`${name} indices must be unique; got [${indices}]`);
+      }
+    }
+    const droppedCount = dropped?.length ?? 0;
+    const createdCount = created?.length ?? 0;
+    const inputCount = axisCount(transform.input, coordinateSystems);
+    const outputCount = axisCount(transform.output, coordinateSystems);
+    if (inputCount !== undefined) {
+      if (droppedCount > inputCount) {
+        throw new Error(
+          `projectAxis drops ${droppedCount} axes, more than the ` +
+            `${inputCount} axes of coordinate system ` +
+            `'${transform.input?.name}'`,
+        );
+      }
+      const beyond = (dropped ?? []).filter((axis) => axis >= inputCount);
+      if (beyond.length > 0) {
+        throw new Error(
+          `droppedInputs indices [${beyond}] are beyond the ${inputCount} ` +
+            `axes of coordinate system '${transform.input?.name}'`,
+        );
+      }
+    }
+    if (outputCount !== undefined) {
+      if (createdCount > outputCount) {
+        throw new Error(
+          `projectAxis creates ${createdCount} axes, more than the ` +
+            `${outputCount} axes of coordinate system ` +
+            `'${transform.output?.name}'`,
+        );
+      }
+      const beyond = (created ?? []).filter((axis) => axis >= outputCount);
+      if (beyond.length > 0) {
+        throw new Error(
+          `createdOutputs indices [${beyond}] are beyond the ${outputCount} ` +
+            `axes of coordinate system '${transform.output?.name}'`,
+        );
+      }
+    }
+    if (inputCount !== undefined && outputCount !== undefined) {
+      const expected = inputCount - droppedCount + createdCount;
+      if (expected !== outputCount) {
+        throw new Error(
+          `projectAxis maps ${inputCount} input axes to ${expected} output ` +
+            `axes, but coordinate system '${transform.output?.name}' ` +
+            `declares ${outputCount}`,
         );
       }
     }

--- a/ts/src/utils/v06_metadata.ts
+++ b/ts/src/utils/v06_metadata.ts
@@ -104,6 +104,19 @@ export function buildV06MultiscalesEntry(
           );
         }
       }
+      // The reader's own check, against the systems that get serialized: the
+      // intrinsic one built above when `metadata.coordinateSystems` is absent.
+      try {
+        validateV06Transform(transform, coordinateSystems);
+      } catch (invalid) {
+        throw new Error(
+          `multiscales coordinateTransformations[${index}] ` +
+            `(${transform.type}) would be written as a transform this ` +
+            `package cannot read back: ${
+              invalid instanceof Error ? invalid.message : String(invalid)
+            }`,
+        );
+      }
     });
     entry.coordinateTransformations = metadata.coordinateTransformations.map(
       serializeV06Transform,
@@ -559,10 +572,16 @@ export function validateV06Transform(
         );
       }
     }
+  } else if (transform.type === "sequence") {
+    for (const nested of transform.transformations) {
+      validateV06Transform(nested, coordinateSystems);
+    }
   } else if (transform.type === "byDimension") {
     const inputCount = axisCount(transform.input, coordinateSystems);
     const seenOutputAxes = new Set<number>();
     for (const item of transform.transformations) {
+      // The reader validates each child as it parses it.
+      validateV06Transform(item.transformation, coordinateSystems);
       const axes = [...item.inputAxes, ...item.outputAxes];
       if (!axes.every((axis) => Number.isInteger(axis))) {
         throw new Error(
@@ -622,6 +641,8 @@ export function validateV06Transform(
       }
     }
   } else if (transform.type === "bijection") {
+    validateV06Transform(transform.forward, coordinateSystems);
+    validateV06Transform(transform.inverse, coordinateSystems);
     const inputCount = axisCount(transform.input, coordinateSystems);
     const outputCount = axisCount(transform.output, coordinateSystems);
     if (

--- a/ts/src/utils/v06_metadata.ts
+++ b/ts/src/utils/v06_metadata.ts
@@ -399,6 +399,16 @@ function axisCount(
     .length;
 }
 
+/**
+ * `projectAxis` may add or drop at most this many axes at once, which is the
+ * `maxItems` its schema sets on `droppedInputs` and `createdOutputs`. The
+ * companion `maximum: 4` on each index is deliberately not mirrored: it follows
+ * from the five-axis cap of 0.4 through 0.6, which RFC-3 lifts at 0.9.dev1, so
+ * an index is bounded by the coordinate system it points into rather than by a
+ * constant.
+ */
+const PROJECT_AXIS_MAX_OPERATIONS = 3;
+
 /** Dimensionality a byDimension item's axis lists must have, if knowable. */
 function itemDimensions(transformation: V06Transform): number | undefined {
   switch (transformation.type) {
@@ -480,7 +490,9 @@ export function validateV06Transform(
         continue;
       }
       if (!indices.every((axis) => Number.isInteger(axis))) {
-        throw new Error(`${name} axis indices must be integers; got [${indices}]`);
+        throw new Error(
+          `${name} axis indices must be integers; got [${indices}]`,
+        );
       }
       if (indices.length === 0) {
         throw new Error(`${name} must hold at least one index`);
@@ -493,6 +505,12 @@ export function validateV06Transform(
       }
       if (new Set(indices).size !== indices.length) {
         throw new Error(`${name} indices must be unique; got [${indices}]`);
+      }
+      if (indices.length > PROJECT_AXIS_MAX_OPERATIONS) {
+        throw new Error(
+          `${name} may name at most ${PROJECT_AXIS_MAX_OPERATIONS} axes; ` +
+            `got [${indices}]`,
+        );
       }
     }
     const droppedCount = dropped?.length ?? 0;

--- a/ts/test/v06_coordinate_transformations_test.ts
+++ b/ts/test/v06_coordinate_transformations_test.ts
@@ -842,6 +842,100 @@ Deno.test("v0.6 read accepts the snake_case byDimension axis keys", async () => 
 
 // Mirrors test_coordinate_transformations.py: the mapAxis, byDimension and
 // bijection payloads survive the round-trip by value, not just by type.
+Deno.test("the writer refuses a transform it could not read back", async () => {
+  // A projection dropping one axis between two systems of equal size does not
+  // reconcile them, so it is refused at write. Mirrors
+  // test_the_writer_refuses_a_transform_it_could_not_read_back.
+  const multiscales = await buildMultiscales();
+  const intrinsic = multiscales.metadata.coordinateSystems![0];
+
+  multiscales.metadata.coordinateTransformations = [
+    {
+      type: "projectAxis",
+      droppedInputs: [0],
+      input: { name: intrinsic.name },
+      output: { name: intrinsic.name },
+    },
+  ];
+
+  const store: MemoryStore = new Map();
+  let message = "";
+  try {
+    await toOmeZarr(store, multiscales, { version: "0.6" });
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  if (!message.includes("cannot read back")) {
+    throw new Error(`expected the writer to refuse it; got: ${message}`);
+  }
+});
+
+Deno.test("the writer checks against the intrinsic system it will serialize", async () => {
+  // With no explicit coordinateSystems the writer builds the intrinsic one from
+  // the axes and serializes it, so that is what the reader resolves against and
+  // what the transform must reconcile.
+  const multiscales = await buildMultiscales();
+  const axes = multiscales.metadata.coordinateSystems![0].axes;
+  delete (multiscales.metadata as { coordinateSystems?: unknown })
+    .coordinateSystems;
+  multiscales.metadata.axes = axes;
+  multiscales.metadata.coordinateTransformations = [
+    {
+      type: "projectAxis",
+      droppedInputs: [0],
+      input: { name: "intrinsic" },
+      output: { name: "intrinsic" },
+    },
+  ];
+
+  const store: MemoryStore = new Map();
+  await assertRejects(
+    () => toOmeZarr(store, multiscales, { version: "0.6" }),
+    Error,
+    "cannot read back",
+  );
+});
+
+Deno.test("the writer refuses an invalid transform nested in a wrapper", async () => {
+  // A wrapper is only as valid as what it holds, and the reader validates each
+  // child as it parses it. The writer has to reach the same verdict.
+  const bad = {
+    type: "projectAxis" as const,
+    droppedInputs: [0, 0],
+  };
+
+  for (
+    const wrapper of [
+      { type: "sequence" as const, transformations: [bad] },
+      { type: "bijection" as const, forward: bad, inverse: bad },
+      {
+        type: "byDimension" as const,
+        transformations: [
+          { transformation: bad, inputAxes: [0], outputAxes: [0] },
+        ],
+      },
+    ]
+  ) {
+    const multiscales = await buildMultiscales();
+    const intrinsic = multiscales.metadata.coordinateSystems![0];
+    multiscales.metadata.coordinateTransformations = [
+      {
+        ...wrapper,
+        input: { name: intrinsic.name },
+        output: { name: intrinsic.name },
+      } as V06Transform,
+    ];
+
+    const store: MemoryStore = new Map();
+    await assertRejects(
+      () => toOmeZarr(store, multiscales, { version: "0.6" }),
+      Error,
+      "cannot read back",
+      `${wrapper.type} should be refused`,
+    );
+  }
+});
+
 Deno.test("a projectAxis payload survives the round-trip", async () => {
   // Before projectAxis was modelled, a document using it passed the bundled
   // schema and the reader threw on an unsupported transform type.
@@ -990,9 +1084,11 @@ Deno.test("invalid mapAxis, byDimension and bijection metadata are rejected", as
     multiscales.metadata.coordinateTransformations = [transform];
 
     const store: MemoryStore = new Map();
-    await toOmeZarr(store, multiscales, { version: "0.6" });
+    // The writer refuses it, which is where the refusal now happens: it runs
+    // the reader's own check before serializing, so a store this package wrote
+    // is always one it can read back.
     await assertRejects(
-      () => fromOmeZarr(store),
+      () => toOmeZarr(store, multiscales, { version: "0.6" }),
       Error,
       undefined,
       `case '${name}' should be rejected`,
@@ -1017,8 +1113,12 @@ Deno.test("byDimension incomplete output coverage is rejected", async () => {
   multiscales.metadata.coordinateTransformations = [byDimension];
 
   const store: MemoryStore = new Map();
-  await toOmeZarr(store, multiscales, { version: "0.6" });
-  await assertRejects(() => fromOmeZarr(store), Error, "exactly once");
+  // Refused by the writer, which runs the reader's check before serializing.
+  await assertRejects(
+    () => toOmeZarr(store, multiscales, { version: "0.6" }),
+    Error,
+    "exactly once",
+  );
 });
 
 // A byDimension item may wrap any transformation, including a sequence; the

--- a/ts/test/v06_coordinate_transformations_test.ts
+++ b/ts/test/v06_coordinate_transformations_test.ts
@@ -842,6 +842,44 @@ Deno.test("v0.6 read accepts the snake_case byDimension axis keys", async () => 
 
 // Mirrors test_coordinate_transformations.py: the mapAxis, byDimension and
 // bijection payloads survive the round-trip by value, not just by type.
+Deno.test("a projectAxis payload survives the round-trip", async () => {
+  // Before projectAxis was modelled, a document using it passed the bundled
+  // schema and the reader threw on an unsupported transform type.
+  const multiscales = await buildMultiscales();
+  const intrinsic = multiscales.metadata.coordinateSystems![0];
+
+  multiscales.metadata.coordinateSystems!.push({
+    name: "plane",
+    axes: [
+      { name: "y", type: "space", unit: undefined },
+      { name: "x", type: "space", unit: undefined },
+    ],
+  });
+  multiscales.metadata.coordinateTransformations = [
+    {
+      type: "projectAxis",
+      droppedInputs: [0],
+      input: { name: intrinsic.name },
+      output: { name: "plane" },
+      name: "drop_z",
+    },
+  ];
+
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  const imported = await fromOmeZarr(store);
+
+  const transforms = imported.metadata.coordinateTransformations!;
+  assertEquals(transforms.length, 1);
+  const projection = transforms[0];
+  if (projection.type !== "projectAxis") {
+    throw new Error("expected a projectAxis transform");
+  }
+  assertEquals(projection.droppedInputs, [0]);
+  assertEquals(projection.createdOutputs, undefined);
+  assertEquals(projection.output?.name, "plane");
+});
+
 Deno.test("mapAxis, byDimension and bijection payloads survive the round-trip", async () => {
   const multiscales = await buildMultiscales();
   const intrinsic = multiscales.metadata.coordinateSystems![0];


### PR DESCRIPTION
Closes part of #667. Independent of the RFC-3 stack: this one branches from main.

0.6rc0 adds `projectAxis`, "Add or drop axes from a coordinate vector", and #677 vendored that schema without the code behind it. Both ports raised `Unsupported transform type` on it, so a document the bundled schema accepts broke the reader.

@thewtex asked in #667 whether `projectAxis` was meant to be dropped from the schema. @jo-mueller did not answer that directly; what he settled is why the RFC-5 text lags, and it is pinned at `0.6.dev3` by design, because keeping it in step with each dev release became too costly and a source of error.

The conclusion that the transformation is real is therefore an inference from that, not his confirmation. It rests on `ngff-spec` being the authority for anything after `0.6.dev3`, and on what the `0.6rc0` tag carries: a dedicated section in `index.md`, an entry in the transformation table, two worked examples, and a conformance suite of 2 valid and 7 invalid fixtures. If upstream later removes it, this PR is what gets reverted.

`droppedInputs` names the indices of the input coordinate vector to remove, `createdOutputs` the indices of the output vector where a zero is inserted. At least one of the two is required, the indices in each are unique and non-negative, and where the `input` and `output` coordinate systems resolve, the output dimensionality must be the input dimensionality less the dropped axes plus the created ones. Dropping a dimension loses information, so a projection is not invertible in general.

The shared `rfc5_transform_cases.json` gains 13 cases, named after the upstream conformance fixtures (`remove_non_unique`, `insert_too_high_dim`, `missing_op` and the rest), so both ports are held to the same verdict on each. I also checked the model against the bundled 0.6rc0 schema case by case: the two agree on every one.

Verified: Python 1126 passed and 3 skipped, Deno 601 passed, prek clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for RFC-5 `projectAxis` coordinate transformations.
  * Supports dropping input axes, inserting zero-valued output axes, or both.
  * Added serialization, parsing, and round-trip support across Python and TypeScript metadata APIs.

* **Bug Fixes**
  * Metadata writing now rejects invalid or unreadable transformations earlier, with clearer validation errors.

* **Documentation**
  * Documented dimensionality rules, index requirements, and reduced invertibility when axes are dropped.

* **Tests**
  * Added coverage for valid transformations, invalid configurations, unresolved coordinate systems, and metadata round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

