### PR TITLE
zarrista follow ups

### DIFF
--- a/docs/migration_guides/v0-43_to_v0-44.md
+++ b/docs/migration_guides/v0-43_to_v0-44.md
@@ -449,7 +449,12 @@ encodes with the `bytes` codec plus one bytes-to-bytes compressor -- gzip,
 zstd, or blosc. `filters` (array-to-array codecs) and a `serializer` naming
 anything but `bytes` describe chains it cannot write, and are rejected. A
 `serializer` that names `bytes` asks for what the writer already does and is
-accepted.
+accepted -- unless it also asks for `endian: big`, which the engine does not
+encode either.
+
+`chunks` is rejected too, with a `TypeError` naming where to set it instead:
+the stored chunk shape follows the dask chunking of the images, which
+`to_multiscales(..., chunks=...)` sets.
 
 This affects codec chains, not compression settings: `compressor` and
 `compressors` are unchanged for the three compressors above.
@@ -460,8 +465,10 @@ This affects codec chains, not compression settings: `compressor` and
 ValueError: filters are not supported by the zarrista write engine, which
 encodes with the bytes codec plus gzip, zstd, or blosc compression. To write
 another codec chain, create the store's metadata and empty arrays with
-to_ome_zarr(..., metadata_only=True), then create and fill each dataset with a
-writer that supports those codecs (for example zarr-python's zarr.create_array).
+to_ome_zarr(..., metadata_only=True) -- without the codec arguments, which that
+call rejects the same way -- then re-create and fill each dataset with a writer
+that supports those codecs (for example zarr-python's zarr.create_array with
+overwrite=True).
 ```
 
 Any *other* unrecognized array-creation keyword is ignored with a
@@ -471,7 +478,9 @@ release. Before v0.46 such a keyword was accepted and silently dropped.
 **Migration.** Write the metadata with ngff-zarr and the arrays with a writer
 that implements the codecs. `metadata_only=True` creates every scale level's
 array -- shape, dtype, chunks, shards -- and writes no pixels, so each one can
-be re-created with its codec chain and filled:
+be re-created with its codec chain and filled. Leave the codec arguments off
+that call: it validates them exactly like a full write and raises the same
+error.
 
 ```python
 # Before -- silently produced a plain `bytes` array on v0.44 and v0.45
@@ -481,29 +490,39 @@ to_ome_zarr(
 )
 
 # After
+import dask.array as da
 import zarr
 
 to_ome_zarr("image.ome.zarr", multiscales, version="0.5", metadata_only=True)
 for dataset, level in zip(multiscales.metadata.datasets, multiscales.images):
-    data = np.asarray(level.data)
+    skeleton = zarr.open_array("image.ome.zarr", path=dataset.path, mode="r")
     array = zarr.create_array(
         "image.ome.zarr",
         name=dataset.path,
-        shape=data.shape,
-        chunks=data.shape,          # or the chunk shape the codecs expect
-        dtype=data.dtype,
+        shape=skeleton.shape,
+        chunks=skeleton.chunks,     # keep the layout ngff-zarr chose ...
+        shards=skeleton.shards,     # ... including its sharding
+        dtype=skeleton.dtype,
         filters=[...], serializer=..., compressors=[...],
         fill_value=0,
         dimension_names=list(level.dims),
         overwrite=True,             # replace the skeleton, codec chain and all
     )
-    array[...] = data
+    # One dask chunk per stored write unit: every chunk (or shard) has a
+    # single writer and needs no lock, and no level is held in memory whole.
+    write_shape = skeleton.shards or skeleton.chunks
+    da.store(level.data.rechunk(write_shape), array, lock=False)
 zarr.consolidate_metadata("image.ome.zarr")
 ```
 
-The consolidation at the end matters: ngff-zarr consolidated the skeletons it
-wrote, and a reader that trusts the consolidated document would otherwise see
-the codec chain the skeletons had rather than the one the arrays carry.
+Two details are easy to lose. Re-creating the array from `skeleton.shape`
+rather than from a materialized `level.data` keeps the migration lazy, and
+carrying `skeleton.chunks` and `skeleton.shards` over keeps the layout
+ngff-zarr picked -- passing the full shape as `chunks` would collapse each
+level into one chunk and drop the sharding. The consolidation at the end
+matters too: ngff-zarr consolidated the skeletons it wrote, and a reader that
+trusts the consolidated document would otherwise see the codec chain the
+skeletons had rather than the one the arrays carry.
 
 Reading such a store needs the same split -- `from_ome_zarr` decodes through
 zarrista and raises on the foreign chain, while `ngff_zarr.validate` checks the

--- a/docs/migration_guides/v0-43_to_v0-44.md
+++ b/docs/migration_guides/v0-43_to_v0-44.md
@@ -45,7 +45,7 @@ metadata documents, same pixels.
 | `.ozx` archives (RFC-9) | Unchanged, read and write. `.zip` archives are read-only |
 | HCS plates and wells | Unchanged for path, URL, and `.ozx` stores |
 | RFC-4 anatomical orientation, RFC-5 coordinate systems, metadata validation | Unchanged |
-| Sharding (`chunks_per_shard`), chunking, compressor and codec arguments | Unchanged |
+| Sharding (`chunks_per_shard`), chunking, and the `compressor` / `compressors` arguments | Unchanged for gzip, zstd and blosc -- the compression the engine writes |
 | CLI flags and the `ngff-zarr` command | Unchanged |
 | Downsampling methods | Unchanged |
 | Installing zarr-python alongside ngff-zarr | Supported -- the two no longer conflict |
@@ -61,6 +61,7 @@ metadata documents, same pixels.
 | `remote` extra is now just `obstore` | You relied on `ngff-zarr[remote]` to install `fsspec`, `s3fs`, ... | [The remote extra no longer pulls in fsspec](#the-remote-extra-no-longer-pulls-in-fsspec) |
 | `tensorstore` extra removed | You install `ngff-zarr[tensorstore]` or pass `use_tensorstore=True` | [The tensorstore extra is removed](#the-tensorstore-extra-is-removed) |
 | `chunk_store` removed | You pass `chunk_store=` to `to_ome_zarr` | [The chunk_store argument is removed](#the-chunk-store-argument-is-removed) |
+| `filters` and a non-`bytes` `serializer` rejected | You write a codec chain other than `bytes` plus gzip/zstd/blosc | [Only the bytes codec plus gzip, zstd, or blosc is written](#only-the-bytes-codec-plus-gzip-zstd-or-blosc-is-written) |
 | Stricter Zarr metadata parsing | You read a store with out-of-spec codec metadata | [Zarr metadata is validated more strictly on read](#zarr-metadata-is-validated-more-strictly-on-read) |
 | Narrower in-memory mapping reads | You read a sharded store from a `dict` | [In-memory mapping reads cover fewer stores](#in-memory-mapping-reads-cover-fewer-stores) |
 
@@ -439,6 +440,74 @@ to_ome_zarr("image.ome.zarr", multiscales, chunk_store="chunks")
 # After
 to_ome_zarr("image.ome.zarr", multiscales)
 ```
+
+## Only the bytes codec plus gzip, zstd, or blosc is written
+
+**What changed and why.** zarr-python resolves a codec chain through its codec
+entry points, so any registered codec could be written. The zarrista engine
+encodes with the `bytes` codec plus one bytes-to-bytes compressor -- gzip,
+zstd, or blosc. `filters` (array-to-array codecs) and a `serializer` naming
+anything but `bytes` describe chains it cannot write, and are rejected. A
+`serializer` that names `bytes` asks for what the writer already does and is
+accepted.
+
+This affects codec chains, not compression settings: `compressor` and
+`compressors` are unchanged for the three compressors above.
+
+**Error you will see.**
+
+```text
+ValueError: filters are not supported by the zarrista write engine, which
+encodes with the bytes codec plus gzip, zstd, or blosc compression. To write
+another codec chain, create the store's metadata and empty arrays with
+to_ome_zarr(..., metadata_only=True), then create and fill each dataset with a
+writer that supports those codecs (for example zarr-python's zarr.create_array).
+```
+
+Any *other* unrecognized array-creation keyword is ignored with a
+`DeprecationWarning` naming it, and will become a `TypeError` in a later
+release. Before v0.46 such a keyword was accepted and silently dropped.
+
+**Migration.** Write the metadata with ngff-zarr and the arrays with a writer
+that implements the codecs. `metadata_only=True` creates every scale level's
+array -- shape, dtype, chunks, shards -- and writes no pixels, so each one can
+be re-created with its codec chain and filled:
+
+```python
+# Before -- silently produced a plain `bytes` array on v0.44 and v0.45
+to_ome_zarr(
+    "image.ome.zarr", multiscales, version="0.5",
+    filters=[...], serializer=..., compressors=[...],
+)
+
+# After
+import zarr
+
+to_ome_zarr("image.ome.zarr", multiscales, version="0.5", metadata_only=True)
+for dataset, level in zip(multiscales.metadata.datasets, multiscales.images):
+    data = np.asarray(level.data)
+    array = zarr.create_array(
+        "image.ome.zarr",
+        name=dataset.path,
+        shape=data.shape,
+        chunks=data.shape,          # or the chunk shape the codecs expect
+        dtype=data.dtype,
+        filters=[...], serializer=..., compressors=[...],
+        fill_value=0,
+        dimension_names=list(level.dims),
+        overwrite=True,             # replace the skeleton, codec chain and all
+    )
+    array[...] = data
+zarr.consolidate_metadata("image.ome.zarr")
+```
+
+The consolidation at the end matters: ngff-zarr consolidated the skeletons it
+wrote, and a reader that trusts the consolidated document would otherwise see
+the codec chain the skeletons had rather than the one the arrays carry.
+
+Reading such a store needs the same split -- `from_ome_zarr` decodes through
+zarrista and raises on the foreign chain, while `ngff_zarr.validate` checks the
+OME metadata from the group attributes and zarr-python reads the arrays.
 
 ## Zarr metadata is validated more strictly on read
 

--- a/mcp/ngff_zarr_mcp/models.py
+++ b/mcp/ngff_zarr_mcp/models.py
@@ -4,7 +4,23 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+def _reject_level_without_codec(options):
+    """A compression level is only ever read alongside a codec name.
+
+    Both tools build the compressor from the two together and skip it
+    entirely when the codec is absent, so a lone level asks for a setting
+    the write would not apply -- and would report success anyway.
+    """
+    if options.compression_level is not None and not options.compression_codec:
+        raise ValueError(
+            "compression_level requires compression_codec: the level is an "
+            "argument to the codec, and without one the store is written "
+            "with the default compression."
+        )
+    return options
 
 
 class ConversionOptions(BaseModel):
@@ -82,6 +98,10 @@ class ConversionOptions(BaseModel):
                 raise ValueError(f"All dimensions must be from {valid_dims}")
         return v
 
+    @model_validator(mode="after")
+    def validate_compression(self):
+        return _reject_level_without_codec(self)
+
 
 class ConversionResult(BaseModel):
     """Result of image conversion."""
@@ -143,6 +163,10 @@ class OptimizationOptions(BaseModel):
     storage_options: dict[str, str | int | bool] | None = Field(
         None, description="Storage options for remote stores"
     )
+
+    @model_validator(mode="after")
+    def validate_compression(self):
+        return _reject_level_without_codec(self)
 
 
 class ValidationResult(BaseModel):

--- a/mcp/ngff_zarr_mcp/tools.py
+++ b/mcp/ngff_zarr_mcp/tools.py
@@ -463,13 +463,25 @@ async def optimize_zarr_store(options: OptimizationOptions) -> ConversionResult:
             elif isinstance(chunks_per_shard, list):
                 chunks_per_shard = tuple(chunks_per_shard)
 
-        # Save optimized store
+        # Save optimized store. Compression reaches to_ome_zarr as a codec
+        # under `compressor`, the way convert_to_ome_zarr passes it;
+        # `compression_codec`/`compression_level` are this module's own option
+        # names and are not array-creation keywords the writer knows.
+        compression_kwargs = {}
+        if options.compression_codec:
+            from ngff_zarr.codecs import (
+                codec_from_name,  # type: ignore[import-untyped]
+            )
+
+            compression_kwargs["compressor"] = codec_from_name(
+                options.compression_codec, options.compression_level
+            )
+
         to_ome_zarr(
             output_store,
             optimized_multiscales,
             chunks_per_shard=chunks_per_shard,
-            compression_codec=options.compression_codec,
-            compression_level=options.compression_level,
+            **compression_kwargs,
         )
 
         # Analyze the optimized store

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: MIT
 """Test configuration for pytest."""
 
+import shutil
+import tempfile
+from pathlib import Path
+
 import pytest
 
 
@@ -14,3 +18,17 @@ def event_loop():
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()
+
+
+@pytest.fixture
+def test_input_file():
+    """Path to the test input file."""
+    return Path(__file__).parent.parent / "test" / "data" / "input" / "MR-head.nrrd"
+
+
+@pytest.fixture
+def temp_output_dir():
+    """Create a temporary directory for output files."""
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)

--- a/mcp/tests/test_convert_to_ome_zarr.py
+++ b/mcp/tests/test_convert_to_ome_zarr.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: MIT
 """Tests for convert_to_ome_zarr function."""
 
-import shutil
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -11,20 +9,7 @@ import pytest
 from ngff_zarr_mcp.models import ConversionOptions
 from ngff_zarr_mcp.tools import convert_to_ome_zarr
 
-
-@pytest.fixture
-def test_input_file():
-    """Path to the test input file."""
-    return Path(__file__).parent.parent / "test" / "data" / "input" / "MR-head.nrrd"
-
-
-@pytest.fixture
-def temp_output_dir():
-    """Create a temporary directory for output files."""
-    temp_dir = tempfile.mkdtemp()
-    yield temp_dir
-    # Cleanup after test
-    shutil.rmtree(temp_dir, ignore_errors=True)
+# ``test_input_file`` and ``temp_output_dir`` come from tests/conftest.py.
 
 
 @pytest.mark.asyncio

--- a/mcp/tests/test_zarrista_compression.py
+++ b/mcp/tests/test_zarrista_compression.py
@@ -7,13 +7,13 @@ with it verifies that other zarr implementations can decode zarrista output.
 """
 
 import json
-import tempfile
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pytest
 import zarr
+from pydantic import ValidationError
 
 from ngff_zarr_mcp.models import ConversionOptions, OptimizationOptions
 from ngff_zarr_mcp.tools import (
@@ -21,23 +21,6 @@ from ngff_zarr_mcp.tools import (
     optimize_zarr_store,
     validate_ome_zarr,
 )
-
-
-@pytest.fixture
-def test_input_file():
-    """Path to the test input file."""
-    return Path(__file__).parent.parent / "test" / "data" / "input" / "MR-head.nrrd"
-
-
-@pytest.fixture
-def temp_output_dir():
-    """Create a temporary directory for output files."""
-    temp_dir = tempfile.mkdtemp()
-    yield temp_dir
-    # Cleanup after test
-    import shutil
-
-    shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 def _read_first_scale(output_path: Path) -> np.ndarray:
@@ -220,7 +203,9 @@ def _first_scale_codecs(output_path: Path) -> list[str]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.filterwarnings("error:to_ome_zarr() ignores")
+# The message is matched as a regex, so the parentheses need escaping to mean
+# themselves; unescaped they are an empty group and the filter never fires.
+@pytest.mark.filterwarnings(r"error:to_ome_zarr\(\) ignores")
 async def test_optimize_zarr_store_applies_compression(
     test_input_file, temp_output_dir
 ):
@@ -257,3 +242,19 @@ async def test_optimize_zarr_store_applies_compression(
     assert result.success, f"Optimization failed: {result.error}"
     assert optimized.exists(), "Optimized store was not created"
     assert "gzip" in _first_scale_codecs(optimized)
+
+
+@pytest.mark.parametrize("options_model", [ConversionOptions, OptimizationOptions])
+def test_compression_level_requires_a_codec(tmp_path, options_model):
+    """A level with no codec names a setting neither tool would apply.
+
+    Both build the compressor from codec and level together and skip it when
+    the codec is absent, so the level would be dropped and the call would
+    still report success.
+    """
+    fields = {"output_path": str(tmp_path / "out.ome.zarr"), "compression_level": 6}
+    if options_model is OptimizationOptions:
+        fields["input_path"] = str(tmp_path / "in.ome.zarr")
+
+    with pytest.raises(ValidationError, match="compression_level requires"):
+        options_model(**fields)

--- a/mcp/tests/test_zarrista_compression.py
+++ b/mcp/tests/test_zarrista_compression.py
@@ -6,6 +6,7 @@ zarr-python is a test-only dependency here: reading the written stores back
 with it verifies that other zarr implementations can decode zarrista output.
 """
 
+import json
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -14,8 +15,12 @@ import numpy as np
 import pytest
 import zarr
 
-from ngff_zarr_mcp.models import ConversionOptions
-from ngff_zarr_mcp.tools import convert_to_ome_zarr, validate_ome_zarr
+from ngff_zarr_mcp.models import ConversionOptions, OptimizationOptions
+from ngff_zarr_mcp.tools import (
+    convert_to_ome_zarr,
+    optimize_zarr_store,
+    validate_ome_zarr,
+)
 
 
 @pytest.fixture
@@ -197,3 +202,58 @@ async def test_use_tensorstore_alias_contract(test_input_file, temp_output_dir):
 
     validation = await validate_ome_zarr(str(output_path))
     assert validation.valid, f"Store failed validation: {validation.errors}"
+
+
+def _first_scale_codecs(output_path: Path) -> list[str]:
+    """The codec names the first scale level's zarr v3 metadata records.
+
+    Read from the document on disk rather than through a group handle: it is
+    the artifact other implementations consume, and indexing a group yields a
+    union type that carries no ``codecs`` attribute.
+    """
+    group = zarr.open(str(output_path), mode="r")
+    attrs: dict[str, Any] = dict(group.attrs)
+    metadata = attrs["ome"] if "ome" in attrs else attrs
+    dataset_path = metadata["multiscales"][0]["datasets"][0]["path"]
+    doc = json.loads((output_path / dataset_path / "zarr.json").read_text())
+    return [codec["name"] for codec in doc["codecs"]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("error:to_ome_zarr() ignores")
+async def test_optimize_zarr_store_applies_compression(
+    test_input_file, temp_output_dir
+):
+    """``optimize_zarr_store``'s compression options must reach the writer.
+
+    They were passed as ``compression_codec=``/``compression_level=``, which
+    ``to_ome_zarr`` does not accept; the writer ignored them and the store came
+    out with the default codec chain, so the tool's compression options did
+    nothing at all. Assert the requested codec is in the written metadata --
+    a re-check of the option names alone would not have caught it.
+    """
+    source = Path(temp_output_dir) / "optimize_source.ome.zarr"
+    convert = await convert_to_ome_zarr(
+        [str(test_input_file)],
+        ConversionOptions(
+            output_path=str(source),
+            ome_zarr_version="0.5",
+            method="itkwasm_gaussian",
+            chunks=64,
+        ),
+    )
+    assert convert.success, f"Fixture conversion failed: {convert.error}"
+
+    optimized = Path(temp_output_dir) / "optimize_gzip.ome.zarr"
+    result = await optimize_zarr_store(
+        OptimizationOptions(
+            input_path=str(source),
+            output_path=str(optimized),
+            compression_codec="gzip",
+            compression_level=6,
+        )
+    )
+
+    assert result.success, f"Optimization failed: {result.error}"
+    assert optimized.exists(), "Optimized store was not created"
+    assert "gzip" in _first_scale_codecs(optimized)

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -774,6 +774,25 @@ def _is_bytes_codec(codec) -> bool:
     return name == "bytes"
 
 
+def _unsupported_codec_message(subject: str) -> str:
+    """Explain that *subject* cannot be written, and what to do instead.
+
+    The engine encodes with the ``bytes`` codec plus one bytes-to-bytes
+    compressor, so any other codec chain has to be written by a writer that
+    implements it. ``metadata_only=True`` is what makes that a two-library
+    job rather than a reimplementation: this writer lays down the OME
+    metadata and the empty arrays, the other one fills them.
+    """
+    return (
+        f"{subject} not supported by the zarrista write engine, which encodes "
+        "with the bytes codec plus gzip, zstd, or blosc compression. To write "
+        "another codec chain, create the store's metadata and empty arrays "
+        "with to_ome_zarr(..., metadata_only=True), then create and fill each "
+        "dataset with a writer that supports those codecs (for example "
+        "zarr-python's zarr.create_array)."
+    )
+
+
 def _compression_chain(kwargs: dict) -> list | None:
     """Translate the public compression kwargs into a single ordered chain.
 
@@ -784,12 +803,22 @@ def _compression_chain(kwargs: dict) -> list | None:
     detected with a sentinel. Only the array-to-bytes ("bytes") codec is
     dropped from a supplied chain since the writer always leads with one. The
     consumed keys are removed from ``kwargs``.
+
+    ``filters`` and a ``serializer`` naming anything but the ``bytes`` codec
+    name codec chains the engine cannot write, and raise rather than being
+    dropped into an array whose metadata then disagrees with the request. A
+    ``serializer`` that names ``bytes`` asks for what the writer already
+    does, and is accepted as the no-op it is. Anything left over is not an
+    array-creation option this writer knows; it warns, since silently
+    ignoring it is how a caller comes to believe an inert argument works.
     """
     filters = kwargs.pop("filters", None)
     if filters:
+        raise ValueError(_unsupported_codec_message("filters are"))
+    serializer = kwargs.pop("serializer", None)
+    if serializer is not None and not _is_bytes_codec(serializer):
         raise ValueError(
-            "filters are not supported by the zarrista write engine; pass a "
-            "zarr store object as the target to use the zarr-python engine"
+            _unsupported_codec_message("a serializer other than the bytes codec is")
         )
     _unset = object()
     compressor = kwargs.pop("compressor", _unset)
@@ -804,6 +833,16 @@ def _compression_chain(kwargs: dict) -> list | None:
     else:
         compression_chain = None
     kwargs.pop("chunks", None)  # Remove chunks from kwargs since it's a positional arg
+    if kwargs:
+        warnings.warn(
+            "to_ome_zarr() ignores the array-creation keyword argument(s) "
+            + ", ".join(sorted(kwargs))
+            + ". Supported: compressor (zarr format 2), compressors (zarr "
+            "format 3), chunks. Ignoring them is deprecated and will become "
+            "a TypeError.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     return compression_chain
 
 
@@ -1440,8 +1479,13 @@ def to_ome_zarr(
         ``start_level`` that already exists is replaced.
     :type  start_level: int, optional
 
-    :param **kwargs: Array-creation options, e.g. `compressor` / `compressors`
-        compression settings.
+    :param **kwargs: Array-creation options: `compressor` (zarr format 2),
+        `compressors` (zarr format 3), and `chunks`. The engine encodes with the
+        `bytes` codec plus gzip, zstd, or blosc compression, so `filters` and a
+        `serializer` naming any other codec raise `ValueError` — write those
+        chains by creating the store with ``metadata_only=True`` and filling the
+        arrays with a writer that implements them. Any other keyword is ignored
+        with a `DeprecationWarning` and will become a `TypeError`.
     """
     if use_tensorstore:
         warnings.warn(

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -774,23 +774,51 @@ def _is_bytes_codec(codec) -> bool:
     return name == "bytes"
 
 
+# What to do about a codec chain this engine cannot encode. ``metadata_only``
+# makes it a two-library job rather than a reimplementation: this writer lays
+# down the OME metadata and the empty arrays, the other one replaces them. The
+# codec arguments are left out of that first call on purpose -- it validates
+# them exactly like a full write and would raise here again.
+_FOREIGN_CODEC_REMEDY = (
+    "To write another codec chain, create the store's metadata and empty "
+    "arrays with to_ome_zarr(..., metadata_only=True) -- without the codec "
+    "arguments, which that call rejects the same way -- then re-create and "
+    "fill each dataset with a writer that supports those codecs (for example "
+    "zarr-python's zarr.create_array with overwrite=True)."
+)
+
+
 def _unsupported_codec_message(subject: str) -> str:
     """Explain that *subject* cannot be written, and what to do instead.
 
     The engine encodes with the ``bytes`` codec plus one bytes-to-bytes
     compressor, so any other codec chain has to be written by a writer that
-    implements it. ``metadata_only=True`` is what makes that a two-library
-    job rather than a reimplementation: this writer lays down the OME
-    metadata and the empty arrays, the other one fills them.
+    implements it.
     """
     return (
         f"{subject} not supported by the zarrista write engine, which encodes "
-        "with the bytes codec plus gzip, zstd, or blosc compression. To write "
-        "another codec chain, create the store's metadata and empty arrays "
-        "with to_ome_zarr(..., metadata_only=True), then create and fill each "
-        "dataset with a writer that supports those codecs (for example "
-        "zarr-python's zarr.create_array)."
+        "with the bytes codec plus gzip, zstd, or blosc compression. "
+        + _FOREIGN_CODEC_REMEDY
     )
+
+
+def _bytes_codec_endian(codec) -> str | None:
+    """The byte order a ``bytes`` codec asks for, or ``None`` if it asks none.
+
+    The bare ``"bytes"`` name and zarr-python's ``BytesCodec(endian=None)``
+    leave it open; a config dict or a codec object naming one is read off
+    whichever of the two forms it carries.
+    """
+    if isinstance(codec, str):
+        return None
+    if hasattr(codec, "to_dict"):
+        endian = (codec.to_dict().get("configuration") or {}).get("endian")
+    elif isinstance(codec, dict):
+        endian = (codec.get("configuration") or {}).get("endian")
+    else:
+        endian = getattr(codec, "endian", None)
+    # zarr-python carries it as an enum; the metadata form is its value.
+    return getattr(endian, "value", endian)
 
 
 def _compression_chain(kwargs: dict) -> list | None:
@@ -808,18 +836,28 @@ def _compression_chain(kwargs: dict) -> list | None:
     name codec chains the engine cannot write, and raise rather than being
     dropped into an array whose metadata then disagrees with the request. A
     ``serializer`` that names ``bytes`` asks for what the writer already
-    does, and is accepted as the no-op it is. Anything left over is not an
-    array-creation option this writer knows; it warns, since silently
-    ignoring it is how a caller comes to believe an inert argument works.
+    does, and is accepted as the no-op it is -- unless it also asks for
+    big-endian chunks, which the engine does not encode either. Anything left
+    over is not an array-creation option this writer knows; it warns, since
+    silently ignoring it is how a caller comes to believe an inert argument
+    works.
     """
     filters = kwargs.pop("filters", None)
     if filters:
         raise ValueError(_unsupported_codec_message("filters are"))
     serializer = kwargs.pop("serializer", None)
-    if serializer is not None and not _is_bytes_codec(serializer):
-        raise ValueError(
-            _unsupported_codec_message("a serializer other than the bytes codec is")
-        )
+    if serializer is not None:
+        if not _is_bytes_codec(serializer):
+            raise ValueError(
+                _unsupported_codec_message("a serializer other than the bytes codec is")
+            )
+        endian = _bytes_codec_endian(serializer)
+        if endian is not None and endian != "little":
+            raise ValueError(
+                f"a bytes serializer with endian={endian!r} is not supported "
+                "by the zarrista write engine, which encodes little-endian "
+                "chunks. " + _FOREIGN_CODEC_REMEDY
+            )
     _unset = object()
     compressor = kwargs.pop("compressor", _unset)
     compressors = kwargs.pop("compressors", None)
@@ -832,13 +870,12 @@ def _compression_chain(kwargs: dict) -> list | None:
         compression_chain = [] if compressor is None else [compressor]
     else:
         compression_chain = None
-    kwargs.pop("chunks", None)  # Remove chunks from kwargs since it's a positional arg
     if kwargs:
         warnings.warn(
             "to_ome_zarr() ignores the array-creation keyword argument(s) "
             + ", ".join(sorted(kwargs))
             + ". Supported: compressor (zarr format 2), compressors (zarr "
-            "format 3), chunks. Ignoring them is deprecated and will become "
+            "format 3). Ignoring them is deprecated and will become "
             "a TypeError.",
             DeprecationWarning,
             stacklevel=2,
@@ -1479,13 +1516,18 @@ def to_ome_zarr(
         ``start_level`` that already exists is replaced.
     :type  start_level: int, optional
 
-    :param **kwargs: Array-creation options: `compressor` (zarr format 2),
-        `compressors` (zarr format 3), and `chunks`. The engine encodes with the
-        `bytes` codec plus gzip, zstd, or blosc compression, so `filters` and a
-        `serializer` naming any other codec raise `ValueError` — write those
-        chains by creating the store with ``metadata_only=True`` and filling the
-        arrays with a writer that implements them. Any other keyword is ignored
-        with a `DeprecationWarning` and will become a `TypeError`.
+    :param **kwargs: Array-creation options: `compressor` (zarr format 2) and
+        `compressors` (zarr format 3). The engine encodes with the `bytes` codec
+        plus gzip, zstd, or blosc compression, so `filters`, a `serializer`
+        naming any other codec, and a `bytes` serializer asking for big-endian
+        chunks raise `ValueError`. To write such a chain, create the store with
+        ``metadata_only=True`` — without these arguments, since that call
+        validates them the same way — then re-create and fill each array with a
+        writer that implements them (`zarr.create_array(..., overwrite=True)`).
+        `chunks` raises `TypeError`: the stored chunk shape follows the images'
+        dask chunking, set by ``to_multiscales(..., chunks=...)``. Any other
+        keyword is ignored with a `DeprecationWarning` and will become a
+        `TypeError`.
     """
     if use_tensorstore:
         warnings.warn(
@@ -1505,6 +1547,17 @@ def to_ome_zarr(
             "RFC-4 anatomical orientation is now written automatically whenever "
             "it is present. Set NgffImage.axes_orientations, or pass "
             "orientation= to to_multiscales()."
+        )
+
+    # ``chunks`` collides with the writer's own positional argument, so it has
+    # only ever raised a TypeError naming an internal function. The stored
+    # chunk shape comes from the images' dask chunking; say where to set it.
+    if "chunks" in kwargs:
+        raise TypeError(
+            "to_ome_zarr()/to_ngff_zarr() does not accept 'chunks': the stored "
+            "chunk shape comes from the dask chunking of the images. Set it "
+            "with to_multiscales(..., chunks=...), or rechunk NgffImage.data "
+            "before writing. Pass chunks_per_shard for sharding."
         )
 
     # RFC-9: Handle .ozx (zipped OME-Zarr) files

--- a/py/test/test_migration_guide_v0_44.py
+++ b/py/test/test_migration_guide_v0_44.py
@@ -217,11 +217,19 @@ class TestArrayLevelNthreads:
         )
 
 
-def _sharded_multiscales():
-    """Two sharded scale levels, so a layout the migration must preserve."""
+def _codec_multiscales():
+    """Two scale levels, so a chunk layout the migration must carry over."""
     rng = np.random.default_rng(7)
     data = rng.integers(0, 4096, size=(32, 32), dtype=np.uint16)
     return to_multiscales(data, scale_factors=[2], chunks=8)
+
+
+def _array_codecs(doc):
+    """The codec chain, reaching inside the sharding codec when there is one."""
+    codecs = doc["codecs"]
+    if codecs[0]["name"] == "sharding_indexed":
+        return codecs[0]["configuration"]["codecs"]
+    return codecs
 
 
 class TestForeignCodecMigration:
@@ -245,7 +253,10 @@ class TestForeignCodecMigration:
                 filters=[numcodecs.Delta(dtype="uint8")],
             )
 
-    def test_documented_recipe_writes_the_foreign_chain(self, tmp_path):
+    @pytest.mark.parametrize("chunks_per_shard", [None, 2])
+    def test_documented_recipe_writes_the_foreign_chain(
+        self, tmp_path, chunks_per_shard
+    ):
         """Run the guide's migration snippet and check what it produced.
 
         The chain is a transpose filter: an array-to-array codec zarr-python
@@ -253,6 +264,11 @@ class TestForeignCodecMigration:
         is easy to get wrong -- dropping the skeleton's chunk and shard
         layout, and leaving the consolidated metadata describing the codec
         chain of the skeletons rather than of the arrays.
+
+        The guide writes the skeleton without sharding, which is the
+        ``chunks_per_shard=None`` case. The sharded one runs too because
+        ``shards=skeleton.shards`` is the line of the snippet most easily
+        dropped, and it does nothing unless the skeleton has shards.
         """
         zarr = pytest.importorskip("zarr")
         da = pytest.importorskip("dask.array")
@@ -261,17 +277,20 @@ class TestForeignCodecMigration:
         from zarr.codecs import TransposeCodec
 
         store_path = tmp_path / "foreign_codec.ome.zarr"
-        multiscales = _sharded_multiscales()
+        multiscales = _codec_multiscales()
         expected = [level.data.compute() for level in multiscales.images]
 
-        # --- as published in the migration guide ---
+        # The guide's skeleton call, with this test's sharding parameter added.
         to_ome_zarr(
             str(store_path),
             multiscales,
             version="0.5",
             metadata_only=True,
-            chunks_per_shard=2,
+            chunks_per_shard=chunks_per_shard,
         )
+
+        # --- as published in the migration guide, with the store path and the
+        # placeholder codec chain filled in ---
         for dataset, level in zip(multiscales.metadata.datasets, multiscales.images):
             skeleton = zarr.open_array(str(store_path), path=dataset.path, mode="r")
             array = zarr.create_array(
@@ -298,18 +317,18 @@ class TestForeignCodecMigration:
             multiscales,
             version="0.5",
             metadata_only=True,
-            chunks_per_shard=2,
+            chunks_per_shard=chunks_per_shard,
         )
 
         root = json.loads((store_path / "zarr.json").read_text())
         consolidated = root["consolidated_metadata"]["metadata"]
         for index, dataset in enumerate(multiscales.metadata.datasets):
             doc = json.loads((store_path / dataset.path / "zarr.json").read_text())
-            inner = doc["codecs"][0]["configuration"]["codecs"]
-            assert doc["codecs"][0]["name"] == "sharding_indexed", (
+            is_sharded = doc["codecs"][0]["name"] == "sharding_indexed"
+            assert is_sharded == (chunks_per_shard is not None), (
                 "the skeleton's sharding must survive the re-creation"
             )
-            assert inner[0]["name"] == "transpose"
+            assert _array_codecs(doc)[0]["name"] == "transpose"
 
             written = zarr.open_array(str(store_path), path=dataset.path, mode="r")
             reference = zarr.open_array(

--- a/py/test/test_migration_guide_v0_44.py
+++ b/py/test/test_migration_guide_v0_44.py
@@ -215,3 +215,115 @@ class TestArrayLevelNthreads:
             multiscales.images[0].data.compute(),
             np.zeros((8, 8), dtype=np.uint8),
         )
+
+
+def _sharded_multiscales():
+    """Two sharded scale levels, so a layout the migration must preserve."""
+    rng = np.random.default_rng(7)
+    data = rng.integers(0, 4096, size=(32, 32), dtype=np.uint16)
+    return to_multiscales(data, scale_factors=[2], chunks=8)
+
+
+class TestForeignCodecMigration:
+    """The guide's two-writer recipe for a codec chain zarrista cannot encode."""
+
+    def test_codec_arguments_are_rejected_with_metadata_only(self, tmp_path):
+        """`metadata_only=True` validates codecs exactly like a full write.
+
+        The guide tells callers to leave the codec arguments off that call
+        because of this; passing them along with it raises the same error the
+        migration is trying to get out of.
+        """
+        numcodecs = pytest.importorskip("numcodecs")
+
+        with pytest.raises(ValueError, match="filters are not supported"):
+            to_ome_zarr(
+                str(tmp_path / "skeleton.ome.zarr"),
+                _multiscales(),
+                version="0.5",
+                metadata_only=True,
+                filters=[numcodecs.Delta(dtype="uint8")],
+            )
+
+    def test_documented_recipe_writes_the_foreign_chain(self, tmp_path):
+        """Run the guide's migration snippet and check what it produced.
+
+        The chain is a transpose filter: an array-to-array codec zarr-python
+        writes and this writer rejects. The assertions cover what the snippet
+        is easy to get wrong -- dropping the skeleton's chunk and shard
+        layout, and leaving the consolidated metadata describing the codec
+        chain of the skeletons rather than of the arrays.
+        """
+        zarr = pytest.importorskip("zarr")
+        da = pytest.importorskip("dask.array")
+        if not hasattr(zarr, "create_array"):
+            pytest.skip("the recipe uses the zarr-python 3 array API")
+        from zarr.codecs import TransposeCodec
+
+        store_path = tmp_path / "foreign_codec.ome.zarr"
+        multiscales = _sharded_multiscales()
+        expected = [level.data.compute() for level in multiscales.images]
+
+        # --- as published in the migration guide ---
+        to_ome_zarr(
+            str(store_path),
+            multiscales,
+            version="0.5",
+            metadata_only=True,
+            chunks_per_shard=2,
+        )
+        for dataset, level in zip(multiscales.metadata.datasets, multiscales.images):
+            skeleton = zarr.open_array(str(store_path), path=dataset.path, mode="r")
+            array = zarr.create_array(
+                str(store_path),
+                name=dataset.path,
+                shape=skeleton.shape,
+                chunks=skeleton.chunks,
+                shards=skeleton.shards,
+                dtype=skeleton.dtype,
+                filters=[TransposeCodec(order=(1, 0))],
+                fill_value=0,
+                dimension_names=list(level.dims),
+                overwrite=True,
+            )
+            write_shape = skeleton.shards or skeleton.chunks
+            da.store(level.data.rechunk(write_shape), array, lock=False)
+        zarr.consolidate_metadata(str(store_path))
+        # --- end of published snippet ---
+
+        # An untouched skeleton is the layout the migration had to carry over.
+        reference_path = tmp_path / "reference.ome.zarr"
+        to_ome_zarr(
+            str(reference_path),
+            multiscales,
+            version="0.5",
+            metadata_only=True,
+            chunks_per_shard=2,
+        )
+
+        root = json.loads((store_path / "zarr.json").read_text())
+        consolidated = root["consolidated_metadata"]["metadata"]
+        for index, dataset in enumerate(multiscales.metadata.datasets):
+            doc = json.loads((store_path / dataset.path / "zarr.json").read_text())
+            inner = doc["codecs"][0]["configuration"]["codecs"]
+            assert doc["codecs"][0]["name"] == "sharding_indexed", (
+                "the skeleton's sharding must survive the re-creation"
+            )
+            assert inner[0]["name"] == "transpose"
+
+            written = zarr.open_array(str(store_path), path=dataset.path, mode="r")
+            reference = zarr.open_array(
+                str(reference_path), path=dataset.path, mode="r"
+            )
+            assert (written.chunks, written.shards) == (
+                reference.chunks,
+                reference.shards,
+            ), "the skeleton's chunk and shard layout must survive the re-creation"
+
+            entry = consolidated[dataset.path]
+            assert entry["codecs"] == doc["codecs"], (
+                "a reader trusting the consolidated document would otherwise "
+                "see the skeleton's codec chain"
+            )
+
+            np.testing.assert_array_equal(np.asarray(written), expected[index])

--- a/py/test/test_zarrista_compat.py
+++ b/py/test/test_zarrista_compat.py
@@ -483,6 +483,61 @@ def test_path_store_rejects_filters(tmp_path):
         )
 
 
+def test_path_store_rejects_foreign_serializer(tmp_path):
+    """A serializer the engine cannot write must raise, not be dropped.
+
+    Dropping it wrote the array with the ``bytes`` codec, so the store came
+    back out as a plain array and the caller's ``zarr.json`` disagreed with
+    what they asked for -- silently, only visible on read.
+    """
+    pytest.importorskip("zarrista")
+    from ngff_zarr import to_ngff_zarr
+
+    with pytest.raises(ValueError, match="serializer other than the bytes codec"):
+        to_ngff_zarr(
+            str(tmp_path / "serialized.ome.zarr"),
+            _sample_multiscales(),
+            version="0.5",
+            serializer={"name": "zfp", "configuration": {"mode": "reversible"}},
+        )
+
+
+def test_path_store_accepts_bytes_serializer(tmp_path):
+    """``serializer="bytes"`` asks for what the writer already does."""
+    pytest.importorskip("zarrista")
+    from ngff_zarr import to_ngff_zarr
+
+    store_path = tmp_path / "bytes_serializer.ome.zarr"
+    to_ngff_zarr(
+        str(store_path),
+        _sample_multiscales(),
+        version="0.5",
+        serializer={"name": "bytes", "configuration": {"endian": "little"}},
+    )
+    doc = json.loads((store_path / "scale0" / "image" / "zarr.json").read_text())
+    assert [codec["name"] for codec in doc["codecs"]] == ["bytes", "zstd"]
+
+
+def test_path_store_warns_on_unknown_array_kwarg(tmp_path):
+    """An array-creation keyword the writer does not know is not silently
+    ignored: ignoring it is how a caller comes to believe an inert argument
+    works (the MCP optimizer passed ``compression_codec=`` for releases)."""
+    pytest.importorskip("zarrista")
+    from ngff_zarr import to_ngff_zarr
+
+    store_path = tmp_path / "unknown_kwarg.ome.zarr"
+    with pytest.warns(DeprecationWarning, match="compression_codec"):
+        to_ngff_zarr(
+            str(store_path),
+            _sample_multiscales(),
+            version="0.5",
+            compression_codec="zstd",
+        )
+    # Warned, not failed: the store is still written, with the default chain.
+    doc = json.loads((store_path / "scale0" / "image" / "zarr.json").read_text())
+    assert [codec["name"] for codec in doc["codecs"]] == ["bytes", "zstd"]
+
+
 @pytest.mark.skipif(
     zarr_version < version.parse("3.0.0b2"),
     reason="the legacy-engine comparison requires zarr-python >= 3 (LocalStore)",

--- a/py/test/test_zarrista_compat.py
+++ b/py/test/test_zarrista_compat.py
@@ -503,19 +503,64 @@ def test_path_store_rejects_foreign_serializer(tmp_path):
 
 
 def test_path_store_accepts_bytes_serializer(tmp_path):
-    """``serializer="bytes"`` asks for what the writer already does."""
+    """``serializer="bytes"`` asks for what the writer already does.
+
+    Accepting it as a no-op is only honest if the byte order it names is the
+    one that lands, so read the written ``endian`` back rather than the codec
+    names alone. A multi-byte dtype is what carries one: the spec forbids
+    ``endian`` on single-byte dtypes, and the writer drops it there.
+    """
     pytest.importorskip("zarrista")
     from ngff_zarr import to_ngff_zarr
 
     store_path = tmp_path / "bytes_serializer.ome.zarr"
     to_ngff_zarr(
         str(store_path),
-        _sample_multiscales(),
+        _sample_multiscales(dtype=np.uint16),
         version="0.5",
         serializer={"name": "bytes", "configuration": {"endian": "little"}},
     )
     doc = json.loads((store_path / "scale0" / "image" / "zarr.json").read_text())
     assert [codec["name"] for codec in doc["codecs"]] == ["bytes", "zstd"]
+    assert doc["codecs"][0]["configuration"]["endian"] == "little"
+
+
+def test_path_store_rejects_big_endian_serializer(tmp_path):
+    """A ``bytes`` serializer asking for big-endian must raise.
+
+    The engine encodes little-endian chunks and has no endian knob, so the
+    request was accepted as a no-op and the store came out little-endian --
+    the byte order the caller asked for, silently reversed.
+    """
+    pytest.importorskip("zarrista")
+    from ngff_zarr import to_ngff_zarr
+
+    with pytest.raises(ValueError, match="endian='big'"):
+        to_ngff_zarr(
+            str(tmp_path / "big_endian.ome.zarr"),
+            _sample_multiscales(dtype=np.uint16),
+            version="0.5",
+            serializer={"name": "bytes", "configuration": {"endian": "big"}},
+        )
+
+
+def test_path_store_rejects_chunks_kwarg(tmp_path):
+    """``chunks=`` is not an array-creation option this writer takes.
+
+    It collided with the writer's own positional argument, so it raised a
+    TypeError naming an internal function. Point at where the chunk shape
+    actually comes from instead.
+    """
+    pytest.importorskip("zarrista")
+    from ngff_zarr import to_ngff_zarr
+
+    with pytest.raises(TypeError, match="to_multiscales"):
+        to_ngff_zarr(
+            str(tmp_path / "chunks_kwarg.ome.zarr"),
+            _sample_multiscales(),
+            version="0.5",
+            chunks=(16, 16),
+        )
 
 
 def test_path_store_warns_on_unknown_array_kwarg(tmp_path):


### PR DESCRIPTION
- **fix(py): reject codec chains the write engine cannot encode**
- **test(py): pin the write engine's codec-argument contract**
- **fix(mcp): pass the optimizer's compression through as a codec**
- **docs: correct the v0.44 guide's codec-argument compatibility claim**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Compression settings now apply correctly when optimizing Zarr stores.
  - Added validation requiring a compression codec when specifying a compression level.
- **Bug Fixes**
  - Unsupported big-endian `bytes` serialization and direct `chunks` options now provide clear errors and guidance.
  - Improved handling of foreign codecs during metadata-only migrations.
- **Documentation**
  - Expanded migration guidance for preserving array layout, sharding, lazy writes, and consolidated metadata.
- **Tests**
  - Added coverage for compression, serializer compatibility, chunk validation, and documented migration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->