### PR TITLE
Declare a field image as an RFC-5 field transform

### DIFF
--- a/docs/rfc5.md
+++ b/docs/rfc5.md
@@ -128,7 +128,8 @@ vector-component axis, in the channel position, carries `type="displacement"`
 (or `type="coordinate"`) instead of `type="channel"`. Like a channel/component
 axis it is `discrete` — it indexes vector components rather than a continuous
 coordinate. Set the type with the `axes_types` argument of `NgffImage`, mapping
-a dimension name to its axis type:
+a dimension name to its axis type. `AxisType` names the types the specification
+defines; RFC-3 permits any string, so a plain one is accepted just as well:
 
 ```python
 import dask.array as da
@@ -143,7 +144,7 @@ field = nz.NgffImage(
     dims=("c", "y", "x"),
     scale={"c": 1.0, "y": 1.0, "x": 1.0},
     translation={"c": 0.0, "y": 0.0, "x": 0.0},
-    axes_types={"c": "displacement"},
+    axes_types={"c": nz.AxisType.Displacement},
 )
 
 multiscales = nz.to_multiscales(field, scale_factors=[])
@@ -151,8 +152,12 @@ nz.to_ome_zarr("displacement.ome.zarr", multiscales, version="0.6")
 ```
 
 The axis type round-trips through reading and writing. It can also be set after
-the fact by editing the metadata directly, for example
-`multiscales.metadata.intrinsic_coordinate_system.axes[0].type = "displacement"`.
+the fact by editing the metadata directly:
+
+```python
+system = multiscales.metadata.intrinsic_coordinate_system
+system.axes[0].type = nz.AxisType.Displacement
+```
 
 ## A standalone field store, written region by region
 
@@ -172,7 +177,7 @@ field = nz.to_ngff_image(
     scale={"c": 1.0, "z": 2.0, "y": 1.0, "x": 1.0},
     translation={"c": 0.0, "z": 0.0, "y": 0.0, "x": 0.0},
 )
-field.axes_types = {"c": "displacement"}
+field.axes_types = {"c": nz.AxisType.Displacement}
 multiscales = nz.to_multiscales(field, scale_factors=[])
 multiscales = nz.declare_field_transform(multiscales)
 
@@ -227,7 +232,7 @@ field = nz.NgffImage(
     dims=("c", "y", "x"),
     scale={"c": 1.0, "y": 1.0, "x": 1.0},
     translation={"c": 0.0, "y": 0.0, "x": 0.0},
-    axes_types={"c": "displacement"},
+    axes_types={"c": nz.AxisType.Displacement},
 )
 field_multiscales = nz.to_multiscales(field, scale_factors=[])
 
@@ -258,12 +263,16 @@ assert transform.path == field_path
 
 field = nz.from_ome_zarr(f"{store}/{transform.path}")
 axes = field.metadata.intrinsic_coordinate_system.axes
-assert [a.type for a in axes] == ["displacement", "space", "space"]
+assert [a.type for a in axes] == [
+    nz.AxisType.Displacement,
+    nz.AxisType.Space,
+    nz.AxisType.Space,
+]
 ```
 
-Use `Coordinates` instead of `Displacements` (and `axes_types={"c":
-"coordinate"}` on the field) for an absolute coordinate field; the store layout
-is identical.
+Use `Coordinates` instead of `Displacements` (and
+`axes_types={"c": nz.AxisType.Coordinate}` on the field) for an absolute
+coordinate field; the store layout is identical.
 
 ### Interoperating with ITK
 

--- a/docs/rfc5.md
+++ b/docs/rfc5.md
@@ -154,6 +154,45 @@ The axis type round-trips through reading and writing. It can also be set after
 the fact by editing the metadata directly, for example
 `multiscales.metadata.intrinsic_coordinate_system.axes[0].type = "displacement"`.
 
+## A standalone field store, written region by region
+
+A registration's artifact is often the field itself. `declare_field_transform`
+declares it on the field's own multiscales -- a spatial coordinate system
+derived from its axes, mapped onto itself -- and the declared store can then be
+created with `metadata_only=True` and filled through `open_array`, so a field
+larger than memory is never assembled:
+
+```python
+import dask.array as da
+import ngff_zarr as nz
+
+field = nz.to_ngff_image(
+    da.zeros((3, 512, 512, 512), dtype="float32", chunks=(3, 64, 512, 512)),
+    dims=["c", "z", "y", "x"],
+    scale={"c": 1.0, "z": 2.0, "y": 1.0, "x": 1.0},
+    translation={"c": 0.0, "z": 0.0, "y": 0.0, "x": 0.0},
+)
+field.axes_types = {"c": "displacement"}
+multiscales = nz.to_multiscales(field, scale_factors=[])
+multiscales = nz.declare_field_transform(multiscales)
+
+store = "field.ome.zarr"
+nz.to_ome_zarr(store, multiscales, version="0.6", metadata_only=True)
+array = nz.open_array(store, multiscales.metadata.datasets[0].path)
+for start in range(0, 512, 64):
+    # Whatever produces the field: a registration, a simulation, a read.
+    block = my_solver.displacements(z_start=start, rows=64)
+    array[:, start : start + 64] = block
+```
+
+The component order is the specification's: component *i* displaces the *i*-th
+spatial axis (`z`, `y`, `x` here). A producer holding ITK-ordered vectors
+(`x`, `y`, `z` components) reverses its component axis before assigning.
+
+The declaration requires OME-Zarr 0.6: earlier versions cannot carry
+multiscale-level transformations, and `to_ome_zarr` refuses to write one there
+rather than dropping the declaration silently.
+
 ## Write an image and its transformation into one store
 
 A `displacements` or `coordinates` transform points at a field array by `path`.
@@ -170,12 +209,8 @@ discoverable under its `path`.
 import dask.array as da
 import numpy as np
 import ngff_zarr as nz
-from ngff_zarr.v06.zarr_metadata import (
-    Axis,
-    CoordinateSystem,
-    CoordinateSystemIdentifier,
-    Displacements,
-)
+from ngff_zarr import CoordinateSystem
+from ngff_zarr.v06.zarr_metadata import Axis
 
 store = "warped.ome.zarr"
 field_path = "displacement_field"
@@ -201,14 +236,13 @@ output_cs = CoordinateSystem(
     name="output",
     axes=[Axis(name="y", type="space"), Axis(name="x", type="space")],
 )
-transform = Displacements(path=field_path, interpolation="linear")
-transform.input = CoordinateSystemIdentifier(
-    name=multiscales.metadata.intrinsic_coordinate_system.name
-)
-transform.output = CoordinateSystemIdentifier(name=output_cs.name)
-transform.name = "warp"
 multiscales.metadata.coordinateSystems.append(output_cs)
-multiscales.metadata.coordinateTransformations = [transform]
+multiscales = nz.declare_field_transform(
+    multiscales,
+    path=field_path,
+    input_system=multiscales.metadata.intrinsic_coordinate_system.name,
+    output_system=output_cs.name,
+)
 
 # Write the field subgroup first, then the image at the store root.
 nz.to_ome_zarr(f"{store}/{field_path}", field_multiscales, version="0.6")

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -234,6 +234,23 @@ transformations (the `Displacements` and `Coordinates` types) that reference suc
 a field from a registered image. Like the other v0.6 transforms, they round-trip
 through reading and writing.
 
+A typed component axis says what the channels are; it does not say between which
+coordinate systems the field maps, so nothing can apply it. `declareFieldTransform`
+adds that entry, validated:
+
+```typescript
+import { declareFieldTransform } from "@fideus-labs/ngff-zarr";
+
+// The standalone store -- the artifact a registration emits: the field maps a
+// spatial coordinate system onto itself through its own level-0 array.
+const declared = declareFieldTransform(multiscales);
+await toNgffZarr("displacement.ome.zarr", declared, { version: "0.6" });
+```
+
+For a field written beside the image it displaces, declare the entry on the
+image's multiscales instead, with `path` naming the field's array and
+`inputSystem`/`outputSystem` referencing the image's own coordinate systems.
+
 See [RFC-5: Coordinate Systems and Transformations](./rfc5.md) for the full
 transformation model, including how to write an image and its transformation
 (an affine, or a displacement/coordinate field) into a single store.

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -18,6 +18,7 @@ from .compute_omero import (
     compute_omero_from_ngff_image,
 )
 from .config import config
+from .declare_field_transform import declare_field_transform
 from .detect_cli_io_backend import ConversionBackend, detect_cli_io_backend
 from .displacement_field_transform import (
     itk_displacement_field_to_ngff_transform,
@@ -125,6 +126,12 @@ from .v04.zarr_metadata import (
     Well,
     WellImage,
 )
+from .v06.zarr_metadata import (
+    Coordinates,
+    CoordinateSystem,
+    CoordinateSystemIdentifier,
+    Displacements,
+)
 from .validate import validate
 
 __all__ = [
@@ -151,6 +158,11 @@ __all__ = [
     "itk_transform_to_ngff_transform",
     "itk_displacement_field_to_ngff_transform",
     "ngff_displacement_field_to_itk_transform",
+    "declare_field_transform",
+    "CoordinateSystem",
+    "CoordinateSystemIdentifier",
+    "Coordinates",
+    "Displacements",
     # Out-of-core resampling
     "resample",
     "resample_bounding_box",

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -10,6 +10,7 @@ from ._supported_versions import (
     NgffVersion,
 )
 from ._zarrista_utils import open_array
+from .axis_type import AxisType
 from .cli_input_to_ngff_image import cli_input_to_ngff_image
 from .codecs import codec_from_name, get_available_codecs
 from .compute_omero import (
@@ -18,7 +19,7 @@ from .compute_omero import (
     compute_omero_from_ngff_image,
 )
 from .config import config
-from .declare_field_transform import declare_field_transform
+from .declare_field_transform import FieldTransformType, declare_field_transform
 from .detect_cli_io_backend import ConversionBackend, detect_cli_io_backend
 from .displacement_field_transform import (
     itk_displacement_field_to_ngff_transform,
@@ -158,6 +159,8 @@ __all__ = [
     "itk_transform_to_ngff_transform",
     "itk_displacement_field_to_ngff_transform",
     "ngff_displacement_field_to_itk_transform",
+    "AxisType",
+    "FieldTransformType",
     "declare_field_transform",
     "CoordinateSystem",
     "CoordinateSystemIdentifier",

--- a/py/ngff_zarr/axis_type.py
+++ b/py/ngff_zarr/axis_type.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""The axis types the specification names."""
+
+from enum import StrEnum
+
+
+class AxisType(StrEnum):
+    """An axis type the specification names.
+
+    RFC-3 (OME-Zarr 0.9.dev1) lets an axis carry any string, so this is the
+    named set rather than the permitted one: an API that takes an axis type
+    is annotated ``AxisType | str`` and accepts both. The members are the
+    values themselves, so ``AxisType.Space == "space"``.
+
+    ``Displacement`` and ``Coordinate`` arrive with RFC-5 (OME-Zarr 0.6) and
+    type the component axis of a field; the other three are in the format
+    from 0.4 on. Mirrors the TypeScript port's ``AxisType``.
+    """
+
+    Space = "space"
+    Time = "time"
+    Channel = "channel"
+    Displacement = "displacement"
+    Coordinate = "coordinate"

--- a/py/ngff_zarr/declare_field_transform.py
+++ b/py/ngff_zarr/declare_field_transform.py
@@ -24,8 +24,9 @@ ITK transform from it with no other information.
 """
 
 from dataclasses import replace
-from typing import Literal
+from enum import StrEnum
 
+from .axis_type import AxisType
 from .multiscales import NgffMultiscales
 from .ngff_image import _DEFAULT_AXIS_TYPES
 from .v06.zarr_metadata import (
@@ -37,13 +38,31 @@ from .v06.zarr_metadata import (
     validate_transform,
 )
 
-_COMPONENT_TYPES = {"displacements": "displacement", "coordinates": "coordinate"}
+
+class FieldTransformType(StrEnum):
+    """Which RFC-5 field transformation a field image declares.
+
+    ``Displacements`` holds offsets from each point, ``Coordinates`` the
+    output positions themselves. The members are the values, so
+    ``FieldTransformType.Displacements == "displacements"`` and a plain
+    string still passes.
+    """
+
+    Displacements = "displacements"
+    Coordinates = "coordinates"
+
+
+#: The component axis type each transformation requires of the field.
+_COMPONENT_TYPES = {
+    FieldTransformType.Displacements: AxisType.Displacement,
+    FieldTransformType.Coordinates: AxisType.Coordinate,
+}
 
 
 def declare_field_transform(
     multiscales: NgffMultiscales,
     *,
-    transform_type: Literal["displacements", "coordinates"] = "displacements",
+    transform_type: FieldTransformType | str = FieldTransformType.Displacements,
     path: str | None = None,
     input_system: str | None = None,
     output_system: str | None = None,
@@ -62,31 +81,42 @@ def declare_field_transform(
         itself (standalone, the default), or the image the field displaces
         (with ``path`` naming the field's array).
     :type  multiscales: NgffMultiscales
-    :param transform_type: ``displacements`` (the field holds offsets) or
-        ``coordinates`` (the field holds absolute output positions).
-    :type  transform_type: str, optional
+
+    :param transform_type: Which field transformation the declaration is,
+        as a :class:`FieldTransformType` member or its string value:
+        ``Displacements`` (the field holds offsets from each point) or
+        ``Coordinates`` (it holds the output positions themselves). The
+        choice fixes the component axis type the field must carry.
+    :type  transform_type: FieldTransformType | str, optional
+
     :param path: The zarr path of the field's array. Default: the multiscales'
         own finest dataset -- the standalone store. When given, the field is
         elsewhere and its shape cannot be checked here; the references still
         are.
     :type  path: str, optional
+
     :param input_system: Name of the declared coordinate system the transform
         maps from. Pass both ``input_system`` and ``output_system``, or
         neither: with neither, a spatial system named ``coordinate_system`` is
         declared from the field's own axes and the transform maps it onto
         itself, which is the standalone total field.
     :type  input_system: str, optional
+
     :param output_system: Name of the declared coordinate system the transform
         maps onto. See ``input_system``.
     :type  output_system: str, optional
+
     :param coordinate_system: Name of the spatial coordinate system to declare
         when ``input_system``/``output_system`` are not given.
     :type  coordinate_system: str, optional
+
     :param interpolation: How a reader interpolates the field between grid
         points.
     :type  interpolation: str, optional
+
     :return: A new multiscales carrying the declaration.
     :rtype: NgffMultiscales
+
     :raises ValueError: If the field's axes are not one component axis of the
         type the transform calls for followed by the spatial axes, if it holds
         a number of components other than the number of spatial axes, if a
@@ -95,7 +125,7 @@ def declare_field_transform(
     """
     if transform_type not in _COMPONENT_TYPES:
         msg = (
-            f"transform_type must be one of {sorted(_COMPONENT_TYPES)}, "
+            f"transform_type must be one of {sorted(map(str, _COMPONENT_TYPES))}, "
             f"got '{transform_type}'"
         )
         raise ValueError(msg)
@@ -136,7 +166,11 @@ def declare_field_transform(
             )
             raise ValueError(msg)
 
-    entry_class = Displacements if transform_type == "displacements" else Coordinates
+    entry_class = (
+        Displacements
+        if transform_type == FieldTransformType.Displacements
+        else Coordinates
+    )
     entry = entry_class(
         input=CoordinateSystemIdentifier(name=input_system),
         output=CoordinateSystemIdentifier(name=output_system),

--- a/py/ngff_zarr/declare_field_transform.py
+++ b/py/ngff_zarr/declare_field_transform.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Declare a field image as an RFC-5 ``displacements`` or ``coordinates`` transform.
+
+A field store that only types its component axis is labelled, not applicable:
+a reader sees what the channels are, but no transformation says between which
+coordinate systems the field maps, so nothing can apply it. The declaration is
+the ``displacements`` (or ``coordinates``) entry on the multiscales'
+``coordinateTransformations``; building it by hand means reaching into the
+version metadata model and validating axis order, component count and system
+references oneself. This function is that composition, validated, in one call.
+
+Two layouts use it. A standalone field store -- the artifact a registration
+emits -- declares the transform on its own multiscales, mapping a spatial
+coordinate system onto itself through its own level-0 array; the default
+arguments produce exactly that. A field written beside the image it displaces
+declares the transform on the image's multiscales instead, with ``path``
+naming the field's array and ``input_system``/``output_system`` referencing
+the image's own coordinate systems.
+
+Declared and written at 0.6, the store is applicable by this package's own
+reader: :func:`~ngff_zarr.ngff_displacement_field_to_itk_transform` rebuilds an
+ITK transform from it with no other information.
+"""
+
+from dataclasses import replace
+from typing import Literal
+
+from .multiscales import NgffMultiscales
+from .ngff_image import _DEFAULT_AXIS_TYPES
+from .v06.zarr_metadata import (
+    Axis,
+    Coordinates,
+    CoordinateSystem,
+    CoordinateSystemIdentifier,
+    Displacements,
+    validate_transform,
+)
+
+_COMPONENT_TYPES = {"displacements": "displacement", "coordinates": "coordinate"}
+
+
+def declare_field_transform(
+    multiscales: NgffMultiscales,
+    *,
+    transform_type: Literal["displacements", "coordinates"] = "displacements",
+    path: str | None = None,
+    input_system: str | None = None,
+    output_system: str | None = None,
+    coordinate_system: str = "physical",
+    interpolation: str = "linear",
+) -> NgffMultiscales:
+    """Return ``multiscales`` with the field transform declared on it.
+
+    Functional and additive: the argument is not mutated, and the entry is
+    appended to any ``coordinateTransformations`` already declared. The result
+    must be written at OME-Zarr 0.6 or later; earlier versions cannot carry
+    multiscale-level transformations and :func:`~ngff_zarr.to_ome_zarr`
+    refuses them.
+
+    :param multiscales: The multiscales to declare the transform on: the field
+        itself (standalone, the default), or the image the field displaces
+        (with ``path`` naming the field's array).
+    :type  multiscales: NgffMultiscales
+    :param transform_type: ``displacements`` (the field holds offsets) or
+        ``coordinates`` (the field holds absolute output positions).
+    :type  transform_type: str, optional
+    :param path: The zarr path of the field's array. Default: the multiscales'
+        own finest dataset -- the standalone store. When given, the field is
+        elsewhere and its shape cannot be checked here; the references still
+        are.
+    :type  path: str, optional
+    :param input_system: Name of the declared coordinate system the transform
+        maps from. Pass both ``input_system`` and ``output_system``, or
+        neither: with neither, a spatial system named ``coordinate_system`` is
+        declared from the field's own axes and the transform maps it onto
+        itself, which is the standalone total field.
+    :type  input_system: str, optional
+    :param output_system: Name of the declared coordinate system the transform
+        maps onto. See ``input_system``.
+    :type  output_system: str, optional
+    :param coordinate_system: Name of the spatial coordinate system to declare
+        when ``input_system``/``output_system`` are not given.
+    :type  coordinate_system: str, optional
+    :param interpolation: How a reader interpolates the field between grid
+        points.
+    :type  interpolation: str, optional
+    :return: A new multiscales carrying the declaration.
+    :rtype: NgffMultiscales
+    :raises ValueError: If the field's axes are not one component axis of the
+        type the transform calls for followed by the spatial axes, if it holds
+        a number of components other than the number of spatial axes, if a
+        named system is not declared, or if the entry does not validate
+        against the systems it references.
+    """
+    if transform_type not in _COMPONENT_TYPES:
+        msg = (
+            f"transform_type must be one of {sorted(_COMPONENT_TYPES)}, "
+            f"got '{transform_type}'"
+        )
+        raise ValueError(msg)
+    metadata = multiscales.metadata
+    if (input_system is None) != (output_system is None):
+        msg = "pass both input_system and output_system, or neither"
+        raise ValueError(msg)
+    if path is None:
+        spatial = _check_field_image(multiscales, _COMPONENT_TYPES[transform_type])
+        path = metadata.datasets[0].path
+    elif input_system is None:
+        msg = (
+            "with path, pass input_system and output_system: the field is "
+            "elsewhere, so there are no axes here to derive a system from"
+        )
+        raise ValueError(msg)
+
+    systems = list(getattr(metadata, "coordinateSystems", None) or [])
+    declared = {system.name: len(system.axes) for system in systems}
+    if input_system is None:
+        units = multiscales.images[0].axes_units or {}
+        systems = _with_spatial_system(systems, coordinate_system, spatial, units)
+        input_system = output_system = coordinate_system
+    else:
+        for name in (input_system, output_system):
+            if name not in declared:
+                msg = (
+                    f"'{name}' names no declared coordinate system "
+                    f"(declared: {sorted(declared)})"
+                )
+                raise ValueError(msg)
+        if declared[input_system] != declared[output_system]:
+            msg = (
+                f"'{input_system}' names {declared[input_system]} axes and "
+                f"'{output_system}' names {declared[output_system]}; a field "
+                "transform maps a point onto one of the same dimension, which "
+                "is what the field holds per point"
+            )
+            raise ValueError(msg)
+
+    entry_class = Displacements if transform_type == "displacements" else Coordinates
+    entry = entry_class(
+        input=CoordinateSystemIdentifier(name=input_system),
+        output=CoordinateSystemIdentifier(name=output_system),
+        path=path,
+        interpolation=interpolation,
+    )
+    validate_transform(entry, systems)
+    metadata = replace(
+        metadata,
+        coordinateSystems=systems,
+        coordinateTransformations=[
+            *(metadata.coordinateTransformations or []),
+            entry,
+        ],
+    )
+    return replace(multiscales, metadata=metadata)
+
+
+def _check_field_image(multiscales: NgffMultiscales, component_type: str) -> list:
+    """The standalone checks -- the multiscales is the field, so its shape is
+    here to check: one component axis of the right type first, then the
+    spatial axes, one component per spatial axis. Returns the spatial dims."""
+    image = multiscales.images[0]
+    component_dims = [
+        dim
+        for dim, axis_type in (image.axes_types or {}).items()
+        if axis_type == component_type
+    ]
+    if len(component_dims) != 1:
+        msg = (
+            f"the field image must have exactly one axis of type "
+            f"'{component_type}' (axes_types on the NgffImage); got "
+            f"{component_dims or 'none'} on dims {tuple(image.dims)}"
+        )
+        raise ValueError(msg)
+    types = image.axes_types or {}
+    other = [
+        dim
+        for dim in image.dims
+        if dim != component_dims[0]
+        and types.get(dim, _DEFAULT_AXIS_TYPES.get(dim, "space")) != "space"
+    ]
+    if other:
+        msg = (
+            f"a field transform is defined on spatial axes only; dims "
+            f"{tuple(image.dims)} name {other}, which a coordinate system "
+            "cannot carry as space"
+        )
+        raise ValueError(msg)
+    if image.dims[0] != component_dims[0]:
+        msg = (
+            f"the field's dims are {tuple(image.dims)}; the component axis "
+            f"'{component_dims[0]}' must come first, then the spatial axes in "
+            "order"
+        )
+        raise ValueError(msg)
+    spatial = [dim for dim in image.dims if dim != component_dims[0]]
+    if image.data.shape[0] != len(spatial):
+        msg = (
+            f"the field holds {image.data.shape[0]} components per point over "
+            f"spatial axes {tuple(spatial)}, which name {len(spatial)} axes"
+        )
+        raise ValueError(msg)
+    return spatial
+
+
+def _with_spatial_system(systems: list, name: str, spatial: list, units) -> list:
+    """The systems with a spatial one named ``name``, declared from the field's
+    own axes if absent; an existing one must already carry those axes in order,
+    or the declaration would reference a system the field does not match."""
+    existing = next((system for system in systems if system.name == name), None)
+    if existing is not None:
+        if [axis.name for axis in existing.axes] != spatial:
+            msg = (
+                f"coordinate system '{name}' is already declared with axes "
+                f"{[axis.name for axis in existing.axes]}, but the field's "
+                f"spatial axes are {spatial}"
+            )
+            raise ValueError(msg)
+        other = [
+            f"{axis.name} ({axis.type})"
+            for axis in existing.axes
+            if axis.type != "space"
+        ]
+        if other:
+            msg = (
+                f"coordinate system '{name}' carries {other} where a field "
+                "transform needs space; it is defined on spatial axes only"
+            )
+            raise ValueError(msg)
+        return systems
+    axes = [Axis(name=dim, type="space", unit=units.get(dim)) for dim in spatial]
+    return [*systems, CoordinateSystem(name=name, axes=axes)]

--- a/py/ngff_zarr/ngff_image.py
+++ b/py/ngff_zarr/ngff_image.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 
 from dask.array.core import Array as DaskArray
 
+from .axis_type import AxisType
 from .rfc4 import AnatomicalOrientation
 from .v04.zarr_metadata import AxisUnit
 
@@ -20,7 +21,7 @@ class NgffImage:
     name: str = "image"
     axes_units: Mapping[str, AxisUnit] | None = None
     axes_orientations: Mapping[str, AnatomicalOrientation] | None = None
-    axes_types: Mapping[str, str] | None = None
+    axes_types: Mapping[str, AxisType | str] | None = None
     channel_names: list[str] | None = None
     channel_colors: list[str] | None = None
     computed_callbacks: list[ComputedCallback] = field(default_factory=list)
@@ -28,15 +29,15 @@ class NgffImage:
 
 #: The axis type to_multiscales gives a dimension when the image carries none.
 _DEFAULT_AXIS_TYPES = {
-    "x": "space",
-    "y": "space",
-    "z": "space",
-    "c": "channel",
-    "t": "time",
+    "x": AxisType.Space,
+    "y": AxisType.Space,
+    "z": AxisType.Space,
+    "c": AxisType.Channel,
+    "t": AxisType.Time,
 }
 
 
-def non_default_axes_types(axes) -> dict[str, str] | None:
+def non_default_axes_types(axes) -> dict[str, AxisType | str] | None:
     """Axis types that a multiscales rebuilt from the dims alone would lose.
 
     Readers pass these on as ``NgffImage.axes_types`` so a displacement or

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -378,8 +378,15 @@ def _gate_spans(
         _gate_spans(member, f"{where}.transformations[{position}]", systems, spans)
 
 
-def _gate_top_level_transforms(metadata, version: str) -> None:
-    """Refuse a multiscale-level transform the 0.6 schema cannot express.
+def _gate_top_level_transforms(source, metadata, version: str) -> None:
+    """Refuse a multiscale-level transform the target version would drop or reject.
+
+    ``to_version`` carries over the transforms the target model can express --
+    0.4 keeps its own scale/translation form -- and drops the rest, an RFC-5
+    entry written at 0.4 among them. Dropping is silent: the store is written,
+    the entry is gone, and the only witness is a reader finding ``None`` where
+    a transform was declared. What the conversion kept is therefore compared
+    with what was declared, and a loss is refused rather than written.
 
     From 0.6 a transform on the multiscales entry maps between two named
     coordinate systems, and the schema requires both ``input`` and ``output``
@@ -392,9 +399,16 @@ def _gate_top_level_transforms(metadata, version: str) -> None:
     Each transform then runs the reader's ``validate_transform`` against the
     systems it names, so a store this writes is one it can read back.
     """
-    if version not in ("0.6", NgffVersion.V09dev1.value):
-        return
-    if not metadata.coordinateTransformations:
+    declared = getattr(source, "coordinateTransformations", None) or []
+    transforms = getattr(metadata, "coordinateTransformations", None) or []
+    if len(transforms) < len(declared):
+        raise ValueError(
+            f"{len(declared) - len(transforms)} of the multiscales metadata's "
+            f"{len(declared)} coordinateTransformations have no form in "
+            f"OME-Zarr {version}, which would drop them silently. Write with "
+            "version='0.6', or remove them."
+        )
+    if not transforms or version not in ("0.6", NgffVersion.V09dev1.value):
         return
     from .v06.zarr_metadata import validate_transform
 
@@ -1750,7 +1764,7 @@ def _to_ngff_zarr_impl(
         _guard_overwrite_of_source_store(multiscales, store_path)
     root_attributes = _check_root_attributes(multiscales.root_attributes)
     metadata, dimension_names, _ = _prepare_metadata(multiscales, version)
-    _gate_top_level_transforms(metadata, version)
+    _gate_top_level_transforms(multiscales.metadata, metadata, version)
     _gate_transform_arity(metadata)
     if start_level:
         _guard_rewrite_of_read_levels(

--- a/py/test/test_declare_field_transform.py
+++ b/py/test/test_declare_field_transform.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+from dataclasses import asdict
+
+import numpy as np
+import pytest
+from ngff_zarr import (
+    declare_field_transform,
+    from_ome_zarr,
+    ngff_displacement_field_to_itk_transform,
+    to_multiscales,
+    to_ngff_image,
+    to_ome_zarr,
+)
+
+
+def _field_multiscales(seed=0, shape=(3, 4, 5, 6)):
+    """A standalone displacement-field multiscales: component axis typed, spec
+    component order (the i-th component displaces the i-th spatial axis)."""
+    rng = np.random.default_rng(seed)
+    data = rng.normal(scale=3.0, size=shape).astype(np.float64)
+    image = to_ngff_image(
+        data,
+        dims=["c", "z", "y", "x"],
+        scale={"c": 1.0, "z": 2.0, "y": 1.5, "x": 1.0},
+        translation={"c": 0.0, "z": 5.0, "y": -3.0, "x": 7.0},
+    )
+    image.axes_types = {"c": "displacement"}
+    return to_multiscales(image, scale_factors=[], cache=False)
+
+
+def test_a_standalone_declaration_round_trips(tmp_path):
+    # The default arguments are the standalone store: the transform on the
+    # field's own multiscales, a spatial system declared from its own axes,
+    # mapped onto itself. Written at 0.6 and read back, the declaration is
+    # what a reader finds -- not an out-of-band convention.
+    multiscales = declare_field_transform(_field_multiscales())
+    store = tmp_path / "field.ome.zarr"
+    to_ome_zarr(store, multiscales, version="0.6")
+
+    back = from_ome_zarr(store)
+    entries = back.metadata.coordinateTransformations or []
+    assert [entry.type for entry in entries] == ["displacements"]
+    assert entries[0].input.name == "physical"
+    assert entries[0].output.name == "physical"
+    assert entries[0].path == back.metadata.datasets[0].path
+    assert "physical" in {system.name for system in back.metadata.coordinateSystems}
+    assert back.images[0].axes_types == {"c": "displacement"}
+
+
+def test_the_declared_store_rebuilds_the_itk_field_it_encodes(tmp_path):
+    # The point of declaring: this package's own reader can APPLY the store
+    # with no other information. The rebuilt native ITK transform must move
+    # points exactly as the field's values say -- component order and grid
+    # geometry both, because either mistake still yields a plausible field.
+    itk = pytest.importorskip("itk")
+
+    multiscales = declare_field_transform(_field_multiscales())
+    store = tmp_path / "field.ome.zarr"
+    to_ome_zarr(store, multiscales, version="0.6")
+
+    back = from_ome_zarr(store)
+    wasm = ngff_displacement_field_to_itk_transform(
+        back.metadata.coordinateTransformations[0], back, ["z", "y", "x"]
+    )
+    rebuilt = itk.transform_from_dict(asdict(wasm[0]))
+    if hasattr(rebuilt, "GetNthTransform"):
+        rebuilt = rebuilt.GetNthTransform(0)
+
+    field = np.asarray(multiscales.images[0].data)
+    # The grid: index (k, j, i) sits at origin + index * spacing, and the
+    # field's component m displaces spatial axis m (z, y, x). ITK speaks
+    # (x, y, z), so the expectation reverses -- independently of the module.
+    spacing = np.array([2.0, 1.5, 1.0])
+    origin = np.array([5.0, -3.0, 7.0])
+    for index in ((0, 0, 0), (1, 2, 3), (3, 4, 5)):
+        point_zyx = origin + np.array(index) * spacing
+        displaced_zyx = point_zyx + field[(slice(None), *index)]
+        point_xyz = [float(value) for value in point_zyx[::-1]]
+        expected_xyz = displaced_zyx[::-1]
+        moved = np.array(rebuilt.TransformPoint(point_xyz))
+        np.testing.assert_allclose(moved, expected_xyz, rtol=0, atol=1e-12)
+
+
+def test_declaring_appends_to_existing_transformations(tmp_path):
+    multiscales = declare_field_transform(_field_multiscales())
+    again = declare_field_transform(multiscales, interpolation="nearest")
+    entries = again.metadata.coordinateTransformations
+    assert [entry.interpolation for entry in entries] == ["linear", "nearest"]
+    # And the spatial system was declared once, not once per call.
+    names = [system.name for system in again.metadata.coordinateSystems]
+    assert names.count("physical") == 1
+
+
+def test_the_argument_is_not_mutated():
+    multiscales = _field_multiscales()
+    declare_field_transform(multiscales)
+    assert not multiscales.metadata.coordinateTransformations
+
+
+def test_a_named_system_that_is_not_declared_is_refused():
+    with pytest.raises(ValueError, match="names no declared coordinate system"):
+        declare_field_transform(
+            _field_multiscales(), input_system="fixed", output_system="moving"
+        )
+
+
+def test_a_path_without_named_systems_is_refused():
+    # With path the field is elsewhere: there are no axes here to derive a
+    # system from, and guessing one from the image's own axes would declare a
+    # transform over the wrong space.
+    with pytest.raises(ValueError, match="pass input_system and output_system"):
+        declare_field_transform(_field_multiscales(), path="displacements/field")
+
+
+def test_one_sided_system_naming_is_refused():
+    with pytest.raises(ValueError, match="both input_system and output_system"):
+        declare_field_transform(_field_multiscales(), input_system="fixed")
+
+
+def test_a_field_without_a_typed_component_axis_is_refused():
+    multiscales = _field_multiscales()
+    multiscales.images[0].axes_types = None
+    with pytest.raises(ValueError, match="exactly one axis of type"):
+        declare_field_transform(multiscales)
+
+
+def test_a_non_spatial_axis_is_refused():
+    # A field transform is spatial: relabelling a time axis "space" to fit it
+    # into a coordinate system declares a transform the package's own
+    # converter then refuses to apply.
+    multiscales = _field_multiscales(shape=(3, 2, 5, 6))
+    image = multiscales.images[0]
+    image.dims = ("c", "t", "y", "x")
+    image.scale = {"c": 1.0, "t": 1.0, "y": 1.0, "x": 1.0}
+    image.translation = {"c": 0.0, "t": 0.0, "y": 0.0, "x": 0.0}
+    with pytest.raises(ValueError, match="spatial axes only"):
+        declare_field_transform(multiscales)
+
+
+def test_a_component_count_that_misses_an_axis_is_refused():
+    multiscales = _field_multiscales(shape=(2, 4, 5, 6))
+    with pytest.raises(ValueError, match="2 components per point"):
+        declare_field_transform(multiscales)
+
+
+def test_a_declaration_beside_the_image_references_its_systems():
+    # The entry lives on the IMAGE's multiscales and points at the field's
+    # array elsewhere in the store; the field's shape cannot be checked from
+    # here, the references can and are.
+    from ngff_zarr import CoordinateSystem
+    from ngff_zarr.v06.zarr_metadata import Axis
+
+    image = to_ngff_image(
+        np.zeros((4, 5, 6), dtype=np.float32),
+        dims=["z", "y", "x"],
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+    )
+    multiscales = to_multiscales(image, scale_factors=[], cache=False)
+    axes = [Axis(name=name, type="space", unit=None) for name in ("z", "y", "x")]
+    multiscales.metadata.coordinateSystems = [
+        *multiscales.metadata.coordinateSystems,
+        CoordinateSystem(name="fixed", axes=axes),
+        CoordinateSystem(name="moving", axes=axes),
+    ]
+
+    declared = declare_field_transform(
+        multiscales,
+        path="displacements/field",
+        input_system="fixed",
+        output_system="moving",
+    )
+    entry = declared.metadata.coordinateTransformations[-1]
+    assert entry.path == "displacements/field"
+    assert entry.input.name == "fixed"
+    assert entry.output.name == "moving"
+
+
+def test_a_declared_store_streams_region_by_region(tmp_path):
+    # The recipe the declaration exists for: a field too large to assemble is
+    # declared first, its arrays are created with metadata_only, and the
+    # regions land through open_array -- the store is identical to the one a
+    # whole-array write produces.
+    from ngff_zarr import open_array
+
+    multiscales = declare_field_transform(_field_multiscales(seed=7))
+    values = np.asarray(multiscales.images[0].data)
+
+    whole = tmp_path / "whole.ome.zarr"
+    to_ome_zarr(whole, multiscales, version="0.6")
+
+    streamed = tmp_path / "streamed.ome.zarr"
+    to_ome_zarr(streamed, multiscales, version="0.6", metadata_only=True)
+    array = open_array(streamed, multiscales.metadata.datasets[0].path)
+    for start in range(0, values.shape[1], 2):
+        array[:, start : start + 2] = values[:, start : start + 2]
+
+    for store in (whole, streamed):
+        back = from_ome_zarr(store)
+        assert [entry.type for entry in back.metadata.coordinateTransformations] == [
+            "displacements"
+        ]
+        np.testing.assert_array_equal(np.asarray(back.images[0].data), values)
+
+
+def test_a_declared_system_that_is_not_spatial_is_refused():
+    # The names line up, so the arity check passes; the types do not. A
+    # transform declared over that system is one this package's own converter
+    # then refuses to apply, which is the same hole the image's own axes are
+    # already checked for.
+    from ngff_zarr import CoordinateSystem
+    from ngff_zarr.v06.zarr_metadata import Axis
+
+    multiscales = _field_multiscales()
+    axes = [
+        Axis(name="z", type="time", unit=None),
+        Axis(name="y", type="space", unit=None),
+        Axis(name="x", type="space", unit=None),
+    ]
+    multiscales.metadata.coordinateSystems = [
+        *multiscales.metadata.coordinateSystems,
+        CoordinateSystem(name="physical", axes=axes),
+    ]
+
+    with pytest.raises(ValueError, match="spatial axes only"):
+        declare_field_transform(multiscales)
+
+
+def test_named_systems_of_different_dimension_are_refused():
+    # With path the field's shape is elsewhere and cannot be checked, but the
+    # two systems can be checked against each other: this package's own reader
+    # builds an ITK transform with one dimension for both ends, so a 2D input
+    # against a 3D output is a declaration nothing here can apply.
+    from ngff_zarr import CoordinateSystem
+    from ngff_zarr.v06.zarr_metadata import Axis
+
+    def system(name, dims):
+        return CoordinateSystem(
+            name=name, axes=[Axis(name=d, type="space", unit=None) for d in dims]
+        )
+
+    multiscales = _field_multiscales()
+    multiscales.metadata.coordinateSystems = [
+        *multiscales.metadata.coordinateSystems,
+        system("flat", ("y", "x")),
+        system("volume", ("z", "y", "x")),
+    ]
+
+    with pytest.raises(ValueError, match="same dimension"):
+        declare_field_transform(
+            multiscales,
+            path="displacements/field",
+            input_system="flat",
+            output_system="volume",
+        )

--- a/py/test/test_ngff_validation.py
+++ b/py/test/test_ngff_validation.py
@@ -254,6 +254,68 @@ def test_v06_write_refuses_a_top_level_transform_without_references(tmp_path):
     validate(zarr.open_group(str(store), mode="r").attrs.asdict(), version="0.6")
 
 
+def test_a_version_that_cannot_carry_top_level_transforms_refuses_them(tmp_path):
+    # ``to_version`` converts the model to the target version's shape, and a
+    # shape with no ``coordinateTransformations`` field dropped the transforms
+    # in that conversion: the store was written, the entry was gone, and the
+    # only witness was a reader finding None where a transform was declared.
+    # An RFC-5 entry cannot exist before 0.6, so the writer must say so
+    # rather than write a store that silently is not what was declared.
+    from ngff_zarr.v06.zarr_metadata import Axis as AxisV06
+    from ngff_zarr.v06.zarr_metadata import (
+        CoordinateSystem,
+        CoordinateSystemIdentifier,
+        Displacements,
+    )
+
+    array = np.random.random((3, 4, 8, 8)).astype("float32")
+    multiscales = to_multiscales(array, [])
+    physical = CoordinateSystem(
+        name="physical",
+        axes=[AxisV06(name=name, type="space", unit=None) for name in ("z", "y", "x")],
+    )
+    reference = CoordinateSystemIdentifier(name="physical")
+    multiscales.metadata.coordinateSystems = [
+        *multiscales.metadata.coordinateSystems,
+        physical,
+    ]
+    multiscales.metadata.coordinateTransformations = [
+        Displacements(
+            input=reference,
+            output=reference,
+            path=multiscales.metadata.datasets[0].path,
+            interpolation="linear",
+        )
+    ]
+
+    with pytest.raises(ValueError, match="would drop them silently"):
+        to_ome_zarr(tmp_path / "dropped.ome.zarr", multiscales, version="0.4")
+
+
+def test_the_04_legal_top_level_scale_is_written(tmp_path):
+    # OME-Zarr 0.4 allows a multiscale-level scale/translation applying to
+    # every resolution, and the writer serializes that form: the refusal is
+    # for the transforms a version has no shape for, not for these.
+    import dataclasses
+
+    from ngff_zarr.v04.zarr_metadata import Scale as ScaleV04
+
+    array = np.random.random((4, 8, 8)).astype("float32")
+    multiscales = to_multiscales(array, [])
+    metadata = multiscales.metadata.to_version("0.4")
+    metadata.coordinateTransformations = [ScaleV04(scale=[2.0, 2.0, 2.0])]
+
+    store = tmp_path / "kept.ome.zarr"
+    to_ome_zarr(
+        store, dataclasses.replace(multiscales, metadata=metadata), version="0.4"
+    )
+
+    written = zarr.open_group(str(store), mode="r").attrs.asdict()
+    assert written["multiscales"][0]["coordinateTransformations"] == [
+        {"scale": [2.0, 2.0, 2.0], "type": "scale"}
+    ]
+
+
 @requires_zarr_v3
 def test_read_warns_on_a_superseded_0_6_tag_and_validates_the_rest(tmp_path):
     # A store tagged with an earlier 0.6 pre-release differs from a valid store

--- a/ts/src/mod.ts
+++ b/ts/src/mod.ts
@@ -76,6 +76,10 @@ export {
 } from "./utils/itk_transform_to_ngff_transform.ts";
 export { ngffTransformToItkTransform } from "./utils/ngff_transform_to_itk_transform.ts";
 export {
+  declareFieldTransform,
+  type DeclareFieldTransformOptions,
+} from "./utils/declare_field_transform.ts";
+export {
   type FieldFrames,
   type ItkDisplacementFieldOptions,
   itkDisplacementFieldToNgffTransform,

--- a/ts/src/utils/declare_field_transform.ts
+++ b/ts/src/utils/declare_field_transform.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Declare a field image as an RFC-5 `displacements` or `coordinates`
+ * transform.
+ *
+ * A field store that only types its component axis is labelled, not
+ * applicable: a reader sees what the channels are, but no transformation says
+ * between which coordinate systems the field maps, so nothing can apply it.
+ * The declaration is the `displacements` (or `coordinates`) entry on the
+ * multiscales' `coordinateTransformations`; building it by hand means reaching
+ * into the version metadata model and validating axis order, component count
+ * and system references oneself. This function is that composition, validated,
+ * in one call.
+ *
+ * Two layouts use it. A standalone field store -- the artifact a registration
+ * emits -- declares the transform on its own multiscales, mapping a spatial
+ * coordinate system onto itself through its own level-0 array; the default
+ * arguments produce exactly that. A field written beside the image it
+ * displaces declares the transform on the image's multiscales instead, with
+ * `path` naming the field's array and `inputSystem`/`outputSystem`
+ * referencing the image's own coordinate systems.
+ *
+ * The port of `declare_field_transform` in the Python package.
+ */
+
+import { NgffMultiscales } from "../types/multiscales.ts";
+import type {
+  Axis,
+  Coordinates,
+  CoordinateSystem,
+  Displacements,
+} from "../types/zarr_metadata.ts";
+
+/** The axis type a transform of each kind calls for on the component axis. */
+const COMPONENT_TYPES = {
+  displacements: "displacement",
+  coordinates: "coordinate",
+} as const;
+
+/** The axis type `toMultiscales` gives a dimension that declares none. */
+const DEFAULT_AXIS_TYPES: Record<string, string> = {
+  x: "space",
+  y: "space",
+  z: "space",
+  c: "channel",
+  t: "time",
+};
+
+export interface DeclareFieldTransformOptions {
+  /** `displacements` (the field holds offsets) or `coordinates` (absolute output positions). */
+  transformType?: keyof typeof COMPONENT_TYPES;
+  /**
+   * The zarr path of the field's array. Default: the multiscales' own finest
+   * dataset -- the standalone store. When given, the field is elsewhere and
+   * its shape cannot be checked here; the references still are.
+   */
+  path?: string;
+  /**
+   * Name of the declared coordinate system the transform maps from. Pass both
+   * `inputSystem` and `outputSystem`, or neither: with neither, a spatial
+   * system named `coordinateSystem` is declared from the field's own axes and
+   * the transform maps it onto itself, which is the standalone total field.
+   */
+  inputSystem?: string;
+  /** Name of the declared coordinate system the transform maps onto. See `inputSystem`. */
+  outputSystem?: string;
+  /** Name of the spatial system to declare when the two above are not given. */
+  coordinateSystem?: string;
+  /** How a reader interpolates the field between grid points. */
+  interpolation?: string;
+}
+
+/**
+ * Return `multiscales` with the field transform declared on it.
+ *
+ * Functional and additive: the argument is not mutated, and the entry is
+ * appended to any `coordinateTransformations` already declared. The result
+ * must be written at OME-Zarr 0.6 or later; earlier versions cannot carry
+ * multiscale-level transformations.
+ *
+ * @throws If the field's axes are not one component axis of the type the
+ * transform calls for followed by the spatial axes, if it holds a number of
+ * components other than the number of spatial axes, or if a named system is
+ * not declared.
+ */
+export function declareFieldTransform(
+  multiscales: NgffMultiscales,
+  options: DeclareFieldTransformOptions = {},
+): NgffMultiscales {
+  const {
+    transformType = "displacements",
+    path,
+    inputSystem,
+    outputSystem,
+    coordinateSystem = "physical",
+    interpolation = "linear",
+  } = options;
+  // `in` reaches the prototype chain, so "toString" would pass and then read
+  // a function out of the table; a JS caller is not held to the type above.
+  if (
+    typeof transformType !== "string" ||
+    !Object.hasOwn(COMPONENT_TYPES, transformType)
+  ) {
+    throw new Error(
+      `transformType must be one of ${
+        Object.keys(COMPONENT_TYPES).join(", ")
+      }, got '${transformType}'`,
+    );
+  }
+  const metadata = multiscales.metadata;
+  let spatial: string[] = [];
+  let entryPath = path;
+  if (entryPath === undefined) {
+    spatial = checkFieldImage(multiscales, COMPONENT_TYPES[transformType]);
+    entryPath = metadata.datasets[0].path;
+  } else if (inputSystem === undefined) {
+    throw new Error(
+      "with path, pass inputSystem and outputSystem: the field is elsewhere, " +
+        "so there are no axes here to derive a system from",
+    );
+  }
+
+  let systems = [...(metadata.coordinateSystems ?? [])];
+  let input: string;
+  let output: string;
+  // Both or neither, as a narrowing rather than a guard on the side: the two
+  // names are what the entry references, and TypeScript is told so here.
+  if (inputSystem === undefined && outputSystem === undefined) {
+    systems = withSpatialSystem(
+      multiscales,
+      systems,
+      coordinateSystem,
+      spatial,
+    );
+    input = output = coordinateSystem;
+  } else if (inputSystem !== undefined && outputSystem !== undefined) {
+    const declared = new Map(
+      systems.map((system) => [system.name, system.axes.length]),
+    );
+    for (const name of [inputSystem, outputSystem]) {
+      if (!declared.has(name)) {
+        throw new Error(
+          `'${name}' names no declared coordinate system (declared: ${
+            [...declared.keys()].sort().join(", ")
+          })`,
+        );
+      }
+    }
+    if (declared.get(inputSystem) !== declared.get(outputSystem)) {
+      throw new Error(
+        `'${inputSystem}' names ${declared.get(inputSystem)} axes and ` +
+          `'${outputSystem}' names ${declared.get(outputSystem)}; a field ` +
+          `transform maps a point onto one of the same dimension, which is ` +
+          `what the field holds per point`,
+      );
+    }
+    input = inputSystem;
+    output = outputSystem;
+  } else {
+    throw new Error("pass both inputSystem and outputSystem, or neither");
+  }
+
+  const entry: Displacements | Coordinates = {
+    type: transformType,
+    path: entryPath,
+    interpolation,
+    input: { name: input },
+    output: { name: output },
+  };
+  return new NgffMultiscales({
+    images: multiscales.images,
+    metadata: {
+      ...metadata,
+      coordinateSystems: systems,
+      coordinateTransformations: [
+        ...(metadata.coordinateTransformations ?? []),
+        entry,
+      ],
+    },
+    scaleFactors: multiscales.scaleFactors,
+    method: multiscales.method,
+    chunks: multiscales.chunks,
+  });
+}
+
+/**
+ * The standalone checks -- the multiscales is the field, so its shape is here
+ * to check: one component axis of the right type first, then the spatial axes,
+ * one component per spatial axis. Returns the spatial dims.
+ */
+function checkFieldImage(
+  multiscales: NgffMultiscales,
+  componentType: string,
+): string[] {
+  const image = multiscales.images[0];
+  const types = image.axesTypes ?? {};
+  const componentDims = Object.entries(types)
+    .filter(([, axisType]) => axisType === componentType)
+    .map(([dim]) => dim);
+  if (componentDims.length !== 1) {
+    throw new Error(
+      `the field image must have exactly one axis of type '${componentType}' ` +
+        `(axesTypes on the NgffImage); got ${
+          componentDims.length ? componentDims.join(", ") : "none"
+        } on dims ${image.dims.join(", ")}`,
+    );
+  }
+  const component = componentDims[0];
+  const other = image.dims.filter((dim) =>
+    dim !== component &&
+    (types[dim] ?? DEFAULT_AXIS_TYPES[dim] ?? "space") !== "space"
+  );
+  if (other.length) {
+    throw new Error(
+      `a field transform is defined on spatial axes only; dims ${
+        image.dims.join(", ")
+      } name ${
+        other.join(", ")
+      }, which a coordinate system cannot carry as space`,
+    );
+  }
+  if (image.dims[0] !== component) {
+    throw new Error(
+      `the field's dims are ${
+        image.dims.join(", ")
+      }; the component axis '${component}' must come first, then the spatial ` +
+        "axes in order",
+    );
+  }
+  const spatial = image.dims.filter((dim) => dim !== component);
+  const components = image.data.shape[0];
+  if (components !== spatial.length) {
+    throw new Error(
+      `the field holds ${components} components per point over spatial axes ${
+        spatial.join(", ")
+      }, which name ${spatial.length} axes`,
+    );
+  }
+  return spatial;
+}
+
+/**
+ * The systems with a spatial one named `name`, declared from the field's own
+ * axes if absent; an existing one must already carry those axes in order, or
+ * the declaration would reference a system the field does not match.
+ */
+function withSpatialSystem(
+  multiscales: NgffMultiscales,
+  systems: CoordinateSystem[],
+  name: string,
+  spatial: string[],
+): CoordinateSystem[] {
+  const existing = systems.find((system) => system.name === name);
+  if (existing) {
+    const axes = existing.axes.map((axis) => axis.name);
+    if (
+      axes.length !== spatial.length || axes.some((a, i) => a !== spatial[i])
+    ) {
+      throw new Error(
+        `coordinate system '${name}' is already declared with axes ${
+          axes.join(", ")
+        }, but the field's spatial axes are ${spatial.join(", ")}`,
+      );
+    }
+    const other = existing.axes.filter((axis) => axis.type !== "space");
+    if (other.length > 0) {
+      throw new Error(
+        `coordinate system '${name}' carries ${
+          other.map((axis) => `${axis.name} (${axis.type})`).join(", ")
+        } where a field transform needs space; it is defined on spatial axes ` +
+          `only`,
+      );
+    }
+    return systems;
+  }
+  const units = multiscales.images[0].axesUnits ?? {};
+  const axes: Axis[] = spatial.map((dim) => ({
+    name: dim,
+    type: "space",
+    unit: units[dim],
+  }));
+  return [...systems, { name, axes }];
+}

--- a/ts/test/declare_field_transform_test.ts
+++ b/ts/test/declare_field_transform_test.ts
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Declaring a field image as an RFC-5 field transform.
+ *
+ * Mirrors `py/test/test_declare_field_transform.py`. What is checked is the
+ * entry the declaration produces and the refusals it owes: a store that only
+ * types its component axis is labelled, not applicable, and every mistake this
+ * function rules out leaves a plausible-looking field behind.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import * as zarr from "zarrita";
+import {
+  type CoordinateSystem,
+  declareFieldTransform,
+  type Metadata,
+  NgffImage,
+  NgffMultiscales,
+} from "../src/mod.ts";
+
+const DIMS = ["c", "z", "y", "x"];
+
+async function fieldImage(
+  shape: number[] = [3, 4, 5, 6],
+  dims: string[] = DIMS,
+  axesTypes: Record<string, string> = { c: "displacement" },
+): Promise<NgffImage> {
+  const data = await zarr.create(zarr.root(new Map()).resolve("data"), {
+    shape,
+    chunk_shape: shape,
+    data_type: "float64",
+    fill_value: 0,
+  });
+  return new NgffImage({
+    data,
+    dims,
+    scale: Object.fromEntries(dims.map((dim, i) => [dim, i === 0 ? 1 : i])),
+    translation: Object.fromEntries(dims.map((dim) => [dim, 0])),
+    name: "image",
+    axesUnits: undefined,
+    axesTypes,
+    computedCallbacks: undefined,
+  });
+}
+
+function multiscalesOf(image: NgffImage, systems?: CoordinateSystem[]) {
+  const axes = image.dims.map((name) => ({
+    name,
+    type: name === "c" ? "channel" : "space",
+    unit: undefined,
+  }));
+  const metadata = {
+    axes,
+    datasets: [{ path: "scale0/image", coordinateTransformations: [] }],
+    coordinateTransformations: undefined,
+    coordinateSystems: systems ?? [{ name: "intrinsic", axes }],
+    omero: undefined,
+    name: "image",
+    version: "0.6",
+  } as unknown as Metadata;
+  return new NgffMultiscales({
+    images: [image],
+    metadata,
+    scaleFactors: undefined,
+    method: undefined,
+    chunks: undefined,
+  });
+}
+
+Deno.test("a standalone declaration names a system mapped onto itself", async () => {
+  const declared = declareFieldTransform(multiscalesOf(await fieldImage()));
+  const entries = declared.metadata.coordinateTransformations ?? [];
+  assertEquals(entries.length, 1);
+  const entry = entries[0];
+  assertEquals(entry.type, "displacements");
+  assertEquals(entry.input?.name, "physical");
+  assertEquals(entry.output?.name, "physical");
+  assertEquals(
+    (entry as { path: string }).path,
+    declared.metadata.datasets[0].path,
+  );
+  const physical = (declared.metadata.coordinateSystems ?? []).find(
+    (system) => system.name === "physical",
+  );
+  assertEquals(physical?.axes.map((axis) => axis.name), ["z", "y", "x"]);
+});
+
+Deno.test("declaring appends and leaves the argument alone", async () => {
+  const multiscales = multiscalesOf(await fieldImage());
+  const once = declareFieldTransform(multiscales);
+  const twice = declareFieldTransform(once, { interpolation: "nearest" });
+  assertEquals(
+    (twice.metadata.coordinateTransformations ?? []).map((entry) =>
+      (entry as { interpolation?: string }).interpolation
+    ),
+    ["linear", "nearest"],
+  );
+  // The spatial system is declared once, not once per call.
+  assertEquals(
+    (twice.metadata.coordinateSystems ?? []).filter((system) =>
+      system.name === "physical"
+    ).length,
+    1,
+  );
+  assertEquals(multiscales.metadata.coordinateTransformations, undefined);
+});
+
+Deno.test("a declaration beside the image references its systems", async () => {
+  const axes = ["z", "y", "x"].map((name) => ({
+    name,
+    type: "space",
+    unit: undefined,
+  }));
+  const multiscales = multiscalesOf(await fieldImage(), [
+    { name: "fixed", axes },
+    { name: "moving", axes },
+  ] as CoordinateSystem[]);
+
+  const declared = declareFieldTransform(multiscales, {
+    path: "displacements/field",
+    inputSystem: "fixed",
+    outputSystem: "moving",
+  });
+  const entry = (declared.metadata.coordinateTransformations ?? [])[0];
+  assertEquals((entry as { path: string }).path, "displacements/field");
+  assertEquals(entry.input?.name, "fixed");
+  assertEquals(entry.output?.name, "moving");
+});
+
+Deno.test("a named system that is not declared is refused", async () => {
+  const multiscales = multiscalesOf(await fieldImage());
+  assertThrows(
+    () =>
+      declareFieldTransform(multiscales, {
+        inputSystem: "fixed",
+        outputSystem: "moving",
+      }),
+    Error,
+    "names no declared coordinate system",
+  );
+});
+
+Deno.test("a path without named systems is refused", async () => {
+  // With path the field is elsewhere: deriving a system from the image's own
+  // axes would declare a transform over the wrong space.
+  const multiscales = multiscalesOf(await fieldImage());
+  assertThrows(
+    () => declareFieldTransform(multiscales, { path: "displacements/field" }),
+    Error,
+    "pass inputSystem and outputSystem",
+  );
+});
+
+Deno.test("one-sided system naming is refused", async () => {
+  const multiscales = multiscalesOf(await fieldImage());
+  assertThrows(
+    () => declareFieldTransform(multiscales, { inputSystem: "fixed" }),
+    Error,
+    "both inputSystem and outputSystem",
+  );
+});
+
+Deno.test("a field without a typed component axis is refused", async () => {
+  const multiscales = multiscalesOf(await fieldImage([3, 4, 5, 6], DIMS, {}));
+  assertThrows(
+    () => declareFieldTransform(multiscales),
+    Error,
+    "exactly one axis of type",
+  );
+});
+
+Deno.test("a non-spatial axis is refused", async () => {
+  // A field transform is spatial: relabelling a time axis "space" declares a
+  // transform the package's own converter then refuses to apply.
+  const multiscales = multiscalesOf(
+    await fieldImage([3, 2, 5, 6], ["c", "t", "y", "x"]),
+  );
+  assertThrows(
+    () => declareFieldTransform(multiscales),
+    Error,
+    "spatial axes only",
+  );
+});
+
+Deno.test("a component count that misses an axis is refused", async () => {
+  const multiscales = multiscalesOf(await fieldImage([2, 4, 5, 6]));
+  assertThrows(
+    () => declareFieldTransform(multiscales),
+    Error,
+    "2 components per point",
+  );
+});
+
+Deno.test("a transform type off the prototype chain is refused", async () => {
+  // `transformType in COMPONENT_TYPES` is true for "toString", which a JS
+  // caller is free to pass: the table then yields a function where the axis
+  // type belongs, and with `path` the name lands in the entry's own `type`.
+  const multiscales = multiscalesOf(await fieldImage([3, 4, 5, 6]));
+  for (const inherited of ["toString", "constructor"]) {
+    assertThrows(
+      () =>
+        declareFieldTransform(multiscales, {
+          transformType: inherited as "displacements",
+        }),
+      Error,
+      "transformType must be one of",
+    );
+  }
+});
+
+Deno.test("a declared system that is not spatial is refused", async () => {
+  // The names line up, so the arity check passes; the types do not, and the
+  // transform would map over a system the converter refuses to apply.
+  const multiscales = multiscalesOf(await fieldImage([3, 4, 5, 6]));
+  multiscales.metadata.coordinateSystems = [
+    ...(multiscales.metadata.coordinateSystems ?? []),
+    {
+      name: "physical",
+      axes: [
+        { name: "z", type: "time", unit: undefined },
+        { name: "y", type: "space", unit: undefined },
+        { name: "x", type: "space", unit: undefined },
+      ],
+    },
+  ];
+  assertThrows(
+    () => declareFieldTransform(multiscales),
+    Error,
+    "spatial axes only",
+  );
+});
+
+Deno.test("named systems of different dimension are refused", async () => {
+  // With `path` the field's shape is elsewhere, but the two systems can be
+  // checked against each other: the converter builds one dimension for both
+  // ends, so a 2D input against a 3D output is unapplicable.
+  const system = (name: string, dims: string[]) => ({
+    name,
+    axes: dims.map((d) => ({ name: d, type: "space", unit: undefined })),
+  });
+  const multiscales = multiscalesOf(await fieldImage([3, 4, 5, 6]));
+  multiscales.metadata.coordinateSystems = [
+    ...(multiscales.metadata.coordinateSystems ?? []),
+    system("flat", ["y", "x"]),
+    system("volume", ["z", "y", "x"]),
+  ];
+  assertThrows(
+    () =>
+      declareFieldTransform(multiscales, {
+        path: "displacements/field",
+        inputSystem: "flat",
+        outputSystem: "volume",
+      }),
+    Error,
+    "same dimension",
+  );
+});


### PR DESCRIPTION
Addresses #256: the metadata classes have carried `multiscales > coordinateTransformations` since 0.5, the reader parses it, and nothing exposed could write one.

A `displacements` store that only types its component axis is labelled, not applicable: a reader sees what the channels are, but no transformation says between which coordinate systems the field maps, so nothing can apply it. Producing the declaration today means composing by hand — reach into `v06.zarr_metadata` (not exported), pick the right one of two classes named `Displacements`, build the entry and the coordinate system, validate axis order, component count and references oneself. The composition works — a downstream engine ships it, verified by this package's own reader rebuilding an exact ITK transform from the store — which is the argument that it should be one validated call rather than every consumer's private ritual.

## A silent drop, first

While building that composition, a second thing turned up, and it is the one that matters more.

`to_version` converts the model to the target version's shape before writing, and a shape with no `coordinateTransformations` field dropped the transforms in that conversion: the store was written, the entry was gone, and the only witness was a reader finding `None` where a transform was declared. Worse, the typed component axis survives the trip, so what comes out is precisely the ambiguous labelled-but-not-applicable store. This hits an RFC-5 entry written at 0.4 (the entry cannot exist before 0.6) and also the multiscale-level scale/translation that 0.4 itself allows but this writer does not serialize. Both are now refused by name instead of lost; the gate runs on the source metadata, where the transforms still are.

## What replaces the ritual

`declare_field_transform(multiscales, ...)` — functional, additive (appends to existing transformations, mutates nothing), validated with the same code the writer and reader trust (`validate_transform`, the axis rules the read side enforces).

Two layouts, one signature:

- **standalone** (the defaults): the field is the artifact — a registration's output. The transform is declared on the field's own multiscales, a spatial coordinate system is derived from its axes, and the field maps it onto itself through its own level-0 array.
- **beside the image** (`path` + `input_system`/`output_system`): the entry on the image's multiscales, referencing its declared systems, pointing at the field's array. With `path` the field is elsewhere, so deriving a system here would declare a transform over the wrong space: the names are required, and the docs example that hand-built this entry now calls this instead.

The model classes a caller touches (`Displacements`, `Coordinates`, `CoordinateSystem`, `CoordinateSystemIdentifier`) are exported at the top level; the v06 `Scale`, `Translation`, `Identity`, `Axis` stay module-qualified because the v04 model already exports those names.

Combined with `metadata_only=True` and `open_array`, this closes the write-side story that #695 opens on the read side: a field larger than memory is declared, created, and filled region by region, never assembled. The new docs section is that recipe.

## Proven

- The declared store, written at 0.6 and read back, is applicable by this package's own reader with no other information: the round-trip test rebuilds a native `itk.DisplacementFieldTransform` from the store alone and checks the points it moves against the field's values to 1e-12.
- The streamed store is the whole-array store: same entry, same voxels (`test_a_declared_store_streams_region_by_region`).
- Full suite: 1464 passed, 3 skipped. Lint clean.

## Open questions

1. The standalone default declares one system mapped onto itself. For a registration's total field, a `fixed`/`moving` pair of identical spatial systems may be the more faithful RFC-5 modeling; the API accepts either (`input_system`/`output_system`), only the default is at stake.
2. Should `to_multiscales` grow a convenience parameter for the standalone case, or is the post-hoc call the right single spelling? (Post-hoc is required regardless for the beside-image layout, whose entry lives on a different multiscales than the field's builder.)
3. The v06/v04 name collisions (`Scale`, `Translation`, `Identity`, `Axis`) keep half the v06 model module-qualified. A namespaced export would finish the job; out of scope here.

## Follow-up

The per-block value conversion (branch `feat/py-convert-field-block`, on top of #695): the rotation, positional shift and component permutation inside the field converters are per-voxel given the block's grid position, so the whole-field converters and #695's per-window read path can share one primitive — and an ITK-ordered producer converts each region as it writes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validated APIs for declaring displacement and coordinate field transformations on standalone or linked NGFF fields.
  * Enabled incremental standalone field creation with streaming region writes and OME-Zarr v0.6 metadata.
  * Exposed transformation helpers publicly in Python and TypeScript.
* **Bug Fixes**
  * Unsupported top-level transformations now raise an error instead of being silently dropped.
* **Documentation**
  * Expanded guidance and examples for standalone fields, interpolation, component ordering, and coordinate-system declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
