### PR TITLE
perf(ts): compile metadata validation schemas with Zod 4.5

### DIFF
--- a/ts/deno.json
+++ b/ts/deno.json
@@ -42,7 +42,7 @@
     "dnt": "jsr:@deno/dnt@^0.42.3",
     "itk-wasm": "npm:itk-wasm@^1.0.0-b.201",
     "microdiff": "npm:microdiff@^1.5.0",
-    "zod": "npm:zod@^4.3.6",
+    "zod": "npm:zod@^4.5.0",
     "zarrita": "jsr:@zarrita/zarrita@^0.6.1",
     "fflate": "npm:fflate@^0.8.2",
     "playwright/test": "npm:@playwright/test@^1.58.1"

--- a/ts/deno.lock
+++ b/ts/deno.lock
@@ -40,7 +40,7 @@
     "npm:reference-spec-reader@0.2": "0.2.0",
     "npm:unzipit@1.4.3": "1.4.3",
     "npm:zarrita@~0.6.1": "0.6.1",
-    "npm:zod@^4.3.6": "4.3.6"
+    "npm:zod@^4.5.0": "4.5.4"
   },
   "jsr": {
     "@david/code-block-writer@13.0.3": {
@@ -1271,8 +1271,8 @@
         "numcodecs"
       ]
     },
-    "zod@4.3.6": {
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
+    "zod@4.5.4": {
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="
     }
   },
   "workspace": {
@@ -1294,7 +1294,7 @@
       "npm:fflate@~0.8.2",
       "npm:itk-wasm@^1.0.0-b.201",
       "npm:microdiff@^1.5.0",
-      "npm:zod@^4.3.6"
+      "npm:zod@^4.5.0"
     ]
   }
 }

--- a/ts/scripts/build_npm.ts
+++ b/ts/scripts/build_npm.ts
@@ -38,7 +38,7 @@ export const NPM_DEPENDENCIES: Record<string, string> = {
   // breaks the browser bundle with unresolved "itk-wasm" imports.
   "itk-wasm": "^1.0.0-b.201",
   "@zarrita/storage": "^0.1.4",
-  zod: "^4.0.2",
+  zod: "^4.5.0",
   zarrita: "^0.6.1",
 };
 

--- a/ts/src/schemas/zarr_metadata.ts
+++ b/ts/src/schemas/zarr_metadata.ts
@@ -11,36 +11,44 @@ export const AxisSchema: z.ZodObject<{
   type: typeof AxesTypeSchema;
   unit: z.ZodOptional<typeof UnitsSchema>;
   orientation: z.ZodOptional<typeof AnatomicalOrientationSchema>;
-}> = z.object({
-  name: SupportedDimsSchema,
-  type: AxesTypeSchema,
-  unit: UnitsSchema.optional(),
-  // RFC4: Optional orientation for space axes
-  orientation: AnatomicalOrientationSchema.optional(),
-});
+}> = z.compile(
+  z.object({
+    name: SupportedDimsSchema,
+    type: AxesTypeSchema,
+    unit: UnitsSchema.optional(),
+    // RFC4: Optional orientation for space axes
+    orientation: AnatomicalOrientationSchema.optional(),
+  }),
+);
 
 // Legacy schemas for backward compatibility
 export const IdentitySchema: z.ZodObject<{
   type: z.ZodLiteral<"identity">;
-}> = z.object({
-  type: z.literal("identity"),
-});
+}> = z.compile(
+  z.object({
+    type: z.literal("identity"),
+  }),
+);
 
 export const ScaleSchema: z.ZodObject<{
   scale: z.ZodArray<z.ZodNumber>;
   type: z.ZodLiteral<"scale">;
-}> = z.object({
-  scale: z.array(z.number()),
-  type: z.literal("scale"),
-});
+}> = z.compile(
+  z.object({
+    scale: z.array(z.number()),
+    type: z.literal("scale"),
+  }),
+);
 
 export const TranslationSchema: z.ZodObject<{
   translation: z.ZodArray<z.ZodNumber>;
   type: z.ZodLiteral<"translation">;
-}> = z.object({
-  translation: z.array(z.number()),
-  type: z.literal("translation"),
-});
+}> = z.compile(
+  z.object({
+    translation: z.array(z.number()),
+    type: z.literal("translation"),
+  }),
+);
 
 // Enhanced transform schema that includes all RFC5 transformations
 export const TransformSchema: z.ZodType<unknown> = z.union([
@@ -63,40 +71,48 @@ export const OmeroWindowSchema: z.ZodObject<{
   max: z.ZodNumber;
   start: z.ZodNumber;
   end: z.ZodNumber;
-}> = z.object({
-  min: z.number(),
-  max: z.number(),
-  start: z.number(),
-  end: z.number(),
-});
+}> = z.compile(
+  z.object({
+    min: z.number(),
+    max: z.number(),
+    start: z.number(),
+    end: z.number(),
+  }),
+);
 
 export const OmeroChannelSchema: z.ZodObject<{
   color: z.ZodString;
   window: typeof OmeroWindowSchema;
   label: z.ZodOptional<z.ZodString>;
-}> = z.object({
-  color: z.string().regex(/^[0-9A-Fa-f]{6}$/, {
-    message: "Color must be 6 hex digits",
+}> = z.compile(
+  z.object({
+    color: z.string().regex(/^[0-9A-Fa-f]{6}$/, {
+      message: "Color must be 6 hex digits",
+    }),
+    window: OmeroWindowSchema,
+    label: z.string().optional(),
   }),
-  window: OmeroWindowSchema,
-  label: z.string().optional(),
-});
+);
 
 export const OmeroSchema: z.ZodObject<{
   channels: z.ZodArray<typeof OmeroChannelSchema>;
-}> = z.object({
-  channels: z.array(OmeroChannelSchema),
-});
+}> = z.compile(
+  z.object({
+    channels: z.array(OmeroChannelSchema),
+  }),
+);
 
 export const MethodMetadataSchema: z.ZodType<{
   description: string;
   method: string;
   version: string;
-}> = z.object({
-  description: z.string(),
-  method: z.string(),
-  version: z.string(),
-});
+}> = z.compile(
+  z.object({
+    description: z.string(),
+    method: z.string(),
+    version: z.string(),
+  }),
+);
 
 export const MetadataSchema: z.ZodObject<{
   axes: z.ZodArray<typeof AxisSchema>;

--- a/ts/test/build_npm_test.ts
+++ b/ts/test/build_npm_test.ts
@@ -374,6 +374,7 @@ Deno.test("every published dependency resolves in deno.lock", () => {
 Deno.test("published Zod supports schema compilation", () => {
   const range = parseRange(NPM_DEPENDENCIES.zod);
   assertEquals(satisfies(parse(ZOD_COMPILE_MINIMUM), range), true);
+  assertEquals(satisfies(parse("4.4.99"), range), false);
 });
 
 Deno.test("JSR-resolved exceptions really are absent from npm resolution", () => {

--- a/ts/test/build_npm_test.ts
+++ b/ts/test/build_npm_test.ts
@@ -21,6 +21,8 @@ import {
   rewriteImports,
 } from "../scripts/build_npm.ts";
 
+const ZOD_COMPILE_MINIMUM = "4.5.0";
+
 // ---------------------------------------------------------------------------
 // Relative .ts → .js
 // ---------------------------------------------------------------------------
@@ -367,6 +369,11 @@ Deno.test("every published dependency resolves in deno.lock", () => {
     }. They are published to consumers but never resolved here, so nothing ` +
       `tests them.`,
   );
+});
+
+Deno.test("published Zod supports schema compilation", () => {
+  const range = parseRange(NPM_DEPENDENCIES.zod);
+  assertEquals(satisfies(parse(ZOD_COMPILE_MINIMUM), range), true);
 });
 
 Deno.test("JSR-resolved exceptions really are absent from npm resolution", () => {

--- a/ts/test/schemas_test.ts
+++ b/ts/test/schemas_test.ts
@@ -1,14 +1,41 @@
 // SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 // SPDX-License-Identifier: MIT
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertExists, assertThrows } from "@std/assert";
 import {
   AxisSchema,
+  IdentitySchema,
   MetadataSchema,
+  MethodMetadataSchema,
   OmeroChannelSchema,
+  OmeroSchema,
+  OmeroWindowSchema,
   ScaleSchema,
   TranslationSchema,
 } from "../src/schemas/zarr_metadata.ts";
 import { MethodsSchema } from "../src/schemas/methods.ts";
+
+Deno.test("metadata schema islands use compiled validators", () => {
+  for (
+    const [name, schema] of Object.entries({
+      AxisSchema,
+      IdentitySchema,
+      MethodMetadataSchema,
+      OmeroChannelSchema,
+      OmeroSchema,
+      OmeroWindowSchema,
+      ScaleSchema,
+      TranslationSchema,
+    })
+  ) {
+    const run = schema._zod.run as typeof schema._zod.run & {
+      __originalRun?: unknown;
+    };
+    assertExists(
+      run.__originalRun,
+      `${name} does not have a compiled fast path`,
+    );
+  }
+});
 
 Deno.test("AxisSchema validation", () => {
   const validAxis = {


### PR DESCRIPTION
## Summary

- Upgrade the TypeScript package from Zod 4.3 to Zod 4.5, resolving Zod 4.5.4 in the Deno lockfile and requiring `^4.5.0` from npm consumers.
- Compile the non-recursive metadata validation schemas used by `MetadataSchema`, including axes, common transforms, OMERO metadata, and method metadata.
- Add regression coverage for active compiled fast paths and the published Zod version floor.

## Why

Metadata parsing is a production validation hot path. Zod 4.5 introduces `z.compile()`, which generates optimized validators for valid inputs while retaining the existing runtime parser for detailed failures, improving repeated metadata validation without changing the public schema API.

## Implementation details

The complete `MetadataSchema` cannot be compiled because its RFC-5 coordinate-transformation subtree is recursive. Instead, this change compiles eight eligible schema islands and composes those clones into the existing recursive parent. This provides real fast paths while preserving recursive validation and avoids the process-wide side effects of importing `zod/compile`.

The schema regression test checks Zod's compiled-run marker because unsupported schemas silently fall back to the runtime parser. The npm build dependency test ensures published consumers always resolve a version that implements `z.compile()`.

## Verification

- 68 focused Deno tests pass.
- `ts/src/schemas/zarr_metadata.ts` has 100% branch, function, and line coverage under the focused suite.
- Type checking, formatting, linting, npm package generation, and browser bundling pass.
- CodeRabbit review reported no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved metadata validation performance through optimized validation handling.
  * Updated compatibility to support Zod 4.5.0 and newer versions.

* **Tests**
  * Added coverage confirming published packages require and support the supported Zod version range.
  * Added checks to verify optimized validation across metadata schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->