### PR TITLE
fix(py): carry upstream's re-synced RFC-4 schema descriptions

### DIFF
--- a/py/ngff_zarr/spec/rfc/4/orientation.schema.json
+++ b/py/ngff_zarr/spec/rfc/4/orientation.schema.json
@@ -54,7 +54,7 @@
             "description": "",
             "properties": {
                 "axes": {
-                    "description": "A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. Furthermore, if the attribute orientation is defined for one axis of type space, it  MUST be defined for all the axes of type space. In this case, the type of each orientation MUST be the same and the value MUST be unique.\n",
+                    "description": "A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. The orientation attribute is OPTIONAL: it MAY be defined on any subset of the axes of type space, and it MUST NOT be defined on axes of any other type. Where it is defined, the type of each orientation MUST be one of the types defined by this specification, currently only \"anatomical\", and two axes MUST NOT describe the same anatomical axis: a set of axes MUST only have one of the set { \"left-to-right\", \"right-to-left\" } or { \"anterior-to-posterior\", \"posterior-to-anterior\" } or the remaining values.\n",
                     "items": {
                         "anyOf": [
                             {
@@ -146,7 +146,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The direction of an axis of type space.",
+                    "description": "The direction of an axis of type space. This attribute is OPTIONAL. An axis with no orientation and an axis whose orientation is null are equivalent: in both cases the orientation of that axis is undefined, and neither implies a default value. Writers SHOULD omit the attribute rather than serialize a null value.\n",
                     "type": "string"
                 },
                 "type": {
@@ -155,7 +155,7 @@
                 },
                 "unit": {
                     "$ref": "#/$defs/SpaceUnit",
-                    "description": "Physical unit for spatial measurement along the axis, selected from a standardized list of distance units  (e.g., micrometer, nanometer).\n"
+                    "description": "Physical unit for spatial measurement along the axis, selected from a standardized list of distance units (e.g., micrometer, nanometer).\n"
                 }
             },
             "required": [


### PR DESCRIPTION
Closes #613.

The upstream half of the issue is already done: ome/ngff ede0acc, "Re-sync the axes schema description with the current text", rewrote the stale sentences, and ome/ngff#595 is separately restoring the vocabulary enforcement the generation lost.

What remained was ours. The bundled `spec/rfc/4/orientation.schema.json`, which `rfc4_validation` loads, still said orientation "MUST be defined for all the axes of type space" and that "the type of each orientation MUST be the same". This copies upstream `main`'s file byte for byte.

The diff is three description strings and nothing else, so no document changes validity; the descriptions surface in validation error output. Checked by loading the schema through `load_rfc4_orientation_schema` and by the rfc4/orientation test selection, 108 passed.

When ome/ngff#595 merges upstream, one more sync brings the `const`/`$ref` enforcement back into the generated schema; the package's own vocabulary checks already enforce it in code either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified schema guidance for axis and spatial orientation definitions.
  * Made individual axis orientations optional, including support for omitted or null values.
  * Restricted orientations to valid, non-duplicated anatomical directions.
  * Corrected spacing in the spatial unit description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->