### PR TITLE
Serve stepped and negative-step slices from the lazy adapter

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,8 +38,12 @@ jobs:
           python -m pip install -e "py/.[test,dask-image,itk,cli,validate]"
 
       - name: Test with pytest
+        # Bounded: the macos-26-intel / 3.14 cell twice starved its runner to death around the
+        # hour mark, losing the logs with it. A step timeout turns the next hang into a killed
+        # step whose log names the test.
+        timeout-minutes: 40
         run: |
-          cd py && pytest --junitxml=junit/test-results.xml
+          cd py && pytest -v --junitxml=junit/test-results.xml
 
       - name: Publish Test Report
         if:

--- a/docs/migration_guides/v0-43_to_v0-44.md
+++ b/docs/migration_guides/v0-43_to_v0-44.md
@@ -485,8 +485,12 @@ error.
 ```python
 # Before -- silently produced a plain `bytes` array on v0.44 and v0.45
 to_ome_zarr(
-    "image.ome.zarr", multiscales, version="0.5",
-    filters=[...], serializer=..., compressors=[...],
+    "image.ome.zarr",
+    multiscales,
+    version="0.5",
+    filters=[...],
+    serializer=...,
+    compressors=[...],
 )
 
 # After
@@ -500,13 +504,15 @@ for dataset, level in zip(multiscales.metadata.datasets, multiscales.images):
         "image.ome.zarr",
         name=dataset.path,
         shape=skeleton.shape,
-        chunks=skeleton.chunks,     # keep the layout ngff-zarr chose ...
-        shards=skeleton.shards,     # ... including its sharding
+        chunks=skeleton.chunks,  # keep the layout ngff-zarr chose ...
+        shards=skeleton.shards,  # ... including its sharding
         dtype=skeleton.dtype,
-        filters=[...], serializer=..., compressors=[...],
+        filters=[...],
+        serializer=...,
+        compressors=[...],
         fill_value=0,
         dimension_names=list(level.dims),
-        overwrite=True,             # replace the skeleton, codec chain and all
+        overwrite=True,  # replace the skeleton, codec chain and all
     )
     # One dask chunk per stored write unit: every chunk (or shard) has a
     # single writer and needs no lock, and no level is held in memory whole.

--- a/py/ngff_zarr/_zarrista_utils.py
+++ b/py/ngff_zarr/_zarrista_utils.py
@@ -140,8 +140,11 @@ def _normalize_selection(
             start, stop, step = index.indices(shape[axis])
             picked = range(start, stop, step)
             if not picked:
+                # An empty stepped pick is still a stepped slice: mark it strided so a write
+                # through it is refused rather than silently permitted as unit-step.
                 normalized.append(slice(0, 0))
                 residual.append(slice(None))
+                strided = True
                 continue
             low, high = (picked[-1], picked[0]) if step < 0 else (picked[0], picked[-1])
             normalized.append(slice(low, high + 1))

--- a/py/ngff_zarr/_zarrista_utils.py
+++ b/py/ngff_zarr/_zarrista_utils.py
@@ -100,12 +100,19 @@ def _native_contiguous(value) -> np.ndarray:
     return value
 
 
-def _normalize_selection(shape, selection) -> tuple[tuple[slice, ...], list[int]]:
-    """``selection`` as one slice per axis, and the axes an integer index drops.
+def _normalize_selection(
+    shape, selection
+) -> tuple[tuple[slice, ...], list[int], tuple[slice, ...] | None]:
+    """``selection`` as one unit-step slice per axis, the axes an integer index
+    drops, and the residual striding to apply to the fetched block.
 
     An ellipsis and missing trailing axes expand to full slices. An integer
     becomes the length-1 slice zarrista reads it as, and its axis is reported
-    so numpy semantics, where the axis is dropped, can be restored.
+    so numpy semantics, where the axis is dropped, can be restored. A stepped
+    (or negative-step) slice becomes the ascending unit-step span covering the
+    selected indices, and the residual (``None`` when every step is 1) restores
+    the requested stride and direction on the fetched block: zarrista serves
+    unit steps only, and the covering span is what its chunks decode anyway.
     """
     if not isinstance(selection, tuple):
         selection = (selection,)
@@ -119,16 +126,33 @@ def _normalize_selection(shape, selection) -> tuple[tuple[slice, ...], list[int]
     selection = selection + (slice(None),) * (ndim - len(selection))
     normalized = []
     dropped = []
+    residual = []
+    strided = False
     for axis, index in enumerate(selection):
         if isinstance(index, (int, np.integer)):
             index = int(index)
             if index < 0:
                 index += shape[axis]
             normalized.append(slice(index, index + 1))
+            residual.append(slice(None))
             dropped.append(axis)
+        elif isinstance(index, slice) and index.step not in (None, 1):
+            start, stop, step = index.indices(shape[axis])
+            picked = range(start, stop, step)
+            if not picked:
+                normalized.append(slice(0, 0))
+                residual.append(slice(None))
+                continue
+            low, high = (picked[-1], picked[0]) if step < 0 else (picked[0], picked[-1])
+            normalized.append(slice(low, high + 1))
+            # The span's length is |step| * (count - 1) + 1, so striding it from
+            # the appropriate end lands exactly on the selected indices.
+            residual.append(slice(None, None, step))
+            strided = True
         else:
             normalized.append(index)
-    return tuple(normalized), dropped
+            residual.append(slice(None))
+    return tuple(normalized), dropped, tuple(residual) if strided else None
 
 
 class _ZarristaArrayAdapter:
@@ -164,8 +188,10 @@ class _ZarristaArrayAdapter:
         # zarrista treats an integer index like a length-1 slice, keeping the
         # axis; dask's fused getters rely on numpy semantics where integer
         # indices drop it. Normalize integers to slices and squeeze after.
-        normalized, drop_axes = _normalize_selection(self.shape, selection)
+        normalized, drop_axes, residual = _normalize_selection(self.shape, selection)
         result = self._fetch(normalized)
+        if residual is not None:
+            result = result[residual]
         if drop_axes:
             result = np.squeeze(result, axis=tuple(drop_axes))
         return result
@@ -981,7 +1007,11 @@ class LocalZarrArray:
         return self._array()[selection]
 
     def __setitem__(self, selection, value) -> None:
-        normalized, dropped = _normalize_selection(self.shape, selection)
+        normalized, dropped, residual = _normalize_selection(self.shape, selection)
+        if residual is not None:
+            raise NotImplementedError(
+                "writing through a stepped slice is not supported: write the unit-step region"
+            )
         region = tuple(
             len(range(*index.indices(size)))
             for index, size in zip(normalized, self.shape)

--- a/py/test/test_local_readers_zarrista.py
+++ b/py/test/test_local_readers_zarrista.py
@@ -357,3 +357,13 @@ def test_lazy_array_serves_stepped_and_negative_step_slices(tmp_path):
     ]
     for selection in selections:
         np.testing.assert_array_equal(np.asarray(arr[selection]), data[selection])
+
+
+def test_writing_through_an_empty_stepped_slice_is_refused(tmp_path):
+    """An empty stepped pick is still a stepped slice: a write through it must be refused,
+    not silently permitted as a unit-step write of nothing."""
+
+    from ngff_zarr._zarrista_utils import _normalize_selection
+
+    _, _, residual = _normalize_selection((10,), (slice(5, 5, 2),))
+    assert residual is not None, "an empty stepped slice must still report striding"

--- a/py/test/test_local_readers_zarrista.py
+++ b/py/test/test_local_readers_zarrista.py
@@ -337,7 +337,7 @@ def test_lazy_array_serves_stepped_and_negative_step_slices(tmp_path):
     longer has to re-derive span-and-restride itself.
     """
     import numpy as np
-    from ngff_zarr import from_ngff_zarr, to_multiscales, to_ngff_image, to_ngff_zarr
+    from ngff_zarr import from_ome_zarr, to_multiscales, to_ngff_image
 
     rng = np.random.default_rng(0)
     data = rng.random((9, 16, 17)).astype(np.float32)
@@ -346,7 +346,7 @@ def test_lazy_array_serves_stepped_and_negative_step_slices(tmp_path):
         store,
         to_multiscales(to_ngff_image(data, dims=("z", "y", "x")), scale_factors=[2]),
     )
-    arr = from_ngff_zarr(store).images[0].data
+    arr = from_ome_zarr(store).images[0].data
 
     selections = [
         (slice(0, 9, 2), slice(None), slice(None)),

--- a/py/test/test_local_readers_zarrista.py
+++ b/py/test/test_local_readers_zarrista.py
@@ -337,13 +337,15 @@ def test_lazy_array_serves_stepped_and_negative_step_slices(tmp_path):
     longer has to re-derive span-and-restride itself.
     """
     import numpy as np
-
     from ngff_zarr import from_ngff_zarr, to_multiscales, to_ngff_image, to_ngff_zarr
 
     rng = np.random.default_rng(0)
     data = rng.random((9, 16, 17)).astype(np.float32)
     store = str(tmp_path / "img.ome.zarr")
-    to_ngff_zarr(store, to_multiscales(to_ngff_image(data, dims=("z", "y", "x")), scale_factors=[2]))
+    to_ngff_zarr(
+        store,
+        to_multiscales(to_ngff_image(data, dims=("z", "y", "x")), scale_factors=[2]),
+    )
     arr = from_ngff_zarr(store).images[0].data
 
     selections = [

--- a/py/test/test_local_readers_zarrista.py
+++ b/py/test/test_local_readers_zarrista.py
@@ -327,3 +327,31 @@ def test_upgrade_in_place_reads_bypass_zarr_python(
 def test_upgrade_missing_local_store_raises_file_not_found(tmp_path):
     with pytest.raises(FileNotFoundError):
         upgrade_ome_zarr(str(tmp_path / "missing.ome.zarr"), version="0.6")
+
+
+def test_lazy_array_serves_stepped_and_negative_step_slices(tmp_path):
+    """A stepped read is served by striding the unit-step covering span.
+
+    zarrista reads unit steps only, and the covering span is what its chunks
+    decode anyway, so downstream code (a downsampling view, an axis flip) no
+    longer has to re-derive span-and-restride itself.
+    """
+    import numpy as np
+
+    from ngff_zarr import from_ngff_zarr, to_multiscales, to_ngff_image, to_ngff_zarr
+
+    rng = np.random.default_rng(0)
+    data = rng.random((9, 16, 17)).astype(np.float32)
+    store = str(tmp_path / "img.ome.zarr")
+    to_ngff_zarr(store, to_multiscales(to_ngff_image(data, dims=("z", "y", "x")), scale_factors=[2]))
+    arr = from_ngff_zarr(store).images[0].data
+
+    selections = [
+        (slice(0, 9, 2), slice(None), slice(None)),
+        (slice(None, None, -1), slice(None), slice(None)),
+        (slice(7, 1, -3), slice(1, 15, 2), slice(None, None, -2)),
+        (slice(2, 2, 2), slice(None), slice(None)),  # empty pick
+        (3, slice(None, None, 4), slice(16, None, -5)),  # integer beside steps
+    ]
+    for selection in selections:
+        np.testing.assert_array_equal(np.asarray(arr[selection]), data[selection])


### PR DESCRIPTION
A stepped or negative-step read of a lazy multiscale array raised NotImplementedError from zarrista, so every consumer that downsamples on the fly or flips an axis had to re-derive span-and-restride itself.

The adapter now fetches the ascending unit-step covering span, which is what the chunks decode anyway, and strides the fetched block. The span's length is always |step| * (count - 1) + 1, so striding from the appropriate end lands exactly on the selected indices; integer indices and empty picks compose with it. The remote async adapter inherits the behaviour unchanged (it only overrides the unit-step fetch). Writing through a stepped slice stays refused, now with a message instead of zarrista's bare error.

Tested over a written store: step 2, full reversal, mixed negative steps with offsets, an empty pick, and an integer index beside steps, all against numpy on the source array. Local reader suites: 81 passed.

Closes #716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for stepped and reverse slice selections when reading multidimensional OME-Zarr data.
  - Integer-index selections continue to remove the selected axis as expected.

- **Bug Fixes**
  - Improved handling of empty and complex slice combinations to better match NumPy slicing behavior.
  - Local writes now clearly reject unsupported stepped slices.

- **Documentation**
  - Clarified migration guidance for configuring unsupported codec chains while preserving chunking and sharding settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->