### PR TITLE
Bound a displacement stage of an ITK transform by its values

### DIFF
--- a/py/ngff_zarr/resample.py
+++ b/py/ngff_zarr/resample.py
@@ -14,13 +14,16 @@ from .ngff_transform_to_itk_transform import ngff_transform_to_itk_transform
 from .resample_bounding_box import (
     _as_itk_transform_list,
     _check_geometry,
+    _direction_bounds,
     _field_stream,
+    _grid_physical_box,
     _grown,
     _identity_region,
     _identity_transform_list,
     _is_ngff_transform,
     _itk_direction,
     _metadata_only_itk_image,
+    _nonlinear_interval,
     _shifted_translation,
     _spatial_dims,
     resample_bounding_box,
@@ -457,6 +460,8 @@ def resample(
     out_orientations = fixed.axes_orientations
     field = None
     field_bound = None
+    itk_interval = None
+    itk_growth = None
     if _is_ngff_transform(transform):
         if isinstance(transform, (Coordinates, Displacements)):
             # The blocks divide the grid, so the grid's own window is the
@@ -481,6 +486,20 @@ def resample(
         moving = replace(moving, axes_orientations=None)
     else:
         transform_list = _as_itk_transform_list(transform)
+        # A displacement stage would have its whole field scanned once per
+        # block below; the split and its range are loop constants, so they
+        # are taken here. The graph's tasks keep the original list: only the
+        # regions walk the linear part.
+        itk_dims = [dim for dim in ("x", "y", "z") if dim in fixed_spatial]
+        walked_list, itk_interval = _nonlinear_interval(
+            transform_list,
+            len(fixed_spatial),
+            _grid_physical_box(fixed, itk_dims),
+        )
+        if itk_interval is not None:
+            itk_growth = _direction_bounds(
+                itk_interval, itk_dims, _itk_direction(moving, itk_dims)
+            )
 
     out_chunks = fixed.data.chunks
     out_offsets = _chunk_offsets(out_chunks)
@@ -545,6 +564,13 @@ def resample(
                 _identity_region(grid, moving, padding),
                 field_bound.over(window, outside),
                 moving,
+            )
+        elif itk_interval is not None:
+            region = _grown(
+                resample_bounding_box(walked_list, grid, moving, padding=padding),
+                itk_growth[0],
+                moving,
+                itk_growth[1],
             )
         else:
             region = resample_bounding_box(

--- a/py/ngff_zarr/resample_bounding_box.py
+++ b/py/ngff_zarr/resample_bounding_box.py
@@ -117,6 +117,7 @@ def _grown(
     region: "ResampleBoundingBox",
     bound: Mapping[str, tuple[float, float]],
     moving: NgffImage,
+    index_bound: Mapping[str, tuple[float, float]] | None = None,
 ) -> "ResampleBoundingBox":
     """``region`` moved and widened by a per-axis displacement range.
 
@@ -135,11 +136,15 @@ def _grown(
     padded_max = dict(region.padded_corners_max)
     for dim in region.dims:
         low, high = bound.get(dim, (0.0, 0.0))
-        if low == 0.0 and high == 0.0:
+        # The corners live in world space; the start and size are indices,
+        # which an oriented moving image reaches through its direction. The
+        # two coincide unless a caller passes the index mapping separately.
+        index_low, index_high = (index_bound or bound).get(dim, (0.0, 0.0))
+        if low == high == 0.0 and index_low == index_high == 0.0:
             continue
         scale = float(moving.scale[dim])
-        first = math.floor(min(low / scale, high / scale))
-        last = math.ceil(max(low / scale, high / scale))
+        first = math.floor(min(index_low / scale, index_high / scale))
+        last = math.ceil(max(index_low / scale, index_high / scale))
         start[dim] += first
         size[dim] += last - first
         # The reported corners hold a first and a last index position, which
@@ -440,6 +445,220 @@ def _transform_from_dict(entry: dict):
     return ItkTransform(**entry)
 
 
+#: Parameterizations whose displacement is values read through a kernel that
+#: is non-negative and sums to one: linear interpolation over the field's
+#: vectors, the cubic B-spline basis over its coefficients. The displacement
+#: anywhere is then a convex combination of those numbers and lies between
+#: their smallest and largest, and it is zero beyond the transform's own
+#: domain, where ITK returns the point unchanged.
+#:
+#: The parameter layouts differ and are pinned by
+#: ``test_the_stage_interval_reads_the_layouts_itk_writes``: a field
+#: interleaves components per point, a B-spline blocks them per component.
+_INTERVAL_PARAMETERIZATIONS = {
+    "DisplacementField": lambda values, dimension: values.reshape(-1, dimension),
+    "BSpline": lambda values, dimension: values.reshape(dimension, -1).T,
+}
+
+#: Parameterizations that evaluate ``y = s R x + b`` with ``R`` orthonormal
+#: and ``s = 1``. Each row of ``R`` has unit norm, so a component of ``R r``
+#: is bounded by the Euclidean norm of ``r``: the ball an interval folds into
+#: when the exact matrix is not worth decoding.
+_ORTHONORMAL_PARAMETERIZATIONS = frozenset(
+    {
+        "Euler2D",
+        "Euler3D",
+        "Rigid2D",
+        "Rigid3D",
+        "Versor",
+        "VersorRigid3D",
+        "QuaternionRigid",
+    }
+)
+
+
+def _stage_interval(entry, dimension: int):
+    """One list entry's displacement range, or ``None`` for the rest.
+
+    :return: ``(low, high)`` per physical component, or ``None`` when the
+        entry is not one of the two interval parameterizations. Whether zero
+        joins the range is the caller's question: it depends on whether the
+        grid can leave the stage's domain, where ITK returns the point
+        unchanged.
+    """
+    from .itk_transform_to_ngff_transform import _parameterization_name
+
+    arrange = _INTERVAL_PARAMETERIZATIONS.get(
+        _parameterization_name(entry.transformType)
+    )
+    if arrange is None or entry.parameters is None:
+        return None
+    values = np.asarray(entry.parameters, dtype=float)
+    if values.size == 0 or values.size % dimension:
+        return None
+    per_point = arrange(values, dimension)
+    return per_point.min(axis=0), per_point.max(axis=0)
+
+
+def _box_inside_field_domain(entry, dimension: int, grid_box) -> bool:
+    """Whether ``grid_box`` stays on the field's own lattice.
+
+    A ``DisplacementField``'s fixed parameters carry its grid: size, origin,
+    spacing, then the direction, row-major, the layout
+    :func:`~ngff_zarr.ngff_displacement_field_to_itk_transform` writes and ITK
+    reads. A point past the lattice is displaced by nothing, so a grid that
+    leaves it takes zero into its range; one that stays inside keeps the
+    values' own range, which is what makes a constant field an exact shift.
+    Anything not answerable exactly, a rotated field grid included, answers
+    ``False``, which only widens.
+    """
+    fixed = np.asarray(
+        [] if entry.fixedParameters is None else entry.fixedParameters, dtype=float
+    )
+    if fixed.size != 3 * dimension + dimension * dimension:
+        return False
+    size = fixed[:dimension]
+    origin = fixed[dimension : 2 * dimension]
+    spacing = fixed[2 * dimension : 3 * dimension]
+    direction = fixed[3 * dimension :].reshape(dimension, dimension)
+    if not np.allclose(direction, np.eye(dimension)) or np.any(spacing <= 0):
+        return False
+    low, high = grid_box
+    for component in range(dimension):
+        first = (low[component] - origin[component]) / spacing[component]
+        last = (high[component] - origin[component]) / spacing[component]
+        if min(first, last) < 0 or max(first, last) > size[component] - 1:
+            return False
+    return True
+
+
+def _folded_interval(interval, outer_entries, dimension: int):
+    """``interval`` carried through the stages applied after its own.
+
+    ITK applies the last entry of a list first, so the stages applied after
+    entry ``i`` are the entries before it. An affine stage maps the interval
+    through the signs of its matrix; an orthonormal stage bounds every output
+    component by the Euclidean reach of the input; anything else returns
+    ``None``, and the caller keeps the boundary walk.
+    """
+    from .itk_transform_to_ngff_transform import (
+        _matrix_offset_from_itkwasm,
+        _parameterization_name,
+    )
+
+    low, high = interval
+    for entry in reversed(outer_entries):
+        name = _parameterization_name(entry.transformType)
+        matrix = None
+        try:
+            decoded = _matrix_offset_from_itkwasm(entry, dimension)
+            if decoded is not None:
+                matrix = decoded[0]
+        except Exception:
+            matrix = None
+        if matrix is not None:
+            ends = matrix[:, None, :] * np.stack([low, high])[None, :, :]
+            low = ends.min(axis=1).sum(axis=1)
+            high = ends.max(axis=1).sum(axis=1)
+        elif name in _ORTHONORMAL_PARAMETERIZATIONS:
+            reach = float(np.linalg.norm(np.maximum(np.abs(low), np.abs(high))))
+            low = np.full(dimension, -reach)
+            high = np.full(dimension, reach)
+        else:
+            return None
+    return low, high
+
+
+def _nonlinear_interval(entries, dimension: int, grid_box=None):
+    """Split a transform list into its linear part and a displacement range.
+
+    :param grid_box: ``(low, high)`` per physical component of the fixed
+        grid, when the caller knows it. A lone ``DisplacementField`` whose
+        lattice contains the box keeps the values' own range; in every other
+        case zero joins the range, since ITK displaces a point beyond a
+        stage's domain by nothing.
+    :return: ``(affine_entries, (low, high))`` when every displacement stage
+        could be bounded and folded: the entries with those stages replaced by
+        the identity, whose boundary walk the pipeline reports exactly, and
+        the range to widen its region by. ``(entries, None)`` otherwise, and
+        the caller's boundary walk stands, with the miss its docstring names.
+    """
+    intervals = [
+        (index, interval)
+        for index, entry in enumerate(entries)
+        if (interval := _stage_interval(entry, dimension)) is not None
+    ]
+    if not intervals:
+        return entries, None
+    contained = (
+        len(entries) == 1
+        and grid_box is not None
+        and _box_inside_field_domain(entries[0], dimension, grid_box)
+    )
+    low = np.zeros(dimension)
+    high = np.zeros(dimension)
+    for index, interval in intervals:
+        if not contained:
+            interval = (np.minimum(interval[0], 0.0), np.maximum(interval[1], 0.0))
+        folded = _folded_interval(interval, entries[:index], dimension)
+        if folded is None:
+            return entries, None
+        low = low + folded[0]
+        high = high + folded[1]
+    replaced = list(entries)
+    identity = _identity_transform_list(("z", "y", "x")[-dimension:])[0]
+    for index, _interval in intervals:
+        replaced[index] = identity
+    return replaced, (low, high)
+
+
+def _grid_physical_box(grid: NgffImage, itk_dims):
+    """The grid's physical extent per component, direction included.
+
+    The directions RFC-4 orientations produce are signed permutations, so
+    each physical component follows exactly one grid axis and the box is the
+    per-axis pair of endpoint positions. ``None`` for any other direction.
+    """
+    direction = _itk_direction(grid, itk_dims)
+    dims = tuple(grid.dims)
+    origin = np.array([float(grid.translation[dim]) for dim in itk_dims])
+    low = origin.copy()
+    high = origin.copy()
+    for axis, dim in enumerate(itk_dims):
+        column = direction[:, axis]
+        component = int(np.argmax(np.abs(column)))
+        if not np.isclose(abs(column[component]), 1.0) or np.count_nonzero(column) != 1:
+            return None
+        reach = (
+            column[component]
+            * (int(grid.data.shape[dims.index(dim)]) - 1)
+            * float(grid.scale[dim])
+        )
+        low[component] += min(reach, 0.0)
+        high[component] += max(reach, 0.0)
+    return low, high
+
+
+def _direction_bounds(interval, itk_dims, direction):
+    """The physical range as the two per-dimension mappings ``_grown`` takes.
+
+    The corners the region reports are physical positions keyed by dimension
+    name, so component ``j`` widens the dimension named ``itk_dims[j]``. The
+    start and size are indices, and an index moves through the direction's
+    transpose: with the signed permutations RFC-4 orientations produce, axis
+    ``k`` follows the one component its column names, sign included.
+    """
+    low, high = interval
+    corners = {dim: (float(low[j]), float(high[j])) for j, dim in enumerate(itk_dims)}
+    indices = {}
+    for k, dim in enumerate(itk_dims):
+        j = int(np.argmax(np.abs(direction[:, k])))
+        sign = float(np.sign(direction[j, k])) or 1.0
+        ends = (sign * low[j], sign * high[j])
+        indices[dim] = (min(ends), max(ends))
+    return corners, indices
+
+
 def _identity_region(
     grid: NgffImage, moving: NgffImage, padding: int
 ) -> "ResampleBoundingBox":
@@ -594,10 +813,17 @@ def resample_bounding_box(
     reports is the grid's own image moved and widened by the range that
     displacement takes. The range is read from the field one chunk at a time,
     so a field larger than memory is never held; a field that shifts every
-    point the same way moves the region rather than widening it. An ITK
-    transform is instead measured by walking the boundary of the transformed
-    grid, which reports a linear map exactly and misses what a non-linear one
-    does strictly inside the grid.
+    point the same way moves the region rather than widening it.
+
+    An ITK transform is measured by walking the boundary of the transformed
+    grid, which reports a linear map exactly. A ``DisplacementField`` or
+    ``BSpline`` stage would be missed where it acts strictly inside the grid,
+    so such a stage is bounded the way a field is: the walk measures the list
+    with those stages replaced by the identity, and the range their values
+    can add, carried through the stages applied after them, widens the
+    result. Other non-linear parameterizations, the velocity fields among
+    them, still rely on the walk alone and can under-report a strictly
+    interior excursion.
 
     In both cases the transform maps *fixed* points into *moving* space.
 
@@ -690,6 +916,7 @@ def resample_bounding_box(
         )
 
     field_bound = None
+    field_index_bound = None
     if _is_ngff_transform(transform):
         if isinstance(transform, (Coordinates, Displacements)):
             # A field transform is the identity plus a displacement: the
@@ -712,6 +939,19 @@ def resample_bounding_box(
         transform_list = _as_itk_transform_list(transform)
         fixed_direction = _itk_direction(fixed, itk_dims)
         moving_direction = _itk_direction(moving, itk_dims)
+        walked, interval = _nonlinear_interval(
+            transform_list, len(itk_dims), _grid_physical_box(fixed, itk_dims)
+        )
+        if interval is not None:
+            # The pipeline walks the boundary, which reports a linear map
+            # exactly and misses what a displacement does strictly inside the
+            # grid. The walk therefore measures the list with its
+            # displacement stages replaced by the identity, and the range
+            # those stages can add widens the result.
+            transform_list = walked
+            corners, indices = _direction_bounds(interval, itk_dims, moving_direction)
+            field_bound = corners
+            field_index_bound = indices
 
     result = itkwasm_bounding_box(
         transform_list,
@@ -746,4 +986,4 @@ def resample_bounding_box(
     )
     if field_bound is None:
         return region
-    return _grown(region, field_bound, moving)
+    return _grown(region, field_bound, moving, field_index_bound)

--- a/py/ngff_zarr/resample_bounding_box.py
+++ b/py/ngff_zarr/resample_bounding_box.py
@@ -510,8 +510,14 @@ def _box_inside_field_domain(entry, dimension: int, grid_box) -> bool:
     leaves it takes zero into its range; one that stays inside keeps the
     values' own range, which is what makes a constant field an exact shift.
     Anything not answerable exactly, a rotated field grid included, answers
-    ``False``, which only widens.
+    ``False``, which only widens. A ``BSpline`` never answers ``True``: its
+    control lattice reaches spline-order points beyond its domain of support,
+    so lying inside the lattice proves nothing about staying on the domain.
     """
+    from .itk_transform_to_ngff_transform import _parameterization_name
+
+    if _parameterization_name(entry.transformType) != "DisplacementField":
+        return False
     fixed = np.asarray(
         [] if entry.fixedParameters is None else entry.fixedParameters, dtype=float
     )

--- a/py/test/test_resample_bounding_box.py
+++ b/py/test/test_resample_bounding_box.py
@@ -1367,3 +1367,39 @@ def test_an_affine_around_the_field_folds_its_interval():
     # The affine is outermost now, so the field's range doubles through it.
     assert folded[0].tolist() == [-120.0, 0.0]
     assert folded[1].tolist() == [0.0, 120.0]
+
+
+def test_a_lone_bspline_keeps_zero_in_its_range():
+    """A B-spline's lattice cannot prove the grid stays on its domain.
+
+    The control lattice reaches spline-order points beyond the domain of
+    support, so a grid inside the lattice can still land where ITK displaces
+    it by nothing: coefficients all one way must not carry the region off
+    the undisplaced points.
+    """
+    itk = pytest.importorskip("itk")
+
+    spline = itk.BSplineTransform[itk.D, 2, 3].New()
+    mesh = itk.Size[2]()
+    mesh.Fill(3)
+    spline.SetTransformDomainMeshSize(mesh)
+    physical = itk.Vector[itk.D, 2]()
+    physical[0], physical[1] = 32.0, 32.0
+    spline.SetTransformDomainPhysicalDimensions(physical)
+    count = spline.GetNumberOfParameters()
+    parameters = itk.OptimizerParameters[itk.D](count)
+    for index in range(count):
+        parameters.SetElement(index, 10.0)
+    spline.SetParameters(parameters)
+
+    fixed = _image("yx", {"y": 16, "x": 16}, {"y": 1.0, "x": 1.0}, {"y": 8.0, "x": 8.0})
+    moving = _image(
+        "yx", {"y": 64, "x": 64}, {"y": 1.0, "x": 1.0}, {"y": 0.0, "x": 0.0}
+    )
+
+    region = resample_bounding_box(spline, fixed, moving, padding=0)
+
+    for dim in ("y", "x"):
+        # Zero in the range keeps the grid's own undisplaced extent covered.
+        assert region.start_index[dim] <= 8
+        assert region.start_index[dim] + region.size[dim] >= 8 + 15 + 10

--- a/py/test/test_resample_bounding_box.py
+++ b/py/test/test_resample_bounding_box.py
@@ -24,6 +24,7 @@ from ngff_zarr import (
 )
 from ngff_zarr.ngff_transform_to_itk_transform import _ngff_transform_to_itk_matrix
 from ngff_zarr.resample_bounding_box import (
+    _as_itk_transform_list,
     _itk_direction,
     _metadata_only_itk_image,
     _shifted_translation,
@@ -1196,3 +1197,173 @@ def test_the_identity_region_is_the_pipelines():
         ):
             for dim in dims:
                 np.testing.assert_allclose(mine[dim], theirs[dim], rtol=1e-12)
+
+
+def _bump_displacement_transform(itk, extent=64, radius=20, peaks=(60.0, -60.0)):
+    """A field that is zero on the grid boundary and peaks in the middle.
+
+    The boundary walk sees only the zero, which is what the interval has to
+    make up for. ``peaks`` are the (y, x) amplitudes; the field's grid is
+    unit-spaced at the origin.
+    """
+    grid_y, grid_x = np.mgrid[0:extent, 0:extent].astype(np.float64)
+    distance = np.sqrt((grid_y - extent / 2) ** 2 + (grid_x - extent / 2) ** 2)
+    profile = np.where(
+        distance < radius, 0.5 * (1 + np.cos(np.pi * distance / radius)), 0.0
+    )
+    field = itk.Image[itk.Vector[itk.D, 2], 2].New()
+    field.SetRegions(itk.ImageRegion[2]([extent, extent]))
+    field.Allocate()
+    view = itk.array_view_from_image(field)
+    view[..., 0] = peaks[1] * profile
+    view[..., 1] = peaks[0] * profile
+    transform = itk.DisplacementFieldTransform[itk.D, 2].New()
+    transform.SetDisplacementField(field)
+    return transform, profile
+
+
+def test_the_stage_interval_reads_the_layouts_itk_writes():
+    """A field interleaves components per point; a B-spline blocks them.
+
+    Pinned against ITK itself: one distinctive value planted per component
+    must come back on its own component, not on a neighbour's. Misreading the
+    layout would produce plausible wrong bounds silently.
+    """
+    itk = pytest.importorskip("itk")
+    from ngff_zarr.resample_bounding_box import _stage_interval
+
+    field = itk.Image[itk.Vector[itk.D, 2], 2].New()
+    field.SetRegions(itk.ImageRegion[2]([4, 3]))
+    field.Allocate()
+    field.FillBuffer(itk.Vector[itk.D, 2]())
+    vector = itk.Vector[itk.D, 2]()
+    vector[0], vector[1] = 7.0, -9.0
+    field.SetPixel([2, 1], vector)
+    warp = itk.DisplacementFieldTransform[itk.D, 2].New()
+    warp.SetDisplacementField(field)
+    (entry,) = _as_itk_transform_list(warp)
+    low, high = _stage_interval(entry, 2)
+    assert (low.tolist(), high.tolist()) == ([0.0, -9.0], [7.0, 0.0])
+
+    spline = itk.BSplineTransform[itk.D, 2, 3].New()
+    mesh = itk.Size[2]()
+    mesh.Fill(3)
+    spline.SetTransformDomainMeshSize(mesh)
+    count = spline.GetNumberOfParameters()
+    parameters = itk.OptimizerParameters[itk.D](count)
+    for index in range(count):
+        parameters.SetElement(index, 0.0)
+    parameters.SetElement(5, 11.0)
+    parameters.SetElement(count // 2 + 5, -13.0)
+    spline.SetParameters(parameters)
+    (entry,) = _as_itk_transform_list(spline)
+    low, high = _stage_interval(entry, 2)
+    assert (low.tolist(), high.tolist()) == ([0.0, -13.0], [11.0, 0.0])
+
+
+def test_an_interior_bump_in_an_itk_field_widens_the_region():
+    """A displacement the grid's boundary does not show still gets covered.
+
+    The walk reported the identity region for this field and resample
+    returned the default value for 64 of 4096 pixels, by up to 93.
+    """
+    itk = pytest.importorskip("itk")
+    warp, profile = _bump_displacement_transform(itk)
+
+    fixed = _image("yx", {"y": 64, "x": 64}, {"y": 1.0, "x": 1.0}, {"y": 0.0, "x": 0.0})
+    moving = _image(
+        "yx", {"y": 256, "x": 256}, {"y": 1.0, "x": 1.0}, {"y": 0.0, "x": 0.0}
+    )
+
+    region = resample_bounding_box(warp, fixed, moving, padding=1)
+
+    grid_y, grid_x = np.mgrid[0:64, 0:64].astype(np.float64)
+    for dim, reached in (
+        ("y", grid_y + 60.0 * profile),
+        ("x", grid_x - 60.0 * profile),
+    ):
+        assert region.start_index[dim] <= float(reached.min())
+        assert region.start_index[dim] + region.size[dim] >= float(reached.max())
+
+
+def test_an_interior_bump_resamples_exactly_in_one_block():
+    """One output block over the whole grid, against a whole-image call.
+
+    Small blocks hide the miss by accident, their boundaries crossing the
+    bump; one block is the case the walk got wrong.
+    """
+    itk = pytest.importorskip("itk")
+    from ngff_zarr import resample
+
+    warp, _profile = _bump_displacement_transform(itk)
+    # One block over the whole grid, said explicitly: left to itself dask
+    # cuts this small array into blocks whose boundaries cross the bump, and
+    # the walk then finds by accident what it misses on the block at stake.
+    fixed = NgffImage(
+        data=da.zeros((64, 64), chunks=(64, 64), dtype=np.float32),
+        dims=("y", "x"),
+        scale={"y": 1.0, "x": 1.0},
+        translation={"y": 0.0, "x": 0.0},
+    )
+    # The images this file builds carry no pixels, which the bounding box
+    # never reads; this test resamples, so the moving image has to carry
+    # something a missed region would lose.
+    moving = NgffImage(
+        data=da.from_array(
+            (np.random.default_rng(0).random((256, 256)) * 100).astype(np.float32)
+        ),
+        dims=("y", "x"),
+        scale={"y": 1.0, "x": 1.0},
+        translation={"y": 0.0, "x": 0.0},
+    )
+
+    result = np.asarray(resample(warp, fixed, moving).data)
+
+    from itkwasm_downsample import resample_to_reference
+    from ngff_zarr.ngff_image_to_itk_image import ngff_image_to_itk_image
+    from ngff_zarr.resample import _component_type
+    from ngff_zarr.resample_bounding_box import _spatial_dims
+
+    itk_dims = list(reversed(_spatial_dims(fixed)))
+    reference = _metadata_only_itk_image(
+        fixed, itk_dims, _itk_direction(fixed, itk_dims)
+    )
+    reference.imageType.componentType = _component_type(moving.data.dtype)
+    expected = np.asarray(
+        resample_to_reference(
+            ngff_image_to_itk_image(moving, wasm=True),
+            reference,
+            transform=_as_itk_transform_list(warp),
+            interpolator="linear",
+        ).data
+    ).reshape((64, 64))
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_an_affine_around_the_field_folds_its_interval():
+    """A composite of an affine and a field bounds through the affine's signs."""
+    itk = pytest.importorskip("itk")
+    from ngff_zarr.resample_bounding_box import _nonlinear_interval
+
+    warp, _profile = _bump_displacement_transform(itk, peaks=(60.0, -60.0))
+    scaling = itk.AffineTransform[itk.D, 2].New()
+    scaling.Scale(2.0)
+    composite = itk.CompositeTransform[itk.D, 2].New()
+    composite.AddTransform(warp)
+    composite.AddTransform(scaling)  # applied first: entries = [warp? or scaling?]
+
+    entries = _as_itk_transform_list(composite)
+    walked, interval = _nonlinear_interval(entries, 2)
+
+    assert interval is not None
+    low, high = interval
+    # The field is the outermost stage here, so its range passes through no
+    # affine and keeps its own numbers, zero included.
+    assert low.tolist() == [-60.0, 0.0]
+    assert high.tolist() == [0.0, 60.0]
+
+    reordered = _as_itk_transform_list([entries[1], entries[0]])
+    _walked, folded = _nonlinear_interval(reordered, 2)
+    # The affine is outermost now, so the field's range doubles through it.
+    assert folded[0].tolist() == [-120.0, 0.0]
+    assert folded[1].tolist() == [0.0, 120.0]

--- a/ts/src/io/resample_bounding_box-shared.ts
+++ b/ts/src/io/resample_bounding_box-shared.ts
@@ -16,6 +16,7 @@ import type { NgffMultiscales } from "../types/multiscales.ts";
 import { identityDirection, itkDirection } from "../utils/itk_direction.ts";
 export { itkDirection };
 import { ngffTransformToItkTransform } from "../utils/ngff_transform_to_itk_transform.ts";
+import { decodeMatrixOffset } from "../utils/itk_transform_to_ngff_transform.ts";
 import {
   checkUnorientedField,
   fieldDisplacementRange,
@@ -323,6 +324,255 @@ function fieldFor(
   return field;
 }
 
+//: Parameterizations whose displacement is values read through a kernel that
+//: is non-negative and sums to one. The displacement anywhere is a convex
+//: combination of those numbers, so it lies between their smallest and
+//: largest, and it is zero beyond the transform's own domain, where ITK
+//: returns the point unchanged. The layouts differ: a field interleaves
+//: components per point, a B-spline blocks them per component.
+const INTERVAL_PARAMETERIZATIONS = new Set(["DisplacementField", "BSpline"]);
+
+//: Parameterizations that evaluate `y = R x + b` with `R` orthonormal. Each
+//: row of `R` has unit norm, so a component of `R r` is bounded by the
+//: Euclidean norm of `r`: the ball an interval folds into when the exact
+//: matrix is not worth decoding.
+const ORTHONORMAL_PARAMETERIZATIONS = new Set([
+  "Euler2D",
+  "Euler3D",
+  "Rigid2D",
+  "Rigid3D",
+  "Versor",
+  "VersorRigid3D",
+  "QuaternionRigid",
+]);
+
+interface Interval {
+  low: number[];
+  high: number[];
+}
+
+/** One list entry's displacement range, or undefined for the rest. */
+function stageInterval(
+  entry: TransformList[number],
+  dimension: number,
+): Interval | undefined {
+  const name = String(entry.transformType.transformParameterization);
+  if (!INTERVAL_PARAMETERIZATIONS.has(name)) return undefined;
+  const values = entry.parameters as ArrayLike<number> | null | undefined;
+  if (!values || values.length === 0 || values.length % dimension !== 0) {
+    return undefined;
+  }
+  const low = new Array<number>(dimension).fill(Number.POSITIVE_INFINITY);
+  const high = new Array<number>(dimension).fill(Number.NEGATIVE_INFINITY);
+  const block = values.length / dimension;
+  for (let index = 0; index < values.length; index++) {
+    const component = name === "DisplacementField"
+      ? index % dimension
+      : Math.floor(index / block);
+    const value = values[index];
+    if (value < low[component]) low[component] = value;
+    if (value > high[component]) high[component] = value;
+  }
+  return { low, high };
+}
+
+/** Whether `box` stays on a field's own lattice, read off its fixed
+ * parameters: size, origin, spacing, then the direction, row-major. A point
+ * past the lattice is displaced by nothing, so a grid that leaves it takes
+ * zero into its range; anything not answerable exactly answers false, which
+ * only widens. */
+function boxInsideFieldDomain(
+  entry: TransformList[number],
+  dimension: number,
+  box: Interval,
+): boolean {
+  const fixed = entry.fixedParameters as ArrayLike<number> | null | undefined;
+  if (!fixed || fixed.length !== 3 * dimension + dimension * dimension) {
+    return false;
+  }
+  for (let row = 0; row < dimension; row++) {
+    for (let col = 0; col < dimension; col++) {
+      const expected = row === col ? 1 : 0;
+      if (fixed[3 * dimension + row * dimension + col] !== expected) {
+        return false;
+      }
+    }
+  }
+  for (let component = 0; component < dimension; component++) {
+    const size = fixed[component];
+    const origin = fixed[dimension + component];
+    const spacing = fixed[2 * dimension + component];
+    if (spacing <= 0) return false;
+    const first = (box.low[component] - origin) / spacing;
+    const last = (box.high[component] - origin) / spacing;
+    if (Math.min(first, last) < 0 || Math.max(first, last) > size - 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** `interval` carried through the stages applied after its own: ITK applies
+ * the last entry of a list first, so those are the entries before it. An
+ * affine stage maps the interval through the signs of its matrix, an
+ * orthonormal stage bounds every component by the Euclidean reach, and
+ * anything else returns undefined: the caller keeps the boundary walk. */
+function foldedInterval(
+  interval: Interval,
+  outers: TransformList,
+  dimension: number,
+): Interval | undefined {
+  let low = interval.low.slice();
+  let high = interval.high.slice();
+  for (let position = outers.length - 1; position >= 0; position--) {
+    const entry = outers[position];
+    let matrix: number[][] | undefined;
+    try {
+      matrix = decodeMatrixOffset(entry, dimension).matrix;
+    } catch {
+      matrix = undefined;
+    }
+    if (matrix !== undefined) {
+      const nextLow = new Array<number>(dimension).fill(0);
+      const nextHigh = new Array<number>(dimension).fill(0);
+      for (let row = 0; row < dimension; row++) {
+        for (let col = 0; col < dimension; col++) {
+          const ends = [
+            matrix[row][col] * low[col],
+            matrix[row][col] * high[col],
+          ];
+          nextLow[row] += Math.min(...ends);
+          nextHigh[row] += Math.max(...ends);
+        }
+      }
+      low = nextLow;
+      high = nextHigh;
+    } else if (
+      ORTHONORMAL_PARAMETERIZATIONS.has(
+        String(entry.transformType.transformParameterization),
+      )
+    ) {
+      const reach = Math.hypot(
+        ...low.map((value, i) => Math.max(Math.abs(value), Math.abs(high[i]))),
+      );
+      low = new Array<number>(dimension).fill(-reach);
+      high = new Array<number>(dimension).fill(reach);
+    } else {
+      return undefined;
+    }
+  }
+  return { low, high };
+}
+
+/** The grid's physical extent per component, direction included. The
+ * directions RFC-4 orientations produce are signed permutations, so each
+ * component follows exactly one grid axis; undefined for any other
+ * direction. */
+function gridPhysicalBox(
+  grid: NgffImage,
+  itkDims: string[],
+): Interval | undefined {
+  const direction = itkDirection(grid, itkDims);
+  const dimension = itkDims.length;
+  const low = itkDims.map((dim) => grid.translation[dim]);
+  const high = low.slice();
+  for (let axis = 0; axis < dimension; axis++) {
+    let component = -1;
+    for (let row = 0; row < dimension; row++) {
+      const value = direction[row * dimension + axis];
+      if (value !== 0) {
+        if (component !== -1 || Math.abs(value) !== 1) return undefined;
+        component = row;
+      }
+    }
+    if (component === -1) return undefined;
+    const dim = itkDims[axis];
+    const reach = direction[component * dimension + axis] *
+      (grid.data.shape[grid.dims.indexOf(dim)] - 1) * grid.scale[dim];
+    low[component] += Math.min(reach, 0);
+    high[component] += Math.max(reach, 0);
+  }
+  return { low, high };
+}
+
+/** Split a transform list into its linear part and a displacement range, or
+ * undefined when no stage carries one or a stage could not be folded. A lone
+ * `DisplacementField` whose lattice contains `gridBox` keeps the values' own
+ * range; in every other case zero joins it. */
+function nonlinearInterval(
+  entries: TransformList,
+  dimension: number,
+  gridBox: Interval | undefined,
+): { entries: TransformList; range: Interval } | undefined {
+  const intervals: [number, Interval][] = [];
+  entries.forEach((entry, index) => {
+    const interval = stageInterval(entry, dimension);
+    if (interval !== undefined) intervals.push([index, interval]);
+  });
+  if (intervals.length === 0) return undefined;
+  const contained = entries.length === 1 && gridBox !== undefined &&
+    boxInsideFieldDomain(entries[0], dimension, gridBox);
+  const low = new Array<number>(dimension).fill(0);
+  const high = new Array<number>(dimension).fill(0);
+  for (const [index, interval] of intervals) {
+    const ranged = contained ? interval : {
+      low: interval.low.map((value) => Math.min(value, 0)),
+      high: interval.high.map((value) => Math.max(value, 0)),
+    };
+    const folded = foldedInterval(ranged, entries.slice(0, index), dimension);
+    if (folded === undefined) return undefined;
+    for (let component = 0; component < dimension; component++) {
+      low[component] += folded.low[component];
+      high[component] += folded.high[component];
+    }
+  }
+  const replaced = entries.slice();
+  const identity = ngffTransformToItkTransform(
+    { type: "identity" },
+    ["z", "y", "x"].slice(-dimension),
+  )[0];
+  for (const [index] of intervals) replaced[index] = identity;
+  return { entries: replaced, range: { low, high } };
+}
+
+/** The physical range as the two per-dimension mappings `grown` takes: the
+ * corners are physical positions keyed by name, so component j widens the
+ * dimension named `itkDims[j]`; an index moves through the direction's
+ * transpose, and with the signed permutations RFC-4 orientations produce,
+ * axis k follows the one component its column names, sign included. */
+function directionBounds(
+  range: Interval,
+  itkDims: string[],
+  direction: Float64Array,
+  spatial: string[],
+): { corners: Interval; indices: Interval } {
+  const dimension = itkDims.length;
+  const corners: Record<string, [number, number]> = {};
+  const indices: Record<string, [number, number]> = {};
+  itkDims.forEach((dim, j) => {
+    corners[dim] = [range.low[j], range.high[j]];
+  });
+  for (let axis = 0; axis < dimension; axis++) {
+    let component = 0;
+    let best = 0;
+    for (let row = 0; row < dimension; row++) {
+      const value = Math.abs(direction[row * dimension + axis]);
+      if (value > best) {
+        best = value;
+        component = row;
+      }
+    }
+    const sign = Math.sign(direction[component * dimension + axis]) || 1;
+    const ends = [sign * range.low[component], sign * range.high[component]];
+    indices[itkDims[axis]] = [Math.min(...ends), Math.max(...ends)];
+  }
+  const order = (table: Record<string, [number, number]>) => ({
+    low: spatial.map((dim) => table[dim][0]),
+    high: spatial.map((dim) => table[dim][1]),
+  });
+  return { corners: order(corners), indices: order(indices) };
+}
+
 function isV06Transform(value: unknown): value is V06Transform {
   return typeof value === "object" && value !== null && "type" in value &&
     typeof (value as { type: unknown }).type === "string";
@@ -400,6 +650,7 @@ export async function resampleBoundingBoxShared(
   let fixedDirection: Float64Array;
   let movingDirection: Float64Array;
   let fieldRange: { low: number[]; high: number[] } | undefined;
+  let indexRange: { low: number[]; high: number[] } | undefined;
 
   if (Array.isArray(transform)) {
     // An ITK transform list acts on ITK physical space, so the geometry is
@@ -407,6 +658,27 @@ export async function resampleBoundingBoxShared(
     transformList = transform;
     fixedDirection = itkDirection(fixed, itkDims);
     movingDirection = itkDirection(moving, itkDims);
+    // The pipeline walks the boundary of the transformed grid, which
+    // reports a linear map exactly and misses what a DisplacementField or
+    // BSpline stage does strictly inside it. The walk therefore measures
+    // the list with those stages replaced by the identity, and the range
+    // their values can add widens the result.
+    const split = nonlinearInterval(
+      transform,
+      itkDims.length,
+      gridPhysicalBox(fixed, itkDims),
+    );
+    if (split !== undefined) {
+      transformList = split.entries;
+      const bounds = directionBounds(
+        split.range,
+        itkDims,
+        movingDirection,
+        fixedSpatial,
+      );
+      fieldRange = bounds.corners;
+      indexRange = bounds.indices;
+    }
   } else if (isV06Transform(transform)) {
     if (
       transform.type === "displacements" || transform.type === "coordinates"
@@ -488,7 +760,7 @@ export async function resampleBoundingBoxShared(
   });
   return fieldRange === undefined
     ? region
-    : grown(region, fieldRange, fixedSpatial, moving, movingShape);
+    : grown(region, fieldRange, fixedSpatial, moving, movingShape, indexRange);
 }
 
 /**
@@ -507,6 +779,7 @@ function grown(
   spatial: string[],
   moving: NgffImage,
   movingShape: Record<string, number>,
+  indexRange?: { low: number[]; high: number[] },
 ): ResampleBoundingBox {
   const startIndex = { ...region.startIndex };
   const size = { ...region.size };
@@ -517,10 +790,15 @@ function grown(
   spatial.forEach((dim, axis) => {
     const low = range.low[axis];
     const high = range.high[axis];
-    if (low === 0 && high === 0) return;
+    // The corners live in world space; the start and size are indices, which
+    // an oriented moving image reaches through its direction. The two
+    // coincide unless a caller passes the index mapping separately.
+    const indexLow = (indexRange ?? range).low[axis];
+    const indexHigh = (indexRange ?? range).high[axis];
+    if (low === 0 && high === 0 && indexLow === 0 && indexHigh === 0) return;
     const scale = moving.scale[dim];
-    const first = Math.floor(Math.min(low / scale, high / scale));
-    const last = Math.ceil(Math.max(low / scale, high / scale));
+    const first = Math.floor(Math.min(indexLow / scale, indexHigh / scale));
+    const last = Math.ceil(Math.max(indexLow / scale, indexHigh / scale));
     startIndex[dim] += first;
     size[dim] += last - first;
     // The reported corners hold a first and a last index position, which swap

--- a/ts/src/io/resample_bounding_box-shared.ts
+++ b/ts/src/io/resample_bounding_box-shared.ts
@@ -386,6 +386,15 @@ function boxInsideFieldDomain(
   dimension: number,
   box: Interval,
 ): boolean {
+  // A BSpline never answers true: its control lattice reaches spline-order
+  // points beyond its domain of support, so lying inside the lattice proves
+  // nothing about staying on the domain.
+  if (
+    String(entry.transformType.transformParameterization) !==
+      "DisplacementField"
+  ) {
+    return false;
+  }
   const fixed = entry.fixedParameters as ArrayLike<number> | null | undefined;
   if (!fixed || fixed.length !== 3 * dimension + dimension * dimension) {
     return false;

--- a/ts/src/utils/itk_transform_to_ngff_transform.ts
+++ b/ts/src/utils/itk_transform_to_ngff_transform.ts
@@ -425,3 +425,8 @@ function simplifyTransform(
   }
   return undefined;
 }
+
+// The linear decoder, for callers that bound a transform list rather than
+// convert it: the fold in resample_bounding_box-shared.ts carries a
+// displacement range through the matrices of the stages applied after it.
+export { decode as decodeMatrixOffset };

--- a/ts/test/resample_bounding_box_test.ts
+++ b/ts/test/resample_bounding_box_test.ts
@@ -1447,3 +1447,122 @@ Deno.test("an oriented field is refused by the bounding box", async () => {
     "anatomical orientation",
   );
 });
+
+function displacementFieldEntry(
+  vectors: Float64Array,
+  size: number[],
+  spacing: number[],
+  // deno-lint-ignore no-explicit-any
+): any {
+  const dimension = size.length;
+  return {
+    transformType: {
+      transformParameterization: "DisplacementField",
+      parametersValueType: "float64",
+      inputDimension: dimension,
+      outputDimension: dimension,
+    },
+    name: "DisplacementFieldTransform",
+    inputSpaceName: "",
+    outputSpaceName: "",
+    numberOfFixedParameters: 3 * dimension + dimension * dimension,
+    numberOfParameters: vectors.length,
+    fixedParameters: new Float64Array([
+      ...size,
+      ...size.map(() => 0),
+      ...spacing,
+      ...Array.from(
+        { length: dimension * dimension },
+        (_, index) => index % (dimension + 1) === 0 ? 1 : 0,
+      ),
+    ]),
+    parameters: vectors,
+    metadata: new Map(),
+  };
+}
+
+Deno.test("the stage interval reads the layouts itk writes", async () => {
+  // A field interleaves components per point; a B-spline blocks them per
+  // component. Misreading the layout would produce plausible wrong bounds.
+  const { resampleBoundingBox } = await import(
+    "../src/io/resample_bounding_box.ts"
+  );
+  const vectors = new Float64Array(4 * 3 * 2);
+  vectors[(1 * 4 + 2) * 2] = 7.0;
+  vectors[(1 * 4 + 2) * 2 + 1] = -9.0;
+  const warp = displacementFieldEntry(vectors, [4, 3], [8, 8]);
+  const fixed = await geometryImage(
+    ["y", "x"],
+    { y: 4, x: 4 },
+    { y: 1, x: 1 },
+    {
+      y: 0,
+      x: 0,
+    },
+  );
+  const moving = await geometryImage(["y", "x"], { y: 64, x: 64 }, {
+    y: 1,
+    x: 1,
+  }, { y: 0, x: 0 });
+
+  const region = await resampleBoundingBox([warp], fixed, moving, {
+    padding: 0,
+  });
+
+  // The x range is [0, 7] and the y range [-9, 0], zero joined since the
+  // 4x4 grid leaves nothing to check against the field's own 32x24 reach:
+  // the grid is inside, so the values' range stands alone.
+  assertEquals(region.startIndex, { y: -9, x: 0 });
+  assertEquals(region.size, { y: 13, x: 11 });
+});
+
+Deno.test("an interior bump in an itk field widens the region", async () => {
+  const { resampleBoundingBox } = await import(
+    "../src/io/resample_bounding_box.ts"
+  );
+  const extent = 64;
+  const vectors = new Float64Array(extent * extent * 2);
+  const reach = { y: [0, 0], x: [0, 0] };
+  for (let y = 0; y < extent; y++) {
+    for (let x = 0; x < extent; x++) {
+      const distance = Math.hypot(y - extent / 2, x - extent / 2);
+      const profile = distance < 20
+        ? 0.5 * (1 + Math.cos(Math.PI * distance / 20))
+        : 0;
+      const index = (y * extent + x) * 2;
+      vectors[index] = -60 * profile;
+      vectors[index + 1] = 60 * profile;
+      reach.y = [
+        Math.min(reach.y[0], y + 60 * profile),
+        Math.max(reach.y[1], y + 60 * profile),
+      ];
+      reach.x = [
+        Math.min(reach.x[0], x - 60 * profile),
+        Math.max(reach.x[1], x - 60 * profile),
+      ];
+    }
+  }
+  const warp = displacementFieldEntry(vectors, [extent, extent], [1, 1]);
+  const fixed = await geometryImage(
+    ["y", "x"],
+    { y: extent, x: extent },
+    { y: 1, x: 1 },
+    { y: 0, x: 0 },
+  );
+  const moving = await geometryImage(["y", "x"], { y: 256, x: 256 }, {
+    y: 1,
+    x: 1,
+  }, { y: 0, x: 0 });
+
+  const region = await resampleBoundingBox([warp], fixed, moving, {
+    padding: 1,
+  });
+
+  for (const dim of ["y", "x"] as const) {
+    assertEquals(region.startIndex[dim] <= reach[dim][0], true);
+    assertEquals(
+      region.startIndex[dim] + region.size[dim] >= reach[dim][1],
+      true,
+    );
+  }
+});


### PR DESCRIPTION
Closes #696.

`resample_bounding_box` measures an ITK transform by walking the boundary of the transformed grid. That reports a linear map exactly and says nothing about what a displacement does strictly inside: a `DisplacementFieldTransform` whose field is zero on the boundary voxels and 60 pixels in the middle came back with the identity's region, and `resample` returned the default value for 64 of 4096 pixels, by up to 93.

The same interval that #695 reads off an RFC-5 field applies here, from data already in hand. A `DisplacementField`'s parameters are the field, interleaved per point; a `BSpline`'s are its coefficients, blocked per component, and the cubic basis is non-negative and sums to one, so either stage's displacement lies between its smallest and largest values. Both layouts are pinned against ITK itself: one distinctive value planted per component has to come back on its own component.

The walk then measures the list with those stages replaced by the identity, and the range they can add widens the result. In a composite the range is carried through the stages applied after its own: through the signs of a decodable matrix, or, for the orthonormal rotation family, into the ball its Euclidean reach bounds. A composition this cannot fold keeps the walk it has today, as do the other non-linear parameterizations, the velocity fields among them; the docstring now says which is which.

Zero joins the range unless a lone field's own lattice provably contains the grid, since ITK displaces a point beyond a stage's domain by nothing. That containment is what keeps a constant field an exact shift: the pre-existing tests pinning `corners_min == {y: 3, x: 5}` pass unchanged.

An oriented moving image grows through its direction: the corners are physical and widen by component, the start and size are indices and move through the direction's transpose, exact for the signed permutations RFC-4 orientations produce.

`resample` splits the list once before its block loop, so a field's parameters are scanned once and not per block; the graph's tasks keep the original list, only the regions walk the linear part.

Both ports. TypeScript's `resampleBoundingBox` had the same walk and gets the same split, fold and growth, with the layout and interior-bump tests mirrored.

The end-to-end pin is one output block over the whole grid against a single whole-image call: small blocks hide the miss by accident, their boundaries crossing the bump, which is also why the issue's 63-pixel measurement needed the block at stake. Sensitivity checked by neutralizing the split: the region and resample tests fail without it.

Python 1466 passed, TypeScript 717, prek and deno clean.

## Base

On `feat/py-stream-displacement-field` (#695), which carries the interval machinery this reuses. It targets that branch so the diff here is this change alone; when #695 merges this retargets to `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resampling bounds for nonlinear ITK transforms, including displacement-field and B-spline transforms.
  * More accurately accounts for interior transform effects and direction-aware image growth.
  * Improves whole-block resampling correctness for transformed images.

* **New Features**
  * Added support for decoding ITK transform matrices and offsets for advanced processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->