### PR TITLE
Stream the field of an RFC-5 displacements or coordinates transform

### DIFF
--- a/py/ngff_zarr/displacement_field_transform.py
+++ b/py/ngff_zarr/displacement_field_transform.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -398,6 +399,339 @@ def itk_displacement_field_to_ngff_transform(
     return Displacements(path=path, interpolation="linear"), image
 
 
+def field_image(
+    transform: Displacements | Coordinates, field, dims: Sequence[str]
+) -> NgffImage:
+    """The field image a field transform names, checked against ``dims``.
+
+    Takes the ``NgffImage`` or the ``NgffMultiscales`` a caller passes in
+    ``fields``, and returns the single-scale image, after checking that its
+    axes are the component axis followed by ``dims`` in order and that it
+    holds one component per input axis.
+
+    :param transform: The ``displacements`` or ``coordinates`` transform.
+    :type  transform: Displacements | Coordinates
+    :param field: The field image or multiscales, as ``fields`` holds it.
+    :param dims: The spatial axis names of the input coordinate system, in
+        RFC-5 (Zarr) order.
+    :type  dims: Sequence[str]
+    :return: The field as a single-scale image; the finest level of a
+        multiscales.
+    :rtype: NgffImage
+    :raises ValueError: If the field has no single component axis of the type
+        the transform calls for, if its axes are not that axis followed by
+        ``dims``, or if it holds a number of components other than ``len(dims)``.
+    """
+    dims = tuple(dims)
+    component_type = "coordinate" if transform.type == "coordinates" else "displacement"
+    if hasattr(field, "images") and hasattr(field, "metadata"):
+        # A read multiscales keeps the axis types in its metadata, not on the
+        # image: the component axis is the one typed there.
+        axes = field.metadata.intrinsic_coordinate_system.axes
+        component_dims = [axis.name for axis in axes if axis.type == component_type]
+        field = field.images[0]
+    else:
+        component_dims = [
+            dim
+            for dim, axis_type in (field.axes_types or {}).items()
+            if axis_type == component_type
+        ]
+    if len(component_dims) != 1:
+        msg = (
+            f"the field image must have exactly one axis of type "
+            f"'{component_type}' (axes_types on an NgffImage, the axes metadata "
+            f"of a multiscales); got {component_dims or 'none'} on dims "
+            f"{tuple(field.dims)}"
+        )
+        raise ValueError(msg)
+    expected_dims = (component_dims[0], *dims)
+    if tuple(field.dims) != expected_dims:
+        msg = (
+            f"the field's dims are {tuple(field.dims)}; a {transform.type} "
+            f"transform over dims {dims} needs {expected_dims}: the component "
+            "axis first, then the input axes in order"
+        )
+        raise ValueError(msg)
+    if field.data.shape[0] != len(dims):
+        msg = (
+            f"the field holds {field.data.shape[0]} components per point, but dims "
+            f"{dims} name {len(dims)} axes"
+        )
+        raise ValueError(msg)
+    return field
+
+
+def check_unoriented_field(field: NgffImage, dims: Sequence[str]) -> None:
+    """Refuse a field whose grid cannot be placed without the two images.
+
+    An ITK transform lives in physical space, and an anatomical orientation
+    only says where a grid sits once the images it relates are known.
+
+    :param field: The field image.
+    :type  field: NgffImage
+    :param dims: The spatial axis names, in RFC-5 order.
+    :type  dims: Sequence[str]
+    :raises ValueError: If the field carries an anatomical orientation.
+    """
+    from .itk_transform_to_ngff_transform import _itk_axis_order
+    from .resample_bounding_box import _itk_direction
+
+    if _is_identity(_itk_direction(field, _itk_axis_order(tuple(dims)))):
+        return
+    msg = (
+        "the field carries an anatomical orientation, so its grid "
+        "cannot be placed in ITK physical space on its own; pass the "
+        "fixed and moving images. resample_bounding_box and resample "
+        "have no place for them, because their RFC-5 branch works on "
+        "the intrinsic systems where no orientation applies: call "
+        "ngff_transform_to_itk_transform with both images yourself and "
+        "hand them the ITK transform it returns."
+    )
+    raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class FieldBound:
+    """The range of displacement each chunk of a field can produce.
+
+    A field is read through a kernel that is non-negative and sums to one, so
+    a displacement anywhere in a chunk is a convex combination of that chunk's
+    values and lies between their smallest and largest. That makes the range
+    a bound on every interpolated displacement, not a sample of one: walking
+    the boundary of a region instead misses a bump the region encloses.
+
+    The range is kept rather than its magnitude, so a field that shifts every
+    point the same way moves the region it bounds instead of widening it.
+
+    The granularity is the field's own chunking, since that is what a read
+    costs. A field stored in one chunk therefore reports one range for the
+    whole volume, which is also the case where the field fits in memory.
+    """
+
+    #: Spatial dimension names, in the field's (RFC-5) order.
+    dims: tuple[str, ...]
+    #: Smallest and largest displacement per component, per chunk:
+    #: ``(len(dims), *chunk counts)`` each, components ordered like ``dims``.
+    low: np.ndarray
+    high: np.ndarray
+    #: Index of the first element of each chunk, per spatial axis.
+    offsets: tuple[np.ndarray, ...]
+
+    def over(
+        self, window: Sequence[tuple[int, int]], outside: bool = False
+    ) -> dict[str, tuple[float, float]]:
+        """The displacement range over the chunks ``window`` touches.
+
+        :param window: ``(start, stop)`` per spatial axis, in field index
+            space and in ``dims`` order.
+        :type  window: Sequence[tuple[int, int]]
+        :param outside: Whether the grid the window came from also has points
+            beyond the field. ITK displaces those by nothing, so zero belongs
+            in the range as much as the values do; leaving it out lets a
+            field that displaces every point it covers one way carry the
+            region away from the points it does not cover.
+        :type  outside: bool
+        :return: ``{dim: (low, high)}`` per component, keyed by dimension.
+            Zero for an empty window, where the field displaces nothing.
+        :rtype: dict[str, tuple[float, float]]
+        """
+        if any(stop <= start for start, stop in window):
+            return dict.fromkeys(self.dims, (0.0, 0.0))
+        selection = []
+        for axis, (start, stop) in enumerate(window):
+            offsets = self.offsets[axis]
+            first = int(np.searchsorted(offsets, start, side="right") - 1)
+            last = int(np.searchsorted(offsets, stop - 1, side="right"))
+            selection.append(slice(max(0, first), last))
+        index = (slice(None), *selection)
+        low = self.low[index].reshape(len(self.dims), -1).min(axis=1)
+        high = self.high[index].reshape(len(self.dims), -1).max(axis=1)
+        if outside:
+            low = np.minimum(low, 0.0)
+            high = np.maximum(high, 0.0)
+        return {
+            dim: (float(low[axis]), float(high[axis]))
+            for axis, dim in enumerate(self.dims)
+        }
+
+
+def _block_extrema(block, block_info=None, *, origin=None, spacing=None, offset=None):
+    """Smallest and largest displacement per component over one block.
+
+    Comes back as one array of twice the components, the minima before the
+    maxima, so a single pass over the field answers both. ``offset`` is where
+    the array this block came from starts in the field, since the block is
+    located against its own array rather than the field.
+    """
+    values = np.asarray(block, dtype=np.float64)
+    if origin is not None:
+        # A coordinates field holds the output position of each grid point
+        # rather than the offset from it, so the grid point comes off first.
+        if values is block:
+            values = values.copy()
+        location = block_info[0]["array-location"][1:]
+        for axis, (start, stop) in enumerate(location):
+            shape = [1] * (values.ndim - 1)
+            shape[axis] = -1
+            grid = origin[axis] + spacing[axis] * np.arange(
+                start + offset[axis], stop + offset[axis], dtype=np.float64
+            )
+            values[axis] -= grid.reshape(shape)
+    flat = values.reshape(values.shape[0], -1)
+    extrema = np.concatenate([flat.min(axis=1), flat.max(axis=1)])
+    return extrema.reshape((2 * values.shape[0],) + (1,) * (values.ndim - 1))
+
+
+def field_displacement_bound(
+    transform: Displacements | Coordinates,
+    field: NgffImage,
+    dims: Sequence[str],
+    window: Sequence[tuple[int, int]] | None = None,
+) -> FieldBound:
+    """Bound the displacement of every chunk of ``field``, one chunk at a time.
+
+    One pass over the field, reading a chunk and keeping two numbers per
+    component. The values are not held: what comes back is a few floats per
+    chunk, which is what lets a caller size its reads against a field that
+    does not fit in memory.
+
+    :param transform: The ``displacements`` or ``coordinates`` transform the
+        field belongs to.
+    :type  transform: Displacements | Coordinates
+    :param field: The field image, as :func:`field_image` returns it.
+    :type  field: NgffImage
+    :param dims: The spatial axis names of the input coordinate system, in
+        RFC-5 (Zarr) order.
+    :type  dims: Sequence[str]
+    :param window: The field indices a caller will ask about, as
+        :func:`field_window` returns them. The pass then covers the chunks
+        that window touches and no others, which is what a grid smaller than
+        the field it is defined on saves. Defaults to the whole field.
+    :type  window: Sequence[tuple[int, int]] | None
+    :return: The per-chunk range, keyed by the field's own indices.
+    :rtype: FieldBound
+    """
+    dims = tuple(dims)
+    data = field.data
+    origin = spacing = None
+    if transform.type == "coordinates":
+        origin = np.array([float(field.translation[dim]) for dim in dims])
+        spacing = np.array([float(field.scale[dim]) for dim in dims])
+
+    if not hasattr(data, "chunks") or data.chunks is None:
+        values = np.asarray(data)
+        info = [{"array-location": [(0, size) for size in values.shape]}]
+        extrema = _block_extrema(
+            values, info, origin=origin, spacing=spacing, offset=(0,) * len(dims)
+        )
+        offsets = tuple(np.array([0]) for _ in dims)
+    else:
+        import dask.array as da
+
+        # The component axis is bounded as a whole: a block holding a subset
+        # of the components would report a range for the wrong ones.
+        data = data.rechunk({0: -1})
+        # Cut on chunk borders, so the pass drops whole chunks rather than
+        # reading one to use part of it, and every kept chunk keeps its own
+        # first index.
+        starts = [
+            np.concatenate([[0], np.cumsum(sizes)[:-1]]) for sizes in data.chunks[1:]
+        ]
+        if window is None:
+            window = [(0, int(size)) for size in data.shape[1:]]
+        keep = []
+        offsets = []
+        for axis, (begin, end) in enumerate(window):
+            first = max(0, int(np.searchsorted(starts[axis], begin, side="right") - 1))
+            last = int(np.searchsorted(starts[axis], max(begin, end - 1), side="right"))
+            high = int(
+                starts[axis][last] if last < len(starts[axis]) else data.shape[1 + axis]
+            )
+            keep.append(slice(int(starts[axis][first]), high))
+            offsets.append(starts[axis][first:last])
+        offset = tuple(int(kept[0]) for kept in offsets)
+        offsets = tuple(offsets)
+        # Full slices are normalized away, so an unrestricted pass is the same
+        # array and the same one code path.
+        data = data[(slice(None), *keep)]
+        counts = tuple((1,) * len(sizes) for sizes in data.chunks[1:])
+        extrema = np.asarray(
+            da.map_blocks(
+                _block_extrema,
+                data,
+                origin=origin,
+                spacing=spacing,
+                offset=offset,
+                dtype=np.float64,
+                chunks=((2 * data.shape[0],), *counts),
+                # The reductions have no identity on the zero-size block the
+                # meta probe hands in; naming the meta skips the probe.
+                meta=np.empty((0,) * data.ndim, dtype=np.float64),
+            ).compute()
+        )
+    return FieldBound(
+        dims=dims,
+        low=extrema[: len(dims)],
+        high=extrema[len(dims) :],
+        offsets=offsets,
+    )
+
+
+def field_window(
+    field: NgffImage,
+    dims: Sequence[str],
+    translation: Mapping[str, float],
+    scale: Mapping[str, float],
+    shape: Sequence[int],
+    margin: int = 1,
+) -> tuple[tuple[tuple[int, int], ...], bool]:
+    """The field indices a grid of ``shape`` at ``translation`` reads.
+
+    The field is evaluated at the grid's own points, so the window is that
+    grid's extent expressed in field indices, whatever the displacement is:
+    what a displacement sizes is the *moving* read, which
+    :class:`FieldBound` answers.
+
+    :param field: The field image.
+    :type  field: NgffImage
+    :param dims: The spatial axis names, in RFC-5 order.
+    :type  dims: Sequence[str]
+    :param translation: The grid's translation, keyed by dimension.
+    :type  translation: Mapping[str, float]
+    :param scale: The grid's scale, keyed by dimension.
+    :type  scale: Mapping[str, float]
+    :param shape: The grid's extent, in ``dims`` order.
+    :type  shape: Sequence[int]
+    :param margin: Lattice points kept beyond the bracketing pair, so that
+        linear interpolation at a point on the boundary reads the same values
+        it reads from the whole field.
+    :type  margin: int
+    :return: ``(start, stop)`` per axis, in ``dims`` order, clamped to the
+        field, and whether the grid also has points beyond the field, which
+        ITK displaces by nothing. :meth:`FieldBound.over` takes the second as
+        its ``outside``.
+    :rtype: tuple[tuple[tuple[int, int], ...], bool]
+    """
+    window = []
+    outside = False
+    for axis, dim in enumerate(dims):
+        extent = int(field.data.shape[1 + axis])
+        if shape[axis] == 0:
+            window.append((0, 0))
+            continue
+        corners = [
+            (translation[dim] + scale[dim] * index - field.translation[dim])
+            / field.scale[dim]
+            for index in (0, shape[axis] - 1)
+        ]
+        if min(corners) < 0 or max(corners) > extent - 1:
+            outside = True
+        low = int(np.floor(min(corners))) - margin
+        high = int(np.ceil(max(corners))) + margin + 1
+        window.append((max(0, min(low, extent)), max(0, min(high, extent))))
+    return tuple(window), outside
+
+
 def ngff_displacement_field_to_itk_transform(
     transform: Displacements | Coordinates,
     field,
@@ -449,45 +783,11 @@ def ngff_displacement_field_to_itk_transform(
 
     dims = _check_dims(dims)
     absolute = transform.type == "coordinates"
-    component_type = "coordinate" if absolute else "displacement"
-    if hasattr(field, "images") and hasattr(field, "metadata"):
-        # A read multiscales keeps the axis types in its metadata, not on the
-        # image: the component axis is the one typed there.
-        axes = field.metadata.intrinsic_coordinate_system.axes
-        component_dims = [axis.name for axis in axes if axis.type == component_type]
-        field = field.images[0]
-    else:
-        component_dims = [
-            dim
-            for dim, axis_type in (field.axes_types or {}).items()
-            if axis_type == component_type
-        ]
-    if len(component_dims) != 1:
-        msg = (
-            f"the field image must have exactly one axis of type "
-            f"'{component_type}' (axes_types on an NgffImage, the axes metadata "
-            f"of a multiscales); got {component_dims or 'none'} on dims "
-            f"{tuple(field.dims)}"
-        )
-        raise ValueError(msg)
-    expected_dims = (component_dims[0], *dims)
-    if tuple(field.dims) != expected_dims:
-        msg = (
-            f"the field's dims are {tuple(field.dims)}; a {transform.type} "
-            f"transform over dims {dims} needs {expected_dims}: the component "
-            "axis first, then the input axes in order"
-        )
-        raise ValueError(msg)
+    field = field_image(transform, field, dims)
 
     data = field.data
     data = np.asarray(data.compute() if hasattr(data, "compute") else data)
     dimension = len(dims)
-    if data.shape[0] != dimension:
-        msg = (
-            f"the field holds {data.shape[0]} components per point, but dims "
-            f"{dims} name {dimension} axes"
-        )
-        raise ValueError(msg)
 
     itk_dims = _itk_axis_order(dims)
     canonical = list(reversed(itk_dims))
@@ -503,19 +803,7 @@ def ngff_displacement_field_to_itk_transform(
 
     frames = _frames(fixed, moving, dims)
     if frames is None:
-        if not _is_identity(own_direction):
-            # An ITK transform lives in physical space, and without the images
-            # there is nothing to say where the oriented grid sits in it.
-            msg = (
-                "the field carries an anatomical orientation, so its grid "
-                "cannot be placed in ITK physical space on its own; pass the "
-                "fixed and moving images. resample_bounding_box and resample "
-                "have no place for them, because their RFC-5 branch works on "
-                "the intrinsic systems where no orientation applies: call "
-                "ngff_transform_to_itk_transform with both images yourself and "
-                "hand them the ITK transform it returns."
-            )
-            raise ValueError(msg)
+        check_unoriented_field(field, dims)
         frames = _unoriented_frames(dimension)
     elif not _is_identity(own_direction) and not np.allclose(
         own_direction, frames.direction_in

--- a/py/ngff_zarr/resample.py
+++ b/py/ngff_zarr/resample.py
@@ -8,11 +8,16 @@ from dataclasses import replace
 
 import numpy as np
 
+from .displacement_field_transform import field_window
 from .ngff_image import NgffImage
 from .ngff_transform_to_itk_transform import ngff_transform_to_itk_transform
 from .resample_bounding_box import (
     _as_itk_transform_list,
     _check_geometry,
+    _field_stream,
+    _grown,
+    _identity_region,
+    _identity_transform_list,
     _is_ngff_transform,
     _itk_direction,
     _metadata_only_itk_image,
@@ -20,6 +25,7 @@ from .resample_bounding_box import (
     _spatial_dims,
     resample_bounding_box,
 )
+from .v06.zarr_metadata import Coordinates, Displacements
 
 _INTERPOLATORS = (
     "linear",
@@ -104,6 +110,109 @@ def _block_grid(fixed: NgffImage, starts: dict, shape: tuple) -> NgffImage:
     )
 
 
+def _chunk_offsets(chunks):
+    """The index of each chunk's first element, per axis."""
+    return [np.concatenate([[0], np.cumsum(sizes)[:-1]]) for sizes in chunks]
+
+
+def _nested_key(keys, index):
+    """The dask key at ``index`` in a nested key list."""
+    for axis in index:
+        keys = keys[axis]
+    return keys
+
+
+def _chunk_span(offsets, bounds):
+    """Which chunks a region touches: the first, how many, and where it starts.
+
+    ``offsets`` holds the index of each chunk's first element per axis, as
+    :func:`_chunk_offsets` gives them, and ``bounds`` the region as
+    ``(start, stop)`` per axis.
+    """
+    first = tuple(
+        int(np.searchsorted(offsets[axis], start, side="right") - 1)
+        for axis, (start, _stop) in enumerate(bounds)
+    )
+    last = tuple(
+        int(np.searchsorted(offsets[axis], stop - 1, side="right"))
+        for axis, (_start, stop) in enumerate(bounds)
+    )
+    nchunks = tuple(stop - start for start, stop in zip(first, last))
+    offset = tuple(int(offsets[axis][start]) for axis, start in enumerate(first))
+    return first, nchunks, offset
+
+
+def _field_block_transform(
+    chunks,
+    *,
+    transform,
+    nchunks,
+    offset,
+    bounds,
+    field_dims,
+    field_scale,
+    field_translation,
+    field_axes_types,
+):
+    """The ITK transform one output block needs, from that block's field window.
+
+    Built inside the task, from the field chunks the window touches, so the
+    field reaches ITK a window at a time instead of whole.
+    """
+    from .displacement_field_transform import ngff_displacement_field_to_itk_transform
+
+    crop = NgffImage(
+        data=_assemble_region(chunks, nchunks, offset, bounds),
+        dims=field_dims,
+        scale=dict(field_scale),
+        translation=dict(field_translation),
+        axes_types=dict(field_axes_types),
+    )
+    return ngff_displacement_field_to_itk_transform(transform, crop, field_dims[1:])
+
+
+def _assemble_region(chunks, nchunks, offset, bounds):
+    """Reassemble whole chunks into the sub-array ``bounds`` selects.
+
+    ``chunks`` are whole chunks in C order over the ``nchunks`` grid that
+    covers the region, ``offset`` the index of the first of them in the array
+    they came from, and ``bounds`` the region itself, as ``(start, stop)`` per
+    axis.
+    """
+    nested = np.empty(nchunks, dtype=object)
+    for flat, index in enumerate(np.ndindex(*nchunks)):
+        nested[index] = chunks[flat]
+
+    # Where each chunk of the grid starts in the array it came from, per axis.
+    starts = []
+    for axis in range(len(nchunks)):
+        picker = [0] * len(nchunks)
+        sizes = []
+        for position in range(nchunks[axis]):
+            picker[axis] = position
+            sizes.append(nested[tuple(picker)].shape[axis])
+        starts.append(np.concatenate([[0], np.cumsum(sizes)[:-1]]) + offset[axis])
+
+    # Trim every chunk to its share of the region before assembling. Assembling
+    # first and slicing after would allocate the union of the chunks, which for
+    # a block whose region straddles chunk borders is several times the region.
+    for index in np.ndindex(*nchunks):
+        chunk = nested[index]
+        nested[index] = chunk[
+            tuple(
+                slice(
+                    max(0, low - starts[axis][position]),
+                    min(chunk.shape[axis], high - starts[axis][position]),
+                )
+                for axis, (position, (low, high)) in enumerate(zip(index, bounds))
+            )
+        ]
+
+    if len(chunks) == 1:
+        return np.ascontiguousarray(nested[(0,) * len(nchunks)])
+    return np.block(nested.tolist())
+
+
 def _resample_block(
     chunks,
     transform_list,
@@ -137,39 +246,7 @@ def _resample_block(
 
     from .ngff_image_to_itk_image import ngff_image_to_itk_image
 
-    nested = np.empty(nchunks, dtype=object)
-    for flat, index in enumerate(np.ndindex(*nchunks)):
-        nested[index] = chunks[flat]
-
-    # Where each chunk of the grid starts in the moving image, per axis.
-    starts = []
-    for axis in range(len(nchunks)):
-        picker = [0] * len(nchunks)
-        sizes = []
-        for position in range(nchunks[axis]):
-            picker[axis] = position
-            sizes.append(nested[tuple(picker)].shape[axis])
-        starts.append(np.concatenate([[0], np.cumsum(sizes)[:-1]]) + offset[axis])
-
-    # Trim every chunk to its share of the region before assembling. Assembling
-    # first and slicing after would allocate the union of the chunks, which for
-    # a block whose region straddles chunk borders is several times the region.
-    for index in np.ndindex(*nchunks):
-        chunk = nested[index]
-        nested[index] = chunk[
-            tuple(
-                slice(
-                    max(0, low - starts[axis][position]),
-                    min(chunk.shape[axis], high - starts[axis][position]),
-                )
-                for axis, (position, (low, high)) in enumerate(zip(index, bounds))
-            )
-        ]
-
-    if len(chunks) == 1:
-        region = np.ascontiguousarray(nested[(0,) * len(nchunks)])
-    else:
-        region = np.block(nested.tolist())
+    region = _assemble_region(chunks, nchunks, offset, bounds)
     moving_geometry = NgffImage(
         data=_shape_only(tuple(stop - start for start, stop in bounds)),
         dims=moving_dims,
@@ -211,6 +288,45 @@ def _resample_block(
     return np.asarray(resampled.data).reshape(grid_shape).astype(out_dtype, copy=False)
 
 
+def _add_field_transform(
+    graph,
+    name,
+    index,
+    transform,
+    field: NgffImage,
+    field_keys,
+    field_offsets,
+    field_geometry,
+    window,
+):
+    """Add the task that builds one block's transform, and return its key."""
+    bounds = ((0, int(field.data.shape[0])), *window)
+    first, nchunks, offset = _chunk_span(field_offsets, bounds)
+    spatial = tuple(field.dims[1:])
+    key = (name, *index)
+    graph[key] = (
+        functools.partial(
+            _field_block_transform,
+            transform=transform,
+            nchunks=nchunks,
+            offset=offset,
+            bounds=bounds,
+            field_translation=_shifted_translation(
+                field, {dim: window[axis][0] for axis, dim in enumerate(spatial)}
+            ),
+            **field_geometry,
+        ),
+        [
+            _nested_key(
+                field_keys,
+                tuple(start + relative for start, relative in zip(first, position)),
+            )
+            for position in np.ndindex(*nchunks)
+        ],
+    )
+    return key
+
+
 def resample(
     transform,
     fixed: NgffImage,
@@ -233,12 +349,18 @@ def resample(
     full moving image is never loaded, which is what makes this usable when it
     is larger than memory, remote, or chunked.
 
-    One input is not streamed: an RFC-5 ``displacements`` or ``coordinates``
-    transform is converted before the graph is built, and that conversion reads
-    its field in full. The field bounds where every block reads, so the regions
-    cannot be computed without it. A field the size of the volume therefore has
-    to fit in memory, while the moving image does not. Pass an ITK transform to
-    keep the field out of this call.
+    An RFC-5 ``displacements`` or ``coordinates`` field is streamed the same
+    way. A block reads the window of the field its own points fall in, and
+    that window becomes the block's ITK transform; what sizes the block's
+    moving read is the range of displacement that window holds. The field is
+    passed over once when the graph is built, a chunk at a time, to learn that
+    range per chunk. Neither the moving image nor the field has to fit in
+    memory.
+
+    A window declares its own origin, and on a float64 moving image that
+    changes the last bits of the continuous index ITK computes from it, so
+    the result is bit-identical to an undecomposed call on float32 and equal
+    to about ``1e-13`` on float64.
 
     Resampling runs through ``itkwasm-downsample``, so no native ITK build is
     required and the result is identical to one across platforms.
@@ -333,10 +455,24 @@ def resample(
 
     dtype = moving.data.dtype
     out_orientations = fixed.axes_orientations
+    field = None
+    field_bound = None
     if _is_ngff_transform(transform):
-        transform_list = ngff_transform_to_itk_transform(
-            transform, fixed.dims, fields=fields
-        )
+        if isinstance(transform, (Coordinates, Displacements)):
+            # The blocks divide the grid, so the grid's own window is the
+            # union of theirs: the pass reads no chunk no block asks about.
+            field, field_bound, _window, _outside = _field_stream(
+                transform,
+                fields,
+                fixed,
+                fixed_spatial,
+                dict(zip(fixed.dims, fixed.data.shape)),
+            )
+            transform_list = _identity_transform_list(fixed.dims)
+        else:
+            transform_list = ngff_transform_to_itk_transform(
+                transform, fixed.dims, fields=fields
+            )
         # An RFC-5 transformation acts on the intrinsic coordinate systems,
         # which carry no direction matrix, so the blocks below are resampled
         # with none either. That is what resample_bounding_box does with the
@@ -347,18 +483,23 @@ def resample(
         transform_list = _as_itk_transform_list(transform)
 
     out_chunks = fixed.data.chunks
-    out_offsets = [np.concatenate([[0], np.cumsum(sizes)[:-1]]) for sizes in out_chunks]
-    moving_chunks = moving.data.chunks
-    moving_offsets = [
-        np.concatenate([[0], np.cumsum(sizes)[:-1]]) for sizes in moving_chunks
-    ]
+    out_offsets = _chunk_offsets(out_chunks)
+    moving_offsets = _chunk_offsets(moving.data.chunks)
     moving_keys = moving.data.__dask_keys__()
 
-    def moving_key(index):
-        key = moving_keys
-        for i in index:
-            key = key[i]
-        return key
+    field_data = None
+    if field is not None:
+        field_data = field.data
+        if not isinstance(field_data, da.Array):
+            field_data = da.from_array(field_data)
+        field_offsets = _chunk_offsets(field_data.chunks)
+        field_keys = field_data.__dask_keys__()
+        # The geometry every block's crop of the field shares, built once.
+        field_geometry = {
+            "field_dims": tuple(field.dims),
+            "field_scale": dict(field.scale),
+            "field_axes_types": dict(field.axes_types),
+        }
 
     # Every input the result depends on belongs in the token. The moving
     # image's geometry is not carried by its array name, so leaving it out
@@ -376,6 +517,8 @@ def resample(
         fixed.translation,
         fixed.axes_orientations,
         transform_list,
+        None if field_data is None else field_data.name,
+        None if field is None else (field.scale, field.translation, transform),
         padding,
         interpolator,
         default_value,
@@ -393,31 +536,51 @@ def resample(
         }
         shape = tuple(int(out_chunks[axis][index[axis]]) for axis in range(len(index)))
         grid = _block_grid(fixed, starts, shape)
-        region = resample_bounding_box(transform_list, grid, moving, padding=padding)
+        block_transform = transform_key
+        if field is not None:
+            window, outside = field_window(
+                field, tuple(fixed.dims), grid.translation, grid.scale, shape
+            )
+            region = _grown(
+                _identity_region(grid, moving, padding),
+                field_bound.over(window, outside),
+                moving,
+            )
+        else:
+            region = resample_bounding_box(
+                transform_list, grid, moving, padding=padding
+            )
         if region.is_empty:
             graph[(name, *index)] = (np.full, shape, default_value, dtype)
             continue
+        if field is not None and not any(stop <= start for start, stop in window):
+            # A block whose window is empty falls through to transform_key,
+            # which on this path holds the identity: outside the field ITK
+            # displaces nothing either.
+            block_transform = _add_field_transform(
+                graph,
+                f"{name}-field",
+                index,
+                transform,
+                field,
+                field_keys,
+                field_offsets,
+                field_geometry,
+                window,
+            )
         clamped = region.clamped()
         bounds = tuple(
             clamped[dim] if dim in clamped else (0, moving.data.shape[axis])
             for axis, dim in enumerate(moving.dims)
         )
-        first_chunk = tuple(
-            int(np.searchsorted(moving_offsets[axis], start, side="right") - 1)
-            for axis, (start, _stop) in enumerate(bounds)
-        )
-        last_chunk = tuple(
-            int(np.searchsorted(moving_offsets[axis], stop - 1, side="right"))
-            for axis, (_start, stop) in enumerate(bounds)
-        )
-        nchunks = tuple(last - first for first, last in zip(first_chunk, last_chunk))
+        first_chunk, nchunks, offset = _chunk_span(moving_offsets, bounds)
         chunk_keys = [
-            moving_key(tuple(first + rel for first, rel in zip(first_chunk, relative)))
+            _nested_key(
+                moving_keys,
+                tuple(first + rel for first, rel in zip(first_chunk, relative)),
+            )
             for relative in np.ndindex(*nchunks)
         ]
-        offset = tuple(
-            int(moving_offsets[axis][first]) for axis, first in enumerate(first_chunk)
-        )
         graph[(name, *index)] = (
             functools.partial(
                 _resample_block,
@@ -438,11 +601,14 @@ def resample(
                 out_dtype=dtype,
             ),
             chunk_keys,
-            transform_key,
+            block_transform,
         )
 
+    dependencies = [moving.data]
+    if field_data is not None:
+        dependencies.append(field_data)
     data = da.Array(
-        HighLevelGraph.from_collections(name, graph, dependencies=[moving.data]),
+        HighLevelGraph.from_collections(name, graph, dependencies=dependencies),
         name,
         chunks=out_chunks,
         dtype=dtype,

--- a/py/ngff_zarr/resample_bounding_box.py
+++ b/py/ngff_zarr/resample_bounding_box.py
@@ -4,14 +4,14 @@
 
 import math
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import numpy as np
 
 from .ngff_image import NgffImage
 from .ngff_transform_to_itk_transform import ngff_transform_to_itk_transform
 from .rfc4 import anatomical_orientation_to_itk_direction
-from .v06.zarr_metadata import BaseTransform
+from .v06.zarr_metadata import BaseTransform, Coordinates, Displacements
 
 _SPATIAL_DIMS = ("x", "y", "z")
 
@@ -111,6 +111,55 @@ class ResampleBoundingBox:
             channel_names=moving.channel_names,
             channel_colors=moving.channel_colors,
         )
+
+
+def _grown(
+    region: "ResampleBoundingBox",
+    bound: Mapping[str, tuple[float, float]],
+    moving: NgffImage,
+) -> "ResampleBoundingBox":
+    """``region`` moved and widened by a per-axis displacement range.
+
+    The pipeline walks the boundary of the transformed grid, which reports
+    where a *linear* map sends the grid exactly and misses whatever a
+    displacement does strictly inside it. A point ``p`` of the region reaches
+    ``p + d`` with ``d`` in ``bound``, so the region's image lies between the
+    two ends of that range: a field that shifts every point the same way moves
+    the region, and only what varies widens it.
+    """
+    start = dict(region.start_index)
+    size = dict(region.size)
+    corners_min = dict(region.corners_min)
+    corners_max = dict(region.corners_max)
+    padded_min = dict(region.padded_corners_min)
+    padded_max = dict(region.padded_corners_max)
+    for dim in region.dims:
+        low, high = bound.get(dim, (0.0, 0.0))
+        if low == 0.0 and high == 0.0:
+            continue
+        scale = float(moving.scale[dim])
+        first = math.floor(min(low / scale, high / scale))
+        last = math.ceil(max(low / scale, high / scale))
+        start[dim] += first
+        size[dim] += last - first
+        # The reported corners hold a first and a last index position, which
+        # swap when an axis direction is negative; move the span either way.
+        for begin, stop in ((corners_min, corners_max), (padded_min, padded_max)):
+            if begin[dim] <= stop[dim]:
+                begin[dim] += low
+                stop[dim] += high
+            else:
+                begin[dim] += high
+                stop[dim] += low
+    return replace(
+        region,
+        start_index=start,
+        size=size,
+        corners_min=corners_min,
+        corners_max=corners_max,
+        padded_corners_min=padded_min,
+        padded_corners_max=padded_max,
+    )
 
 
 def _spatial_dims(ngff_image: NgffImage) -> list[str]:
@@ -391,6 +440,119 @@ def _transform_from_dict(entry: dict):
     return ItkTransform(**entry)
 
 
+def _identity_region(
+    grid: NgffImage, moving: NgffImage, padding: int
+) -> "ResampleBoundingBox":
+    """The region the pipeline reports for the identity, computed directly.
+
+    A field transform's linear part is the identity, so its ungrown region is
+    plain arithmetic: the grid's own physical extent, read off in the moving
+    image's index space, floored and ceiled, padded. Equality with the
+    pipeline is pinned by ``test_the_identity_region_is_the_pipelines`` over
+    randomized geometry. Only :func:`~ngff_zarr.resample`'s per-block loop
+    uses it, where the pipeline round trip measured as three quarters of the
+    graph build; :func:`resample_bounding_box` itself stays on the pipeline.
+
+    ``grid`` must have at least one sample per spatial axis, which
+    :func:`resample_bounding_box` establishes before reaching a transform.
+    """
+    spatial = _spatial_dims(grid)
+    grid_dims = tuple(grid.dims)
+    moving_dims = tuple(moving.dims)
+    start_index = {}
+    size = {}
+    corners_min = {}
+    corners_max = {}
+    padded_min = {}
+    padded_max = {}
+    for dim in spatial:
+        extent = int(grid.data.shape[grid_dims.index(dim)])
+        first = float(grid.translation[dim])
+        last = first + (extent - 1) * float(grid.scale[dim])
+        scale = float(moving.scale[dim])
+        translation = float(moving.translation[dim])
+        low = (min(first, last) - translation) / scale
+        high = (max(first, last) - translation) / scale
+        low, high = min(low, high), max(low, high)
+        start = math.floor(low) - padding
+        count = math.ceil(high) + padding - start + 1
+        start_index[dim] = start
+        size[dim] = count
+        corners_min[dim] = min(first, last)
+        corners_max[dim] = max(first, last)
+        padded_min[dim] = translation + start * scale
+        padded_max[dim] = translation + (start + count - 1) * scale
+    return ResampleBoundingBox(
+        dims=tuple(spatial),
+        start_index=start_index,
+        size=size,
+        corners_min=corners_min,
+        corners_max=corners_max,
+        padded_corners_min=padded_min,
+        padded_corners_max=padded_max,
+        moving_shape={
+            dim: int(moving.data.shape[moving_dims.index(dim)]) for dim in spatial
+        },
+    )
+
+
+def _field_stream(
+    transform,
+    fields: Mapping[str, object] | None,
+    fixed: NgffImage,
+    spatial: Sequence[str],
+    extent: Mapping[str, int],
+):
+    """The field a field transform names, its per-chunk range, and its window.
+
+    A ``displacements`` or ``coordinates`` transform is the identity plus a
+    displacement, so a region is the grid's own image moved and widened by
+    what the field can displace there. The range comes from the field's
+    values, read one chunk at a time and kept as two numbers per chunk, so a
+    field larger than memory is bounded without being held.
+
+    The field comes back carrying the axis type its component axis has, which
+    a field read from a multiscales keeps in the metadata rather than on the
+    image, so a crop of it is typed without consulting the transform again.
+    """
+    from .displacement_field_transform import (
+        _fields_entry,
+        check_unoriented_field,
+        field_displacement_bound,
+        field_image,
+        field_window,
+    )
+
+    spatial = tuple(spatial)
+    field = field_image(transform, _fields_entry(transform, fields), spatial)
+    check_unoriented_field(field, spatial)
+    field = replace(
+        field,
+        axes_types={
+            **(field.axes_types or {}),
+            field.dims[0]: (
+                "coordinate" if transform.type == "coordinates" else "displacement"
+            ),
+        },
+    )
+    window, outside = field_window(
+        field,
+        spatial,
+        fixed.translation,
+        fixed.scale,
+        [extent[dim] for dim in spatial],
+    )
+    bound = field_displacement_bound(transform, field, spatial, window)
+    return field, bound, window, outside
+
+
+def _identity_transform_list(dims: Sequence[str]) -> list:
+    """A field transform's linear part, which is the identity."""
+    from .v06.zarr_metadata import Identity
+
+    return ngff_transform_to_itk_transform(Identity(), dims)
+
+
 def resample_bounding_box(
     transform,
     fixed: NgffImage,
@@ -427,6 +589,15 @@ def resample_bounding_box(
     ``mapAxis``, ``byDimension``, ``bijection``, or a ``sequence`` of them --
     or a ``displacements`` or ``coordinates`` transformation whose field is
     passed in ``fields``.
+
+    A field transform is the identity plus a displacement, and the region it
+    reports is the grid's own image moved and widened by the range that
+    displacement takes. The range is read from the field one chunk at a time,
+    so a field larger than memory is never held; a field that shifts every
+    point the same way moves the region rather than widening it. An ITK
+    transform is instead measured by walking the boundary of the transformed
+    grid, which reports a linear map exactly and misses what a non-linear one
+    does strictly inside the grid.
 
     In both cases the transform maps *fixed* points into *moving* space.
 
@@ -518,10 +689,21 @@ def resample_bounding_box(
             moving_shape=moving_shape,
         )
 
+    field_bound = None
     if _is_ngff_transform(transform):
-        transform_list = ngff_transform_to_itk_transform(
-            transform, fixed.dims, fields=fields
-        )
+        if isinstance(transform, (Coordinates, Displacements)):
+            # A field transform is the identity plus a displacement: the
+            # pipeline measures the identity, and the displacement widens the
+            # result through the range read off the field.
+            _field, bound, window, outside = _field_stream(
+                transform, fields, fixed, fixed_spatial, fixed_extent
+            )
+            field_bound = bound.over(window, outside)
+            transform_list = _identity_transform_list(fixed.dims)
+        else:
+            transform_list = ngff_transform_to_itk_transform(
+                transform, fixed.dims, fields=fields
+            )
         # An RFC-5 transformation is defined on the intrinsic coordinate
         # system, which carries no direction matrix.
         fixed_direction = np.eye(len(itk_dims))
@@ -548,7 +730,7 @@ def resample_bounding_box(
         indexed = dict(zip(itk_dims, values))
         return {dim: indexed[dim] for dim in fixed_spatial}
 
-    return ResampleBoundingBox(
+    region = ResampleBoundingBox(
         dims=tuple(fixed_spatial),
         start_index={k: int(v) for k, v in by_dim(result["paddedStartIndex"]).items()},
         size={k: int(v) for k, v in by_dim(result["paddedSize"]).items()},
@@ -562,3 +744,6 @@ def resample_bounding_box(
         },
         moving_shape=moving_shape,
     )
+    if field_bound is None:
+        return region
+    return _grown(region, field_bound, moving)

--- a/py/test/test_resample_bounding_box.py
+++ b/py/test/test_resample_bounding_box.py
@@ -1059,3 +1059,140 @@ def test_rfc5_coordinates_matches_the_displacements_it_equals():
 
     assert via_coordinates.start_index == via_displacements.start_index
     assert via_coordinates.size == via_displacements.size
+
+
+def _interior_bump(extent, radius, peaks):
+    """A displacement that is zero on the grid boundary and peaks in the middle.
+
+    The boundary walk the pipeline runs sees only the zero, which is what
+    makes this the case a region has to be widened for.
+    """
+    axes = np.mgrid[tuple(slice(0, extent) for _ in peaks)].astype(np.float64)
+    distance = np.sqrt(sum((axis - extent / 2) ** 2 for axis in axes))
+    profile = np.where(
+        distance < radius, 0.5 * (1 + np.cos(np.pi * distance / radius)), 0.0
+    )
+    return np.stack([peak * profile for peak in peaks]).astype(np.float32)
+
+
+def test_a_bump_inside_the_grid_widens_the_region():
+    """The reported region has to contain what the field displaces onto.
+
+    The pipeline sizes a region by walking the boundary of the transformed
+    grid, so a displacement that is zero there and large inside left the
+    region covering the grid alone. The peak here carries the grid past its
+    own extent, so that is not enough.
+    """
+    fixed = _image("yx", {"y": 64, "x": 64}, {"y": 1.0, "x": 1.0}, {"y": 0.0, "x": 0.0})
+    moving = _image(
+        "yx", {"y": 160, "x": 160}, {"y": 1.0, "x": 1.0}, {"y": 0.0, "x": 0.0}
+    )
+    values = _interior_bump(64, 20, (60.0, -60.0))
+    assert float(np.abs(values[:, 0, :]).max()) == 0.0
+    assert float(np.abs(values[:, -1, :]).max()) == 0.0
+    field = NgffImage(
+        data=da.from_array(values, chunks=(2, 16, 16)),
+        dims=("c", "y", "x"),
+        scale=dict.fromkeys(("c", "y", "x"), 1.0),
+        translation=dict.fromkeys(("c", "y", "x"), 0.0),
+        axes_types={"c": "displacement"},
+    )
+
+    region = resample_bounding_box(
+        Displacements(path="warp"), fixed, moving, fields={"warp": field}
+    )
+
+    index = np.mgrid[0:64, 0:64].astype(np.float64)
+    for axis, dim in enumerate(("y", "x")):
+        reached = index[axis] + values[axis]
+        assert region.start_index[dim] <= float(reached.min())
+        assert region.start_index[dim] + region.size[dim] >= float(reached.max())
+
+
+def test_a_fields_chunking_does_not_change_the_region_it_reports():
+    """The range is read a chunk at a time; over the whole grid it is one range."""
+    fixed = _image("yx", {"y": 64, "x": 64}, {"y": 1.0, "x": 1.0}, {"y": 0.0, "x": 0.0})
+    moving = _image(
+        "yx", {"y": 160, "x": 160}, {"y": 1.0, "x": 1.0}, {"y": 0.0, "x": 0.0}
+    )
+    values = _interior_bump(64, 20, (60.0, -60.0))
+
+    regions = []
+    for chunks in ((2, 16, 16), (2, 64, 64)):
+        field = NgffImage(
+            data=da.from_array(values, chunks=chunks),
+            dims=("c", "y", "x"),
+            scale=dict.fromkeys(("c", "y", "x"), 1.0),
+            translation=dict.fromkeys(("c", "y", "x"), 0.0),
+            axes_types={"c": "displacement"},
+        )
+        regions.append(
+            resample_bounding_box(
+                Displacements(path="warp"), fixed, moving, fields={"warp": field}
+            )
+        )
+
+    assert regions[0].start_index == regions[1].start_index
+    assert regions[0].size == regions[1].size
+
+
+def test_the_identity_region_is_the_pipelines():
+    """The arithmetic region and the pipeline's agree, field for field.
+
+    The field path derives its region from `_identity_region` rather than a
+    per-block pipeline call, so the two must not drift: randomized geometry,
+    fractional and integer scales and translations, paddings 0 to 3.
+    """
+    from ngff_zarr.ngff_transform_to_itk_transform import (
+        ngff_transform_to_itk_transform,
+    )
+    from ngff_zarr.resample_bounding_box import _identity_region
+
+    rng = np.random.default_rng(0)
+    for _ in range(25):
+        ndim = int(rng.integers(2, 4))
+        dims = ("z", "y", "x")[-ndim:]
+
+        def geometry():
+            kind = int(rng.integers(0, 3))
+            if kind == 0:
+                return 1.0
+            if kind == 1:
+                return float(rng.integers(1, 4))
+            return float(np.round(rng.random() * 3 + 0.25, 3))
+
+        def offset():
+            if rng.random() < 0.7:
+                return float(np.round(rng.random() * 20 - 10, 3))
+            return float(rng.integers(-10, 10))
+
+        grid = NgffImage(
+            data=da.zeros(tuple(int(v) for v in rng.integers(1, 40, ndim))),
+            dims=dims,
+            scale={dim: geometry() for dim in dims},
+            translation={dim: offset() for dim in dims},
+        )
+        moving = NgffImage(
+            data=da.zeros(tuple(int(v) for v in rng.integers(8, 200, ndim))),
+            dims=dims,
+            scale={dim: geometry() for dim in dims},
+            translation={dim: offset() for dim in dims},
+        )
+        padding = int(rng.integers(0, 4))
+        identity = ngff_transform_to_itk_transform(Identity(), dims)
+
+        pipeline = resample_bounding_box(identity, grid, moving, padding=padding)
+        direct = _identity_region(grid, moving, padding)
+
+        assert direct.dims == pipeline.dims
+        assert direct.start_index == pipeline.start_index
+        assert direct.size == pipeline.size
+        assert direct.moving_shape == pipeline.moving_shape
+        for mine, theirs in (
+            (direct.corners_min, pipeline.corners_min),
+            (direct.corners_max, pipeline.corners_max),
+            (direct.padded_corners_min, pipeline.padded_corners_min),
+            (direct.padded_corners_max, pipeline.padded_corners_max),
+        ):
+            for dim in dims:
+                np.testing.assert_allclose(mine[dim], theirs[dim], rtol=1e-12)

--- a/py/test/test_resample_field_streaming.py
+++ b/py/test/test_resample_field_streaming.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Resampling through a field that is read a window at a time.
+
+The anchor everywhere is a single undecomposed ITK call with the whole field
+converted: the streamed result has to be that result, pixel for pixel. What
+the streaming changes is what has to be in memory to reach it, and what a
+region of the grid is allowed to displace onto.
+"""
+
+import dask.array as da
+import numpy as np
+import pytest
+from ngff_zarr import (
+    NgffImage,
+    ngff_transform_to_itk_transform,
+    resample,
+    to_multiscales,
+)
+from ngff_zarr.displacement_field_transform import field_displacement_bound
+from ngff_zarr.v06.zarr_metadata import Coordinates, Displacements
+
+from .test_resample import _whole_image_reference
+from .test_resample_bounding_box import _interior_bump
+
+pytest.importorskip("itkwasm_downsample")
+
+
+def _grid(dims, shape, chunks=None, scale=1.0, translation=0.0, seed=None):
+    if seed is None:
+        array = np.zeros(shape, dtype=np.float32)
+    else:
+        array = (np.random.default_rng(seed).random(shape) * 100.0).astype(np.float32)
+    return NgffImage(
+        data=da.from_array(array, chunks=chunks or shape),
+        dims=tuple(dims),
+        scale=dict.fromkeys(dims, scale),
+        translation=dict.fromkeys(dims, translation),
+    )
+
+
+def _field(values, dims, chunks, absolute=False):
+    """A field image over ``dims``, its component axis first."""
+    component = "coordinate" if absolute else "displacement"
+    return NgffImage(
+        data=da.from_array(values, chunks=chunks),
+        dims=("c", *dims),
+        scale=dict.fromkeys(("c", *dims), 1.0),
+        translation=dict.fromkeys(("c", *dims), 0.0),
+        axes_types={"c": component},
+    )
+
+
+def _bump(extent, radius, peaks):
+    """An interior bump, checked to be exactly zero on the grid boundary.
+
+    The boundary walk the pipeline runs sees only that zero, which is what
+    makes this the case a region has to be widened for.
+    """
+    values = _interior_bump(extent, radius, peaks)
+    for axis in range(1, values.ndim):
+        for edge in (0, -1):
+            assert float(np.abs(values.take(edge, axis=axis)).max()) == 0.0
+    return values
+
+
+def _as_itk(transform, field, dims):
+    return ngff_transform_to_itk_transform(transform, dims, fields={"warp": field})
+
+
+def test_a_field_resamples_like_one_whole_image_call():
+    """The streamed result is the undecomposed result, pixel for pixel."""
+    moving = _grid("yx", (96, 96), chunks=(16, 16), seed=0)
+    fixed = _grid("yx", (64, 64), chunks=(16, 16))
+    values = (np.random.default_rng(1).random((2, 64, 64)) * 6.0 - 3.0).astype(
+        np.float32
+    )
+    field = _field(values, ("y", "x"), chunks=(2, 16, 16))
+    transform = Displacements(path="warp")
+
+    result = np.asarray(resample(transform, fixed, moving, fields={"warp": field}).data)
+
+    expected = _whole_image_reference(
+        _as_itk(transform, field, ("y", "x")), fixed, moving
+    )
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_a_bump_inside_the_grid_is_not_missed():
+    """A displacement the grid's boundary does not show still gets its pixels.
+
+    The pipeline sizes a region by walking the boundary of the transformed
+    grid, so a bump strictly inside it left the region unchanged and the
+    pixels it displaces onto unread: they came back as the default value.
+    """
+    moving = _grid("yx", (160, 160), chunks=(32, 32), seed=0)
+    fixed = _grid("yx", (64, 64), chunks=(16, 16))
+    field = _field(_bump(64, 20, (24.0, -24.0)), ("y", "x"), chunks=(2, 16, 16))
+    transform = Displacements(path="warp")
+
+    result = np.asarray(resample(transform, fixed, moving, fields={"warp": field}).data)
+
+    expected = _whole_image_reference(
+        _as_itk(transform, field, ("y", "x")), fixed, moving
+    )
+    np.testing.assert_array_equal(result, expected)
+    # The bump reaches pixels the unwidened region excluded, so this is only
+    # a real test while those pixels carry something.
+    assert float(np.abs(result[24:40, 24:40]).max()) > 0.0
+
+
+def test_the_field_is_read_a_window_at_a_time():
+    """No block depends on more of the field than its own window covers."""
+    moving = _grid("yx", (64, 64), chunks=(16, 16))
+    fixed = _grid("yx", (64, 64), chunks=(16, 16))
+    field = _field(
+        np.zeros((2, 64, 64), dtype=np.float32), ("y", "x"), chunks=(2, 16, 16)
+    )
+
+    result = resample(Displacements(path="warp"), fixed, moving, fields={"warp": field})
+
+    graph = dict(result.data.__dask_graph__())
+    per_block = [
+        len(task[1])
+        for key, task in graph.items()
+        if isinstance(key, tuple) and str(key[0]).endswith("-field")
+    ]
+    assert per_block, "no per-block field task was built"
+    # 16 chunks in the field; a block covers one and its neighbours.
+    assert max(per_block) <= 9
+
+
+def test_a_coordinates_field_resamples_like_the_displacements_it_equals():
+    moving = _grid("yx", (96, 96), chunks=(16, 16), seed=0)
+    fixed = _grid("yx", (64, 64), chunks=(16, 16))
+    values = (np.random.default_rng(2).random((2, 64, 64)) * 6.0 - 3.0).astype(
+        np.float32
+    )
+    grid = np.mgrid[0:64, 0:64].astype(np.float32)
+    displacements = _field(values, ("y", "x"), chunks=(2, 16, 16))
+    coordinates = _field(values + grid, ("y", "x"), chunks=(2, 16, 16), absolute=True)
+
+    relative = resample(
+        Displacements(path="warp"), fixed, moving, fields={"warp": displacements}
+    )
+    absolute = resample(
+        Coordinates(path="warp"), fixed, moving, fields={"warp": coordinates}
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(absolute.data), np.asarray(relative.data), rtol=1e-5, atol=1e-3
+    )
+
+
+def test_a_field_read_from_a_multiscales_streams(tmp_path):
+    """A field whose component axis is typed in the metadata, not on the image."""
+    from ngff_zarr import from_ome_zarr, to_ome_zarr
+
+    values = (np.random.default_rng(3).random((2, 64, 64)) * 6.0 - 3.0).astype(
+        np.float32
+    )
+    path = str(tmp_path / "warp.ome.zarr")
+    to_ome_zarr(
+        path,
+        to_multiscales(
+            _field(values, ("y", "x"), chunks=(2, 16, 16)),
+            scale_factors=[],
+            chunks=(2, 16, 16),
+        ),
+        version="0.6",
+    )
+    stored = from_ome_zarr(path)
+
+    moving = _grid("yx", (96, 96), chunks=(16, 16), seed=0)
+    fixed = _grid("yx", (64, 64), chunks=(16, 16))
+    transform = Displacements(path="warp")
+
+    result = resample(transform, fixed, moving, fields={"warp": stored})
+
+    expected = _whole_image_reference(
+        _as_itk(transform, stored, ("y", "x")), fixed, moving
+    )
+    np.testing.assert_array_equal(np.asarray(result.data), expected)
+
+
+def test_a_grid_beyond_the_field_takes_the_identity():
+    """Outside the field ITK displaces nothing, and so does an empty window."""
+    moving = _grid("yx", (96, 96), chunks=(16, 16), seed=0)
+    fixed = NgffImage(
+        data=da.zeros((16, 16), chunks=(16, 16), dtype=np.float32),
+        dims=("y", "x"),
+        scale={"y": 1.0, "x": 1.0},
+        translation={"y": 70.0, "x": 70.0},
+    )
+    field = _field(
+        np.full((2, 32, 32), 5.0, dtype=np.float32), ("y", "x"), chunks=(2, 16, 16)
+    )
+    transform = Displacements(path="warp")
+
+    result = resample(transform, fixed, moving, fields={"warp": field})
+
+    expected = _whole_image_reference(
+        _as_itk(transform, field, ("y", "x")), fixed, moving
+    )
+    np.testing.assert_array_equal(np.asarray(result.data), expected)
+
+
+def test_the_bound_pass_reads_only_the_chunks_the_grid_touches():
+    """A grid smaller than the field it is defined on pays for its own part."""
+    read = []
+
+    def counting(block, block_info=None):
+        read.append(block_info[0]["chunk-location"])
+        return block
+
+    raw = da.zeros((2, 256, 256), chunks=(2, 32, 32), dtype=np.float32)
+    field = NgffImage(
+        data=raw.map_blocks(counting, dtype=np.float32),
+        dims=("c", "y", "x"),
+        scale=dict.fromkeys(("c", "y", "x"), 1.0),
+        translation=dict.fromkeys(("c", "y", "x"), 0.0),
+        axes_types={"c": "displacement"},
+    )
+    moving = _grid("yx", (256, 256), chunks=(32, 32))
+    fixed = _grid("yx", (32, 32), chunks=(16, 16))
+
+    resample(Displacements(path="warp"), fixed, moving, fields={"warp": field})
+
+    assert int(np.prod([len(sizes) for sizes in raw.chunks])) == 64
+    assert len(set(read)) == 4
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_a_restricted_bound_is_the_bound_over_the_same_window(absolute):
+    """Reading fewer chunks has to give the same range, and a real range.
+
+    Random windows against uneven chunks, since the pass cuts on chunk
+    borders and an off-border window is where an index offset goes wrong.
+    """
+    rng = np.random.default_rng(0)
+    for _ in range(12):
+        extent = int(rng.integers(20, 70))
+        borders = np.linspace(0, extent, int(rng.integers(3, 7))).astype(int)
+        chunks = tuple(int(size) for size in np.diff(borders) if size > 0)
+        values = (rng.random((2, extent, extent)) * 20 - 10).astype(np.float32)
+        stored = values
+        if absolute:
+            stored = values + np.mgrid[0:extent, 0:extent].astype(np.float32)
+        field = NgffImage(
+            data=da.from_array(stored, chunks=(2, chunks, chunks)),
+            dims=("c", "y", "x"),
+            scale=dict.fromkeys(("c", "y", "x"), 1.0),
+            translation=dict.fromkeys(("c", "y", "x"), 0.0),
+            axes_types={"c": "coordinate" if absolute else "displacement"},
+        )
+        transform = Coordinates(path="w") if absolute else Displacements(path="w")
+        window = tuple(
+            (int(low), int(rng.integers(low + 1, extent + 1)))
+            for low in rng.integers(0, extent, size=2)
+        )
+
+        restricted = field_displacement_bound(transform, field, ("y", "x"), window)
+        whole = field_displacement_bound(transform, field, ("y", "x"))
+
+        ranges = restricted.over(window)
+        assert ranges.keys() == whole.over(window).keys()
+        for dim, (low, high) in ranges.items():
+            reference = whole.over(window)[dim]
+            np.testing.assert_allclose((low, high), reference, atol=1e-4)
+        inside = values[
+            :, window[0][0] : window[0][1], window[1][0] : window[1][1]
+        ].reshape(2, -1)
+        for axis, dim in enumerate(("y", "x")):
+            low, high = ranges[dim]
+            assert low <= inside[axis].min() + 1e-4
+            assert high >= inside[axis].max() - 1e-4
+
+
+def test_a_grid_reaching_past_the_field_keeps_the_points_it_displaces_nothing():
+    """A grid half on the field and half off it reads both halves.
+
+    ITK displaces a point beyond the field by nothing, so zero belongs in the
+    range as much as the values do. A field that displaces every point it
+    covers the same way otherwise carries the region off the points it does
+    not cover, and those come back as the default value.
+    """
+    moving = _grid("yx", (160, 160), chunks=(32, 32), seed=0)
+    fixed = _grid("yx", (64, 64), chunks=(64, 64))
+    field = _field(
+        np.full((2, 32, 32), -5.0, dtype=np.float32), ("y", "x"), chunks=(2, 16, 16)
+    )
+    transform = Displacements(path="warp")
+
+    result = np.asarray(resample(transform, fixed, moving, fields={"warp": field}).data)
+
+    expected = _whole_image_reference(
+        _as_itk(transform, field, ("y", "x")), fixed, moving
+    )
+    np.testing.assert_array_equal(result, expected)
+    # The half beyond the field is the half at stake, so it has to carry
+    # something for this to be a test.
+    assert float(np.abs(result[32:, 32:]).max()) > 0.0

--- a/ts/src/io/resample_bounding_box-shared.ts
+++ b/ts/src/io/resample_bounding_box-shared.ts
@@ -16,7 +16,12 @@ import type { NgffMultiscales } from "../types/multiscales.ts";
 import { identityDirection, itkDirection } from "../utils/itk_direction.ts";
 export { itkDirection };
 import { ngffTransformToItkTransform } from "../utils/ngff_transform_to_itk_transform.ts";
-import { ngffDisplacementFieldToItkTransform } from "../utils/displacement_field_transform.ts";
+import {
+  checkUnorientedField,
+  fieldDisplacementRange,
+  fieldImage,
+  fieldWindow,
+} from "../utils/displacement_field_transform.ts";
 
 const SPATIAL_DIMS = ["x", "y", "z"];
 
@@ -394,6 +399,7 @@ export async function resampleBoundingBoxShared(
   let transformList: TransformList;
   let fixedDirection: Float64Array;
   let movingDirection: Float64Array;
+  let fieldRange: { low: number[]; high: number[] } | undefined;
 
   if (Array.isArray(transform)) {
     // An ITK transform list acts on ITK physical space, so the geometry is
@@ -402,16 +408,40 @@ export async function resampleBoundingBoxShared(
     fixedDirection = itkDirection(fixed, itkDims);
     movingDirection = itkDirection(moving, itkDims);
   } else if (isV06Transform(transform)) {
-    transformList =
+    if (
       transform.type === "displacements" || transform.type === "coordinates"
-        // The field is an array, so it comes in beside the transformation
-        // rather than inside it.
-        ? await ngffDisplacementFieldToItkTransform(
-          transform,
-          fieldFor(transform, options.fields),
-          fixedSpatial,
-        )
-        : ngffTransformToItkTransform(transform, fixed.dims);
+    ) {
+      // A field transform is the identity plus a displacement. The identity
+      // is what the pipeline measures; the displacement is read off the field
+      // a chunk at a time and widens the region afterwards, so the field is
+      // never held whole and a bump inside the grid is not walked past.
+      const image = fieldImage(
+        transform,
+        fieldFor(transform, options.fields),
+        fixedSpatial,
+      );
+      checkUnorientedField(image, fixedSpatial);
+      const { window, outside } = fieldWindow(
+        image,
+        fixedSpatial,
+        fixed.translation,
+        fixed.scale,
+        fixedSpatial.map((dim) => fixed.data.shape[fixed.dims.indexOf(dim)]),
+      );
+      fieldRange = await fieldDisplacementRange(
+        transform,
+        image,
+        fixedSpatial,
+        window,
+        outside,
+      );
+      transformList = ngffTransformToItkTransform(
+        { type: "identity" },
+        fixed.dims,
+      );
+    } else {
+      transformList = ngffTransformToItkTransform(transform, fixed.dims);
+    }
     // An RFC-5 transformation is defined on the intrinsic coordinate system,
     // which carries no direction matrix.
     fixedDirection = identityDirection(itkDims.length);
@@ -446,7 +476,7 @@ export async function resampleBoundingBoxShared(
     return record;
   };
 
-  return new ResampleBoundingBox({
+  const region = new ResampleBoundingBox({
     dims: fixedSpatial,
     startIndex: byDim(raw.paddedStartIndex),
     size: byDim(raw.paddedSize),
@@ -454,6 +484,70 @@ export async function resampleBoundingBoxShared(
     cornersMax: byDim(raw.corners.max),
     paddedCornersMin: byDim(raw.paddedCorners.min),
     paddedCornersMax: byDim(raw.paddedCorners.max),
+    movingShape,
+  });
+  return fieldRange === undefined
+    ? region
+    : grown(region, fieldRange, fixedSpatial, moving, movingShape);
+}
+
+/**
+ * `region` moved and widened by a per-axis displacement range.
+ *
+ * The pipeline walks the boundary of the transformed grid, which reports
+ * where a *linear* map sends the grid exactly and misses whatever a
+ * displacement does strictly inside it. A point `p` of the region reaches
+ * `p + d` with `d` in the range, so the region's image lies between the two
+ * ends of that range: a field that shifts every point the same way moves the
+ * region, and only what varies widens it.
+ */
+function grown(
+  region: ResampleBoundingBox,
+  range: { low: number[]; high: number[] },
+  spatial: string[],
+  moving: NgffImage,
+  movingShape: Record<string, number>,
+): ResampleBoundingBox {
+  const startIndex = { ...region.startIndex };
+  const size = { ...region.size };
+  const cornersMin = { ...region.cornersMin };
+  const cornersMax = { ...region.cornersMax };
+  const paddedCornersMin = { ...region.paddedCornersMin };
+  const paddedCornersMax = { ...region.paddedCornersMax };
+  spatial.forEach((dim, axis) => {
+    const low = range.low[axis];
+    const high = range.high[axis];
+    if (low === 0 && high === 0) return;
+    const scale = moving.scale[dim];
+    const first = Math.floor(Math.min(low / scale, high / scale));
+    const last = Math.ceil(Math.max(low / scale, high / scale));
+    startIndex[dim] += first;
+    size[dim] += last - first;
+    // The reported corners hold a first and a last index position, which swap
+    // when an axis direction is negative; move the span either way.
+    for (
+      const [begin, stop] of [
+        [cornersMin, cornersMax],
+        [paddedCornersMin, paddedCornersMax],
+      ] as Record<string, number>[][]
+    ) {
+      if (begin[dim] <= stop[dim]) {
+        begin[dim] += low;
+        stop[dim] += high;
+      } else {
+        begin[dim] += high;
+        stop[dim] += low;
+      }
+    }
+  });
+  return new ResampleBoundingBox({
+    dims: region.dims,
+    startIndex,
+    size,
+    cornersMin,
+    cornersMax,
+    paddedCornersMin,
+    paddedCornersMax,
     movingShape,
   });
 }

--- a/ts/src/utils/displacement_field_transform.ts
+++ b/ts/src/utils/displacement_field_transform.ts
@@ -470,6 +470,251 @@ export async function itkDisplacementFieldToNgffTransform(
 }
 
 /**
+ * Refuse a field whose grid cannot be placed without the two images.
+ *
+ * An ITK transform lives in physical space, and an anatomical orientation only
+ * says where a grid sits once the images it relates are known.
+ *
+ * @param image The field image.
+ * @param dims The spatial axis names, in RFC-5 order.
+ * @throws If the field carries an anatomical orientation.
+ */
+export function checkUnorientedField(image: NgffImage, dims: string[]): void {
+  const itkDims = itkAxisOrder(dims);
+  const direction = directionRows(itkDirection(image, itkDims), dims.length);
+  if (allClose(direction, identity(dims.length))) return;
+  throw new Error(
+    "the field carries an anatomical orientation; pass the fixed and " +
+      "moving images so its grid is placed in their frame",
+  );
+}
+
+/**
+ * The field image a field transform names, checked against `dims`.
+ *
+ * Takes the `NgffImage` or the `NgffMultiscales` a caller passes in `fields`,
+ * and returns the single-scale image, after checking that its axes are the
+ * component axis followed by `dims` in order and that it holds one component
+ * per input axis.
+ *
+ * @param transform The `displacements` or `coordinates` transform.
+ * @param field The field image or multiscales, as `fields` holds it.
+ * @param dims The spatial axis names, in RFC-5 (Zarr) order.
+ * @returns The field as a single-scale image; the finest level of a
+ *   multiscales.
+ * @throws If the field has no single component axis of the type the transform
+ *   calls for, if its axes are not that axis followed by `dims`, or if it
+ *   holds a number of components other than `dims.length`.
+ */
+export function fieldImage(
+  transform: Displacements | Coordinates,
+  field: NgffImage | NgffMultiscales,
+  dims: string[],
+): NgffImage {
+  const componentType = transform.type === "coordinates"
+    ? "coordinate"
+    : "displacement";
+  let componentDims: string[];
+  let image: NgffImage;
+  if ("images" in field && "metadata" in field) {
+    // A read multiscales keeps the axis types in its metadata, not on the
+    // image: the component axis is the one typed there.
+    componentDims = field.metadata.axes
+      .filter((axis) => axis.type === componentType)
+      .map((axis) => axis.name);
+    image = field.images[0];
+  } else {
+    image = field;
+    componentDims = Object.entries(image.axesTypes ?? {})
+      .filter(([, type]) => type === componentType)
+      .map(([dim]) => dim);
+  }
+  if (componentDims.length !== 1) {
+    throw new Error(
+      `the field image must have exactly one axis of type '${componentType}' ` +
+        "(axesTypes on an NgffImage, the axes metadata of a multiscales); " +
+        `got [${componentDims.join(", ")}] on dims [${image.dims.join(", ")}]`,
+    );
+  }
+  const expectedDims = [componentDims[0], ...dims];
+  if (
+    image.dims.length !== expectedDims.length ||
+    image.dims.some((dim, i) => dim !== expectedDims[i])
+  ) {
+    throw new Error(
+      `the field's dims are [${image.dims.join(", ")}]; a ${transform.type} ` +
+        `transform over dims [${dims.join(", ")}] needs ` +
+        `[${expectedDims.join(", ")}]: the component axis first, then the ` +
+        "input axes in order",
+    );
+  }
+  if (image.data.shape[0] !== dims.length) {
+    throw new Error(
+      `the field holds ${image.data.shape[0]} components per point, but dims ` +
+        `[${dims.join(", ")}] name ${dims.length} axes`,
+    );
+  }
+  return image;
+}
+
+/**
+ * The field indices a grid of `shape` at `translation` reads.
+ *
+ * The field is evaluated at the grid's own points, so the window is that
+ * grid's extent expressed in field indices, whatever the displacement is:
+ * what a displacement sizes is the *moving* read, which
+ * {@link fieldDisplacementRange} answers.
+ *
+ * @param image The field image.
+ * @param dims The spatial axis names, in RFC-5 order.
+ * @param translation The grid's translation, keyed by dimension.
+ * @param scale The grid's scale, keyed by dimension.
+ * @param shape The grid's extent, in `dims` order.
+ * @param margin Lattice points kept beyond the bracketing pair, so that linear
+ *   interpolation at a point on the boundary reads the same values it reads
+ *   from the whole field.
+ * @returns `[start, stop]` per axis, in `dims` order, clamped to the field,
+ *   and whether the grid also has points beyond the field, which ITK
+ *   displaces by nothing. {@link fieldDisplacementRange} takes the second as
+ *   its `outside`.
+ */
+export function fieldWindow(
+  image: NgffImage,
+  dims: string[],
+  translation: Record<string, number>,
+  scale: Record<string, number>,
+  shape: number[],
+  margin = 1,
+): { window: [number, number][]; outside: boolean } {
+  let outside = false;
+  const window = dims.map((dim, axis) => {
+    const extent = image.data.shape[1 + axis];
+    if (shape[axis] === 0) return [0, 0] as [number, number];
+    const corners = [0, shape[axis] - 1].map((index) =>
+      (translation[dim] + scale[dim] * index - image.translation[dim]) /
+      image.scale[dim]
+    );
+    if (Math.min(...corners) < 0 || Math.max(...corners) > extent - 1) {
+      outside = true;
+    }
+    const low = Math.floor(Math.min(...corners)) - margin;
+    const high = Math.ceil(Math.max(...corners)) + margin + 1;
+    return [
+      Math.max(0, Math.min(low, extent)),
+      Math.max(0, Math.min(high, extent)),
+    ] as [number, number];
+  });
+  return { window, outside };
+}
+
+/**
+ * The range of displacement a window of the field can produce, per component.
+ *
+ * A field is read through a kernel that is non-negative and sums to one, so a
+ * displacement anywhere is a convex combination of the values around it and
+ * lies between their smallest and largest. That makes the range a bound on
+ * every interpolated displacement, not a sample of one: walking the boundary
+ * of a region instead misses a bump the region encloses.
+ *
+ * The window is read a chunk at a time and only a number per component is
+ * kept, so a field larger than memory is bounded without being held.
+ *
+ * @param transform The `displacements` or `coordinates` transform.
+ * @param image The field image, as {@link fieldImage} returns it.
+ * @param dims The spatial axis names, in RFC-5 order.
+ * @param window `[start, stop]` per axis, as {@link fieldWindow} returns it.
+ * @param outside Whether the grid the window came from also has points beyond
+ *   the field. ITK displaces those by nothing, so zero belongs in the range as
+ *   much as the values do; leaving it out lets a field that displaces every
+ *   point it covers one way carry the region away from the points it does not
+ *   cover.
+ * @returns The smallest and largest displacement per component, ordered like
+ *   `dims`. Zero for an empty window, where the field displaces nothing.
+ */
+export async function fieldDisplacementRange(
+  transform: Displacements | Coordinates,
+  image: NgffImage,
+  dims: string[],
+  window: [number, number][],
+  outside = false,
+): Promise<{ low: number[]; high: number[] }> {
+  const rank = dims.length;
+  const low = new Array(rank).fill(Number.POSITIVE_INFINITY);
+  const high = new Array(rank).fill(Number.NEGATIVE_INFINITY);
+  const zero = { low: new Array(rank).fill(0), high: new Array(rank).fill(0) };
+  if (window.some(([start, stop]) => stop <= start)) return zero;
+
+  const absolute = transform.type === "coordinates";
+  const chunkShape = image.data.chunks ?? image.data.shape;
+  const starts: number[][] = window.map(([begin, end], axis) => {
+    const size = chunkShape[1 + axis];
+    const first = Math.floor(begin / size) * size;
+    const positions: number[] = [];
+    for (let position = first; position < end; position += size) {
+      positions.push(position);
+    }
+    return positions;
+  });
+
+  for (const origin of gridPositions(starts)) {
+    const selection: (zarr.Slice | null)[] = [null];
+    const sizes: number[] = [];
+    origin.forEach((start, axis) => {
+      const stop = Math.min(
+        start + chunkShape[1 + axis],
+        image.data.shape[1 + axis],
+      );
+      selection.push(zarr.slice(start, stop));
+      sizes.push(stop - start);
+    });
+    const chunk = await zarr.get(image.data, selection);
+    const values = chunk.data as ArrayLike<number>;
+    const count = sizes.reduce((a, b) => a * b, 1);
+    const strides = new Array(rank).fill(1);
+    for (let axis = rank - 2; axis >= 0; axis--) {
+      strides[axis] = strides[axis + 1] * sizes[axis + 1];
+    }
+    for (let component = 0; component < rank; component++) {
+      const offset = component * count;
+      const origin_ = image.translation[dims[component]];
+      const step = image.scale[dims[component]];
+      for (let index = 0; index < count; index++) {
+        let value = values[offset + index];
+        if (absolute) {
+          // A coordinates field holds the output position of each grid point
+          // rather than the offset from it, so the grid point comes off first.
+          const along = Math.floor(index / strides[component]) %
+            sizes[component];
+          value -= origin_ + step * (origin[component] + along);
+        }
+        if (value < low[component]) low[component] = value;
+        if (value > high[component]) high[component] = value;
+      }
+    }
+  }
+  // A window that reached no value displaces nothing.
+  if (!Number.isFinite(low[0])) return zero;
+  if (outside) {
+    for (let component = 0; component < rank; component++) {
+      low[component] = Math.min(low[component], 0);
+      high[component] = Math.max(high[component], 0);
+    }
+  }
+  return { low, high };
+}
+
+function* gridPositions(starts: number[][]): Generator<number[]> {
+  if (starts.length === 0) {
+    yield [];
+    return;
+  }
+  const [head, ...rest] = starts;
+  for (const value of head) {
+    for (const tail of gridPositions(rest)) yield [value, ...tail];
+  }
+}
+
+/**
  * Convert an RFC-5 `displacements` or `coordinates` transform to ITK.
  *
  * The counterpart of {@link itkDisplacementFieldToNgffTransform}. The field
@@ -508,52 +753,12 @@ export async function ngffDisplacementFieldToItkTransform(
   // the position of the grid point itself. ITK has no absolute-coordinate
   // transform, so both reach it as one DisplacementField.
   const absolute = transform.type === "coordinates";
-  const componentType = absolute ? "coordinate" : "displacement";
-  let componentDims: string[];
-  let image: NgffImage;
-  if ("images" in field && "metadata" in field) {
-    // A read multiscales keeps the axis types in its metadata, not on the
-    // image: the component axis is the one typed there.
-    componentDims = field.metadata.axes
-      .filter((axis) => axis.type === componentType)
-      .map((axis) => axis.name);
-    image = field.images[0];
-  } else {
-    image = field;
-    componentDims = Object.entries(image.axesTypes ?? {})
-      .filter(([, type]) => type === componentType)
-      .map(([dim]) => dim);
-  }
-  if (componentDims.length !== 1) {
-    throw new Error(
-      `the field image must have exactly one axis of type '${componentType}' ` +
-        "(axesTypes on an NgffImage, the axes metadata of a multiscales); " +
-        `got [${componentDims.join(", ")}] on dims [${image.dims.join(", ")}]`,
-    );
-  }
-  const expectedDims = [componentDims[0], ...dims];
-  if (
-    image.dims.length !== expectedDims.length ||
-    image.dims.some((dim, i) => dim !== expectedDims[i])
-  ) {
-    throw new Error(
-      `the field's dims are [${image.dims.join(", ")}]; a ${transform.type} ` +
-        `transform over dims [${dims.join(", ")}] needs ` +
-        `[${expectedDims.join(", ")}]: the component axis first, then the ` +
-        "input axes in order",
-    );
-  }
+  const image = fieldImage(transform, field, dims);
 
   const chunk = await zarr.get(image.data, null);
   const data = chunk.data as ArrayLike<number>;
   const shape = chunk.shape;
   const dimension = dims.length;
-  if (shape[0] !== dimension) {
-    throw new Error(
-      `the field holds ${shape[0]} components per point, but dims ` +
-        `[${dims.join(", ")}] name ${dimension} axes`,
-    );
-  }
 
   const itkDims = itkAxisOrder(dims);
   const size = itkDims.map((dim) => shape[1 + dims.indexOf(dim)]);
@@ -563,12 +768,7 @@ export async function ngffDisplacementFieldToItkTransform(
 
   let frame = optionalFrameGeometry(frames_.fixed, frames_.moving, itkDims);
   if (frame === undefined) {
-    if (!allClose(ownDirection, identity(dimension))) {
-      throw new Error(
-        "the field carries an anatomical orientation; pass the fixed and " +
-          "moving images so its grid is placed in their frame",
-      );
-    }
+    checkUnorientedField(image, dims);
     frame = unorientedFrames(dimension);
   } else if (
     !allClose(ownDirection, identity(dimension)) &&

--- a/ts/test/resample_bounding_box_test.ts
+++ b/ts/test/resample_bounding_box_test.ts
@@ -1232,3 +1232,218 @@ Deno.test("a bijection region follows its forward direction", async () => {
   assertEquals(region.startIndex, directly.startIndex);
   assertEquals(region.size, directly.size);
 });
+
+/** A field image over `dims`, its component axis first, from raw values. */
+async function bumpField(
+  values: Float32Array,
+  dims: string[],
+  extent: number,
+  chunk: number,
+): Promise<NgffImage> {
+  const shape = [dims.length, ...dims.map(() => extent)];
+  const voxels = shape.slice(1).reduce((a, b) => a * b, 1);
+  const strides = new Array<number>(dims.length);
+  let step = 1;
+  for (let axis = dims.length - 1; axis >= 0; axis--) {
+    strides[axis] = step;
+    step *= extent;
+  }
+  const data = await zarr.create(zarr.root(new Map()).resolve("warp"), {
+    shape,
+    chunk_shape: [dims.length, ...dims.map(() => chunk)],
+    data_type: "float32",
+    fill_value: 0,
+  });
+  await zarr.set(data, null, {
+    data: values,
+    shape,
+    stride: [voxels, ...strides],
+  });
+  const geometry: Record<string, number> = { c: 1 };
+  const origin: Record<string, number> = { c: 0 };
+  for (const dim of dims) {
+    geometry[dim] = 1;
+    origin[dim] = 0;
+  }
+  return new NgffImage({
+    data,
+    dims: ["c", ...dims],
+    scale: geometry,
+    translation: origin,
+    name: "warp",
+    axesUnits: undefined,
+    axesTypes: { c: "displacement" },
+    axesOrientations: undefined,
+    computedCallbacks: undefined,
+  });
+}
+
+/** A displacement that is zero on the grid boundary and peaks in the middle. */
+function interiorBump(extent: number, radius: number, peaks: number[]) {
+  const values = new Float32Array(peaks.length * extent * extent);
+  const voxels = extent * extent;
+  for (let y = 0; y < extent; y++) {
+    for (let x = 0; x < extent; x++) {
+      const distance = Math.hypot(y - extent / 2, x - extent / 2);
+      const profile = distance < radius
+        ? 0.5 * (1 + Math.cos(Math.PI * distance / radius))
+        : 0;
+      peaks.forEach((peak, component) => {
+        values[component * voxels + y * extent + x] = peak * profile;
+      });
+    }
+  }
+  return values;
+}
+
+Deno.test("a bump inside the grid widens the region", async () => {
+  // The pipeline sizes a region by walking the boundary of the transformed
+  // grid, so a displacement that is zero there and large inside left the
+  // region unchanged and the pixels it reaches unread.
+  const extent = 64;
+  // The peak carries the grid past its own extent, so a region that only
+  // covers the grid is not enough.
+  const values = interiorBump(extent, 20, [60, -60]);
+  const field = await bumpField(values, ["y", "x"], extent, 16);
+  const fixed = await geometryImage(
+    ["y", "x"],
+    { y: extent, x: extent },
+    { y: 1, x: 1 },
+    { y: 0, x: 0 },
+  );
+  const moving = await geometryImage(["y", "x"], { y: 160, x: 160 }, {
+    y: 1,
+    x: 1,
+  }, { y: 0, x: 0 });
+
+  const region = await resampleBoundingBox(
+    { type: "displacements", path: "warp" },
+    fixed,
+    moving,
+    { fields: { warp: field } },
+  );
+
+  const voxels = extent * extent;
+  ["y", "x"].forEach((dim, component) => {
+    let lowest = Number.POSITIVE_INFINITY;
+    let highest = Number.NEGATIVE_INFINITY;
+    for (let y = 0; y < extent; y++) {
+      for (let x = 0; x < extent; x++) {
+        const index = component === 0 ? y : x;
+        const reached = index + values[component * voxels + y * extent + x];
+        lowest = Math.min(lowest, reached);
+        highest = Math.max(highest, reached);
+      }
+    }
+    assertEquals(region.startIndex[dim] <= lowest, true);
+    assertEquals(region.startIndex[dim] + region.size[dim] >= highest, true);
+  });
+});
+
+Deno.test("a field's chunking does not change the region it reports", async () => {
+  // The range is read a chunk at a time; over the whole grid that has to be
+  // the same range whatever the chunks are.
+  const extent = 64;
+  const values = interiorBump(extent, 20, [60, -60]);
+  const fixed = await geometryImage(
+    ["y", "x"],
+    { y: extent, x: extent },
+    { y: 1, x: 1 },
+    { y: 0, x: 0 },
+  );
+  const moving = await geometryImage(["y", "x"], { y: 160, x: 160 }, {
+    y: 1,
+    x: 1,
+  }, { y: 0, x: 0 });
+  const transform = { type: "displacements" as const, path: "warp" };
+
+  const chunked = await resampleBoundingBox(transform, fixed, moving, {
+    fields: { warp: await bumpField(values, ["y", "x"], extent, 16) },
+  });
+  const whole = await resampleBoundingBox(transform, fixed, moving, {
+    fields: { warp: await bumpField(values, ["y", "x"], extent, extent) },
+  });
+
+  assertEquals(chunked.startIndex, whole.startIndex);
+  assertEquals(chunked.size, whole.size);
+});
+
+Deno.test("a grid reaching past the field keeps its undisplaced part", async () => {
+  // ITK displaces a point beyond the field by nothing, so zero belongs in the
+  // range as much as the values do. A field that displaces every point it
+  // covers the same way otherwise carries the region off the points it does
+  // not cover.
+  const extent = 32;
+  const grid = 64;
+  const values = new Float32Array(2 * extent * extent).fill(-5);
+  const field = await bumpField(values, ["y", "x"], extent, 16);
+  const fixed = await geometryImage(
+    ["y", "x"],
+    { y: grid, x: grid },
+    { y: 1, x: 1 },
+    { y: 0, x: 0 },
+  );
+  const moving = await geometryImage(["y", "x"], { y: 160, x: 160 }, {
+    y: 1,
+    x: 1,
+  }, { y: 0, x: 0 });
+
+  const region = await resampleBoundingBox(
+    { type: "displacements", path: "warp" },
+    fixed,
+    moving,
+    { fields: { warp: field } },
+  );
+
+  // The half beyond the field maps identically, so the region has to reach
+  // the grid's own last index, not only that index shifted by -5.
+  for (const dim of ["y", "x"]) {
+    assertEquals(region.startIndex[dim] <= -5, true);
+    assertEquals(region.startIndex[dim] + region.size[dim] >= grid - 1, true);
+  }
+});
+
+Deno.test("an oriented field is refused by the bounding box", async () => {
+  // This branch works on the intrinsic systems, where no orientation applies,
+  // so a field carrying one cannot be placed here.
+  const { AnatomicalOrientationValues, createAnatomicalOrientation } =
+    await import("../src/types/rfc4.ts");
+  const values = new Float32Array(2 * 32 * 32);
+  const field = await bumpField(values, ["y", "x"], 32, 16);
+  const oriented = new NgffImage({
+    data: field.data,
+    dims: field.dims,
+    scale: field.scale,
+    translation: field.translation,
+    name: field.name,
+    axesUnits: undefined,
+    axesTypes: field.axesTypes,
+    axesOrientations: {
+      y: createAnatomicalOrientation(
+        AnatomicalOrientationValues.AnteriorToPosterior,
+      ),
+      x: createAnatomicalOrientation(AnatomicalOrientationValues.LeftToRight),
+    },
+    computedCallbacks: undefined,
+  });
+  const fixed = await geometryImage(["y", "x"], { y: 32, x: 32 }, {
+    y: 1,
+    x: 1,
+  }, { y: 0, x: 0 });
+  const moving = await geometryImage(["y", "x"], { y: 64, x: 64 }, {
+    y: 1,
+    x: 1,
+  }, { y: 0, x: 0 });
+
+  await assertRejects(
+    () =>
+      resampleBoundingBox(
+        { type: "displacements", path: "warp" },
+        fixed,
+        moving,
+        { fields: { warp: oriented } },
+      ),
+    Error,
+    "anatomical orientation",
+  );
+});


### PR DESCRIPTION
Closes #692.

`resample` streamed the moving image and nothing else. An RFC-5 `displacements` or `coordinates` transform was converted before the graph was built, and that conversion read its field in full and allocated three to five times its size on top of it. A field the size of the volume had to fit in memory while the moving image did not.

While measuring that, a second thing turned up, and it is the one that matters more.

## The region misses what a field does inside the grid

`resample_bounding_box` sizes a region by walking the boundary of the transformed grid. That reports a linear map exactly and says nothing about what a displacement does strictly inside it. A field that is zero on the boundary voxels and large in the middle left the region covering the grid alone, and `resample` then returned the default value for every pixel the bump displaces onto.

Measured on a 64x64 grid, a 160x160 moving image and a bump of 60 pixels in the middle:

- the reported region missed the true reach by 28.6 px on y and 27.6 px on x
- 63 of 4096 output pixels came back as 0 where the value was up to 213
- overwriting the moving pixels outside the reported region changes 64 output pixels, which is the same fact without an interpolation oracle

The same appears in 3D, and on the ITK-transform branch, so the cause is the boundary walk rather than the RFC-5 conversion. This PR fixes the RFC-5 field path; the ITK-transform branch is #696.

## What replaces it

A `displacements` or `coordinates` transform is the identity plus a displacement, so the region is now the grid's own image moved and widened by the range that displacement takes.

The range comes from the field itself. A chunk is read, two numbers per component are kept, the values are dropped. A field is read through a kernel that is non-negative and sums to one, so a displacement anywhere is a convex combination of the values around it and lies between their smallest and largest: a bound, not a sample.

The range is kept rather than its magnitude, which matters in practice. A field that shifts every point the same way moves the region instead of widening it, so the region for a constant field is still the affine one to the pixel, and `test_rfc5_displacements_matches_the_itk_field_it_came_from` passes unchanged.

## What each block reads

Each output block reads the window of the field its own points fall in, and that window becomes the block's ITK transform. What sizes the block's moving read is the range of displacement that window holds, so a quiet slab pays a quiet halo instead of the worst displacement in the volume. The field is passed over once when the graph is built, a chunk at a time, to learn the range per chunk; nothing else about it is held.

A block whose window falls outside the field takes the identity, which is what ITK does there anyway.

## Measured

3 x 256^3 float32 field, 201 MB, resident growth over the source buffer:

| | graph build | after compute |
|---|---|---|
| before | 1508 MB | 1581 MB |
| after | 236 MB | 279 MB |

The streamed result is the undecomposed result pixel for pixel on a float32 image. A window declares its own origin, which changes the last bits of the continuous index ITK computes from it, so on a float64 image the two agree to about 1e-13 rather than exactly. That is recorded in the `resample` docstring.

The crop window keeps one lattice point per side. Zero is sufficient and one is safe: checked over about 700 blocks, 2D and 3D, aligned and unaligned, round and non-round field geometry, and a window one point short per side is not sufficient.

## Benchmark

Against `main`, which converts the whole field once and hands it to the pipeline per block. Same inputs, 4 workers, and the checksums are equal, so the outputs are identical to the bit.

| scenario | main | this branch |
|---|---|---|
| 2D 2048^2, 128^2 chunks, 256 blocks | build 20.96 s, compute 8.45 s, +754 MB | build 0.19 s, compute 0.58 s, +0 MB |
| 3D 256^3, 64^3 chunks, 64 blocks | build 31.87 s, compute 13.87 s, +4156 MB | build 0.06 s, compute 0.65 s, +0 MB |

On `main` the whole field crosses into wasm once per block while the graph is built, and again inside each block's resample. Here a block carries only its window, and the region it reads is arithmetic.

Profiled after the first round, the remaining build time was three quarters a wasm round trip per block that measured nothing but the identity: a field transform's linear part. `_identity_region` computes that region directly in `resample`'s per-block loop, and `test_the_identity_region_is_the_pipelines` pins it to the pipeline's own answer over randomized geometry, all seven reported fields. The public `resample_bounding_box` stays on the pipeline: it is called once per invocation, and the pipeline remains the one authority for its answer. What is left of the build is the single pass over the field for the per-chunk ranges, and the compute is the resampling itself: profiled single-threaded, wasm execution takes 0.44 s of a 0.9 s compute, and the Python around it under 0.1 s.

## TypeScript

TypeScript has no `resample`, but `resampleBoundingBox` had the same boundary walk and the same whole-field read, so both halves are mirrored there. `fieldImage`, `fieldWindow` and `fieldDisplacementRange` are the counterparts of the Python helpers.

## Design

The shape is KonfAI's `Resample`, moved upstream rather than reimplemented: the field is read region by region, the window a region samples is its own box, and the range of the values just read bounds that region's pull. That is the direction of #650 and #667, one streamed resampler upstream instead of a bespoke one downstream.

## Base

On `main`, which carries #674.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added streaming support for displacement and coordinate fields during resampling.
  - Improved handling of chunked, multiscale, and lazy data with windowed reads.
  - Resampling bounds now account for interior displacements, reversed axes, and out-of-field regions.
  - Added validation for field orientation, component layout, and supported field types.

- **Bug Fixes**
  - Corrected bounding regions for fields with interior displacement.

- **Tests**
  - Added coverage for chunking, multiscale data, windowing, coordinate fields, and out-of-field behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
