### PR TITLE
Add OME-Zarr 0.9.dev3 with the RFC-8 node model and collections

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ A lean and kind
   stay readable by zarr-python 2 and 3, and 0.5+ (Zarr v3) by zarr-python 3
 - [Anatomical orientation metadata](./rfc4.md) (RFC-4)
 - [Coordinate systems and transformations](./rfc5.md) (RFC-5)
+- [Collections and extensibility](./rfc8.md) (RFC-8, in progress)
 - **OME-Zarr Zip (.ozx) file support** for single-file OME-Zarr datasets (RFC-9)
 - **High Content Screening (HCS) support** for plate and well data
 - **TIFF/OME-TIFF support** with automatic metadata extraction and multi-series conversion
@@ -52,6 +53,7 @@ cli.md
 mcp.md
 rfc4.md
 rfc5.md
+rfc8.md
 hcs.md
 spec_features.md
 itk.md

--- a/docs/rfc8.md
+++ b/docs/rfc8.md
@@ -1,0 +1,95 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+# 🗂️ RFC-8: Collections and Extensibility
+
+[RFC-8] introduces a general extensibility mechanism for OME-Zarr metadata:
+typed paths, references, and a common node structure through which images and
+other data objects can be grouped into collections, nested, referenced locally
+or remotely, and enriched with additional metadata.
+
+ngff-zarr gates the RFC-8 node model on the development version `0.9.dev3`,
+which extends `0.9.dev1` (RFC-3 axes and RFC-4 orientation stay normative).
+At `0.9.dev3` the root `ome` value is a typed node document; the
+`multiscales` wrapper of earlier versions is replaced. RFC-8 is an early
+draft (status D1), so this surface is expected to evolve with it.
+
+Support is being built in stages
+([issue #714](https://github.com/fideus-labs/ngff-zarr/issues/714)). The
+current stage covers the building blocks and collections:
+
+- the `OmePath`, `Reference`, `Node` and `Collection` model
+  (`ngff_zarr.rfc8`), open-world: unknown node types and prefixed extension
+  attributes (e.g. `mobie:grid`) round-trip unchanged;
+- reading and writing collection documents in a Zarr group
+  (`from_collection_zarr` / `to_collection_zarr`) or standalone JSON
+  (`from_collection_json` / `to_collection_json`);
+- lazy dereferencing of path-referenced nodes (`NgffCollection.load`),
+  including multiscales image stores written at earlier versions;
+- the seven RFC-8 structural rules, dispatched by `validate_collection` (see
+  the [validation rule reference](./validation/rule-reference.md)).
+
+Writing *images* at `0.9.dev3` (the RFC-8 multiscale/singlescale node model)
+is not implemented yet: `to_ome_zarr(version="0.9.dev3")` explains the
+staging. Write the image at `0.9.dev1` and reference it from a `0.9.dev3`
+collection.
+
+## Usage
+
+### Build and write a collection
+
+```python
+import ngff_zarr
+from ngff_zarr import Collection, Node, OmePath
+
+collection = Collection(
+    "study",
+    id="study",
+    nodes=[
+        Node(type="multiscale", name="raw", id="raw", path=OmePath("zarr", "./raw")),
+        Collection("annotations", path=OmePath("json", "./annotations.json")),
+    ],
+    attributes={"mobie:grid": "true"},
+)
+
+# Metadata-only: the referenced stores are written separately, at their own
+# versions. Nothing beneath the root is ever removed.
+ngff_zarr.to_collection_zarr("study.ome.zarr", collection)
+ngff_zarr.to_ome_zarr("study.ome.zarr/raw", multiscales, version="0.9.dev1")
+```
+
+### Read and dereference
+
+```python
+collection = ngff_zarr.from_collection_zarr("study.ome.zarr", validate=True)
+
+image = collection.load("raw")  # -> NgffMultiscales
+nested = collection.load("annotations")  # -> NgffCollection
+
+# Standalone JSON documents work the same way
+gallery = ngff_zarr.from_collection_json("gallery.json")
+```
+
+Relative paths resolve against the document that holds them (the Zarr group
+or the JSON file), per the RFC; `file://` paths and `http(s)://` URLs stand
+alone. Dereferenced documents are cached per resolved location.
+
+### Validation
+
+`validate_collection` runs the RFC-8 structural rules over a raw `ome`
+document or a parsed node tree. The rules are normative at `0.9.dev3`, stay
+on when no version is declared, and are inert when an earlier version is
+declared. `validate=True` on the readers additionally checks the bundled
+RFC-8 node schema. RFC-8 publishes no normative JSON schema yet, so that
+schema is authored in this repository from the RFC text; the vendored
+`spec/0.9` tree remains verbatim upstream and only covers `0.9.dev1`.
+
+### TypeScript
+
+The TypeScript package mirrors the surface with `fromCollectionZarr` /
+`toCollectionZarr`, `fromCollectionJson` / `toCollectionJson`,
+`loadCollectionNode`, `validateCollection`, and the `OmeNode` / `OmePath` /
+`Reference` / `NgffCollection` types (the RFC's `Node` name would collide
+with the DOM type). Rule identifiers, messages and locations are
+byte-identical across the two ports, pinned by a shared case fixture.
+
+[RFC-8]: https://ngff.openmicroscopy.org/rfc/8/index.html

--- a/docs/rfc8.md
+++ b/docs/rfc8.md
@@ -73,6 +73,10 @@ Relative paths resolve against the document that holds them (the Zarr group
 or the JSON file), per the RFC; `file://` paths and `http(s)://` URLs stand
 alone. Dereferenced documents are cached per resolved location.
 
+Dereferencing follows whatever locations a document declares, local paths
+and http(s) URLs alike, with no allowlist in between. Load collections from
+sources you trust, or inspect `resolve_location` results first; a resolver
+policy hook is a candidate once the RFC stabilizes.
 ### Validation
 
 `validate_collection` runs the RFC-8 structural rules over a raw `ome`

--- a/docs/spec_features.md
+++ b/docs/spec_features.md
@@ -43,6 +43,12 @@ supported by `ngff-zarr`.
   of axes. It is opt-in: pass `version="0.9.dev1"` explicitly, the default
   target is unchanged. The schemas of the `0.9.dev1` release are bundled, so
   `validate=True` checks a store at that version as it does at any other.
+- **OME-Zarr 0.9.dev3**: The development version that adopts
+  [RFC-8 collections](./rfc8.md). Collection documents are read and written
+  (`from_collection_zarr` / `to_collection_zarr` and the standalone-JSON
+  equivalents); the RFC-8 image (multiscale node) model is not implemented
+  yet, so images are written at `0.9.dev1` and referenced from `0.9.dev3`
+  collections.
 
 ## High Content Screening (HCS)
 

--- a/docs/validation/parity.md
+++ b/docs/validation/parity.md
@@ -73,9 +73,17 @@ The canonical `SpecRule` set, in evaluation order:
 13. `ome-namespace`
 14. `plate-row-index-consistency`
 15. `well-acquisition-missing`
+16. `node-type-required`
+17. `node-name-required`
+18. `node-name-unique`
+19. `node-id-format`
+20. `node-id-unique`
+21. `node-nodes-xor-path`
+22. `path-type-known`
 
 Entries 12–13 are the v0.5 namespacing rules; they fire only for v0.5 metadata
-and are inert for v0.4. Each suite pins this list as a `CANONICAL_SPEC_RULE_IDS`
+and are inert for v0.4. Entries 16–22 are the RFC-8 node/collection rules,
+dispatched by the separate `validate_collection` orchestrator. Each suite pins this list as a `CANONICAL_SPEC_RULE_IDS`
 literal — byte-identical between the two languages so the tests are
 line-for-line comparable.
 
@@ -83,6 +91,7 @@ The versions that adopt the RFC-3 axis model are pinned the same way, as a
 `CANONICAL_RFC3_VERSIONS` literal:
 
 1. `0.9.dev1`
+2. `0.9.dev3`
 
 Rules 1–3 (and the spatial arm of 3) are inert at those versions and enforced
 at every other. Rule 4, `axis-names-unique`, is never inert: RFC-3 *adds* it,
@@ -93,10 +102,20 @@ The versions at which the RFC-4 orientation rules are normative are pinned the
 same way, as a `CANONICAL_RFC4_VERSIONS` literal:
 
 1. `0.9.dev1`
+2. `0.9.dev3`
 
 Rules 9–11 gate the opposite way from the RFC-3 set: they are enforced at
 those versions and when no version is given, and inert at every earlier
 version, where RFC-4 has no normative status (see [[rule-reference]]).
+
+The versions that store the RFC-8 node model are pinned as a
+`CANONICAL_RFC8_VERSIONS` literal:
+
+1. `0.9.dev3`
+
+Rules 16–22 gate like the RFC-4 set: enforced at those versions and when no
+version is given, inert at every other supported version, 0.9.dev1 included
+(RFC-8 lands at 0.9.dev3).
 
 ## The parity tests
 
@@ -133,13 +152,21 @@ Each suite independently locks:
   exactly the versions in `CANONICAL_RFC4_VERSIONS` (and when no version is
   given) and inert at every other supported version, asserted the same way,
   once per orientation rule.
+- **RFC-8 collection version set** — the node/collection rules are enforced
+  at exactly the versions in `CANONICAL_RFC8_VERSIONS` (and when no version
+  is given) and inert at every other supported version, asserted through
+  `validate_collection` / `validateCollection`.
 
-Four of the fifteen rules never appear in `EXPECTED_EVALUATION_ORDER`, each for
-its own reason. The two v0.5 namespacing rules (`zarr-format`, `ome-namespace`)
-run last in the image orchestrator but are inert for the v0.4 metadata the order
-test exercises. The two HCS rules (`plate-row-index-consistency`,
-`well-acquisition-missing`) are deliberately absent; they are dispatched by the
-separate plate/well orchestrators (see [[rule-reference]]).
+Eleven of the twenty-two rules never appear in `EXPECTED_EVALUATION_ORDER`,
+each for its own reason. The two v0.5 namespacing rules (`zarr-format`,
+`ome-namespace`) run last in the image orchestrator but are inert for the v0.4
+metadata the order test exercises. The two HCS rules
+(`plate-row-index-consistency`, `well-acquisition-missing`) and the seven
+RFC-8 rules (`node-type-required` through `path-type-known`) are deliberately
+absent; they are dispatched by the separate plate/well and collection
+orchestrators (see [[rule-reference]]), and the RFC-8 rules' own fail-fast
+order is pinned by the shared `rfc8_collection_cases.json` fixture both suites
+drive.
 
 ## Sanctioned TypeScript-only adaptations
 

--- a/docs/validation/rule-reference.md
+++ b/docs/validation/rule-reference.md
@@ -24,10 +24,12 @@ across the Python and TypeScript ports — see [[parity]] for the guarantee. Mos
 rules enforce OME-Zarr v0.4 MUSTs; the two v0.5 namespacing rules
 (`zarr-format`, `ome-namespace`) fire only for v0.5 metadata and are inert (a
 no-op) for v0.4. The three RFC 4 orientation rules (9–11) are normative from
-OME-Zarr 0.9.dev1, which incorporates RFC-4 through `ome/ngff-spec#190`: they are
-inert when the caller declares 0.4, 0.5 or 0.6, where RFC 4 has no normative
-status, and stay on when no version is declared — a strictness choice, like
-`axis-names-unique` below 0.9.dev1. For the conceptual background and the two
+OME-Zarr 0.9.dev1, which incorporates RFC-4 through `ome/ngff-spec#190` (and
+from 0.9.dev3, which extends it): they are inert when the caller declares 0.4,
+0.5 or 0.6, where RFC 4 has no normative status, and stay on when no version
+is declared — a strictness choice, like `axis-names-unique` below 0.9.dev1.
+The seven RFC 8 node/collection rules (16–22) are normative from OME-Zarr
+0.9.dev3, the version that stores the RFC-8 node model. For the conceptual background and the two
 validation levels, see [[overview]]; for invocation, see [[api]].
 
 Location strings are dotted-segment, JSON-Pointer-style identifiers of the
@@ -55,6 +57,13 @@ the `SpecRule` enum declares them and the orchestrators evaluate them.
 | 13| `ome-namespace` | images/multiscales (v0.5) | A v0.5 entry must not retain a group-level `ome` or `multiscales` wrapper key — the `ome` namespace wraps the group attributes, not each entry. Inert for v0.4. | v0.5: multiscales live under the top-level `ome` namespace, with `version` hoisted to `ome.version`. | `multiscales[0]` |
 | 14| `plate-row-index-consistency` | HCS plate | Each well's `path` is `<row>/<column>`, naming declared row/column entries, with `rowIndex`/`columnIndex` equal to those entries' positions. | v0.4: well `rowIndex`/`columnIndex` match the named row/column positions in `plate.rows`/`plate.columns`. | `plate.wells[3]` |
 | 15| `well-acquisition-missing` | HCS well | When the plate declares more than one acquisition, every well image references one via `acquisition`. | v0.4: with multiple acquisitions, each well image references an acquisition. | `well.images[0].acquisition` |
+| 16| `node-type-required` | RFC-8 nodes | Every node of a 0.9.dev3 document declares a non-empty string `type`. Enforced when the document declares 0.9.dev3 or no version; inert below. | RFC-8 (normative from 0.9.dev3): a node's `type` MUST be a string identifying the node type. | `ome.nodes[1]` |
+| 17| `node-name-required` | RFC-8 nodes | Every node declares a non-empty string `name` for human-readable display. Same gating as rule 16. | RFC-8: a node's `name` MUST be a non-empty string. | `ome.nodes[1]` |
+| 18| `node-name-unique` | RFC-8 nodes | Sibling nodes within one collection carry distinct names; nodes of different collections may share one. Same gating as rule 16. | RFC-8: names MUST be unique within the enclosing collection. | `ome.nodes[2]` |
+| 19| `node-id-format` | RFC-8 nodes | Every declared `id` (node ids today, reference ids when references land) matches `[a-zA-Z0-9-_.]+`. Same gating as rule 16. | RFC-8: an id MUST be a string matching `[a-zA-Z0-9-_.]+`. | `ome.nodes[0].id` |
+| 20| `node-id-unique` | RFC-8 nodes | Ids are unique within the JSON document (path-referenced nodes live in their own documents). Same gating as rule 16. | RFC-8: ids MUST be unique within the JSON document. | `ome.nodes[3].id` |
+| 21| `node-nodes-xor-path` | RFC-8 collections | A collection carries exactly one of `nodes` and `path`; unknown and extension node types are exempt. Same gating as rule 16. | RFC-8: either `nodes` or `path` MUST be present on a collection, but not both. | `ome.nodes[1]` |
+| 22| `path-type-known` | RFC-8 paths | A path `type` is `zarr`, `json`, or a prefixed extension identifier (`prefix:name`), which passes as opaque. Same gating as rule 16. | RFC-8: unprefixed path types are reserved for the core specification, which defines `zarr` and `json`. | `ome.nodes[1].path.type` |
 
 ## Evaluation order and orchestrators
 
@@ -79,10 +88,17 @@ rules:
   (`plate-row-index-consistency`).
 - **`validate_well` / `validateWell`** evaluates rule **15**
   (`well-acquisition-missing`), in the context of its parent plate.
+- **`validate_collection` / `validateCollection`** evaluates rules **16–22**
+  (the RFC-8 node/collection rules) against the raw `ome` document of an
+  OME-Zarr 0.9.dev3 store or standalone JSON file, walking the node tree
+  depth-first once per rule. The rules are enforced when the document
+  declares 0.9.dev3 or no version, and inert when an earlier version is
+  declared (RFC-8 lands at 0.9.dev3; see `is_rfc8_node_model`).
 
-The two HCS rules (14 and 15) are deliberately absent from the image
-orchestrator's order; they operate on separate metadata objects. The exact
-fail-fast sequence is locked by the parity tests described in [[parity]].
+The HCS rules (14 and 15) and the RFC-8 rules (16–22) are deliberately absent
+from the image orchestrator's order; they operate on separate metadata
+objects. The exact fail-fast sequence is locked by the parity tests described
+in [[parity]].
 
 A fourth dispatcher sits on the write path: `_gate_axis_model` /
 `gateAxisModel` refuses to serialize an axis model the target version cannot
@@ -107,3 +123,7 @@ TypeScript by checking the target version in `axisViews`.
 - **v0.5 namespacing** — `zarr-format`, `ome-namespace` (inert for v0.4).
 - **HCS plate / well** — `plate-row-index-consistency`,
   `well-acquisition-missing`.
+- **RFC 8 nodes / collections** (normative from 0.9.dev3) —
+  `node-type-required`, `node-name-required`, `node-name-unique`,
+  `node-id-format`, `node-id-unique`, `node-nodes-xor-path`,
+  `path-type-known`.

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -79,6 +79,18 @@ from .rfc4 import (
     orientation_from_name,
     remove_anatomical_orientation_from_axis,
 )
+from .rfc8 import (
+    Collection,
+    NgffCollection,
+    Node,
+    OmePath,
+    Reference,
+    from_collection_json,
+    from_collection_zarr,
+    to_collection_json,
+    to_collection_zarr,
+    validate_collection,
+)
 from .rfc9_zip import (
     is_ozx_path,
     read_ozx_json_first,
@@ -200,6 +212,7 @@ __all__ = [
     "validate_structural",
     "validate_plate",
     "validate_well",
+    "validate_collection",
     "SpecRule",
     "ValidationLevel",
     "ValidateOptions",
@@ -225,6 +238,16 @@ __all__ = [
     "Omero",
     "OmeroChannel",
     "OmeroWindow",
+    # RFC 8 - Collections (OME-Zarr 0.9.dev3)
+    "OmePath",
+    "Reference",
+    "Node",
+    "Collection",
+    "NgffCollection",
+    "from_collection_zarr",
+    "from_collection_json",
+    "to_collection_zarr",
+    "to_collection_json",
     # HCS (High Content Screening)
     "Plate",
     "PlateAcquisition",

--- a/py/ngff_zarr/_lru_cache.py
+++ b/py/ngff_zarr/_lru_cache.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""A small least-recently-used cache shared by the lazy readers."""
+
+from collections import OrderedDict
+
+
+class LRUCache:
+    """
+    Least Recently Used (LRU) cache with size limit for HCS image caching.
+
+    This prevents unbounded memory growth when accessing many images
+    from large plates.
+    """
+
+    def __init__(self, max_size: int = 100):
+        self.max_size = max_size
+        self.cache = OrderedDict()
+
+    def get(self, key):
+        if key in self.cache:
+            # Move to end (most recently used)
+            self.cache.move_to_end(key)
+            return self.cache[key]
+        return None
+
+    def set(self, key, value):
+        if key in self.cache:
+            # Update existing item
+            self.cache[key] = value
+            self.cache.move_to_end(key)
+        else:
+            # Add new item
+            if len(self.cache) >= self.max_size:
+                # Remove least recently used item before adding
+                self.cache.popitem(last=False)
+            self.cache[key] = value
+
+    def __contains__(self, key):
+        return key in self.cache
+
+    def __getitem__(self, key):
+        """Support dict-like access."""
+        value = self.get(key)
+        if value is None:
+            raise KeyError(key)
+        return value
+
+    def __setitem__(self, key, value):
+        """Support dict-like assignment."""
+        self.set(key, value)
+
+    def clear(self):
+        """Clear all cached items."""
+        self.cache.clear()

--- a/py/ngff_zarr/_lru_cache.py
+++ b/py/ngff_zarr/_lru_cache.py
@@ -14,6 +14,8 @@ class LRUCache:
     """
 
     def __init__(self, max_size: int = 100):
+        if max_size <= 0:
+            raise ValueError("max_size must be positive")
         self.max_size = max_size
         self.cache = OrderedDict()
 

--- a/py/ngff_zarr/_supported_versions.py
+++ b/py/ngff_zarr/_supported_versions.py
@@ -19,6 +19,10 @@ class NgffVersion(StrEnum):
     # OME-Zarr 0.9 in development: 0.6 plus RFC-3 (any axis count, names,
     # types and ordering). LATEST stays 0.6rc0, so 0.9.dev1 is opt-in.
     V09dev1 = "0.9.dev1"
+    # 0.9.dev1 plus RFC-8: the root ``ome`` value becomes a typed node
+    # (collections, references, typed paths) in place of the multiscales
+    # wrapper. Also opt-in; LATEST stays 0.6rc0.
+    V09dev3 = "0.9.dev3"
     # An alias of V06rc0 (same value): it must stay last.
     LATEST = "0.6rc0"
 
@@ -34,7 +38,14 @@ SUPPORTED_VERSIONS = (
     NgffVersion.V06dev4,
     NgffVersion.V06rc0,
     NgffVersion.V09dev1,
+    NgffVersion.V09dev3,
 )
+
+#: The OME-Zarr 0.9 development series, oldest first. Each tag extends the one
+#: before: dev1 is 0.6 plus RFC-3 and RFC-4, dev3 is dev1 plus RFC-8. A tuple
+#: rather than a frozenset: membership tests compare with ``==``, so a
+#: non-string ``version`` object cannot raise on hashing.
+V09_DEV_SERIES = (NgffVersion.V09dev1, NgffVersion.V09dev3)
 
 #: The ``ome.version`` string written to disk for the API version ``"0.6"``.
 #: The 0.6 spec is a release candidate, so a store is tagged with the

--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -359,6 +359,21 @@ def from_ome_zarr(
             "within the plate (e.g., 'plate.zarr/A/1/0' for well A1, field 0)."
         )
 
+    if version == "0.9.dev3":
+        # RFC-8: the root ``ome`` value is a typed node document, not a
+        # multiscales wrapper, so the multiscales readers below cannot parse
+        # it (and without this guard a 0.9.dev3 store would fall through to
+        # the v0.4 branch and fail on a missing ``multiscales`` key).
+        ome_value = root_attrs.get("ome")
+        node_type = ome_value.get("type") if isinstance(ome_value, dict) else None
+        raise ValueError(
+            f"The input is an OME-Zarr 0.9.dev3 store whose root is a "
+            f"{node_type!r} node. 0.9.dev3 stores the RFC-8 node model in "
+            "place of the multiscales metadata; use from_collection_zarr() "
+            "to read it. from_ome_zarr() reads multiscale image stores "
+            "written at earlier versions."
+        )
+
     if version == "0.9.dev1":
         from .v09.zarr_metadata import Metadata
 

--- a/py/ngff_zarr/hcs.py
+++ b/py/ngff_zarr/hcs.py
@@ -18,10 +18,10 @@ Memory Management:
 
 import logging
 import threading
-from collections import OrderedDict
 from pathlib import Path
 from typing import Optional
 
+from ._lru_cache import LRUCache
 from ._remote_reader import RemoteZarrStore, remote_read_available
 from ._zarrista_utils import (
     create_zarrista_group,
@@ -42,56 +42,6 @@ from .v04.zarr_metadata import (
     Well,
     WellImage,
 )
-
-
-class LRUCache:
-    """
-    Least Recently Used (LRU) cache with size limit for HCS image caching.
-
-    This prevents unbounded memory growth when accessing many images
-    from large plates.
-    """
-
-    def __init__(self, max_size: int = 100):
-        self.max_size = max_size
-        self.cache = OrderedDict()
-
-    def get(self, key):
-        if key in self.cache:
-            # Move to end (most recently used)
-            self.cache.move_to_end(key)
-            return self.cache[key]
-        return None
-
-    def set(self, key, value):
-        if key in self.cache:
-            # Update existing item
-            self.cache[key] = value
-            self.cache.move_to_end(key)
-        else:
-            # Add new item
-            if len(self.cache) >= self.max_size:
-                # Remove least recently used item before adding
-                self.cache.popitem(last=False)
-            self.cache[key] = value
-
-    def __contains__(self, key):
-        return key in self.cache
-
-    def __getitem__(self, key):
-        """Support dict-like access."""
-        value = self.get(key)
-        if value is None:
-            raise KeyError(key)
-        return value
-
-    def __setitem__(self, key, value):
-        """Support dict-like assignment."""
-        self.set(key, value)
-
-    def clear(self):
-        """Clear all cached items."""
-        self.cache.clear()
 
 
 class HCSPlate:

--- a/py/ngff_zarr/rfc8/__init__.py
+++ b/py/ngff_zarr/rfc8/__init__.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""RFC-8 "Collections and Extensibility" support (OME-Zarr 0.9.dev3)."""
+
+from .collection import NgffCollection
+from .io import (
+    from_collection_json,
+    from_collection_zarr,
+    load_rfc8_node_schema,
+    to_collection_json,
+    to_collection_zarr,
+)
+from .model import (
+    PATH_TYPE_JSON,
+    PATH_TYPE_ZARR,
+    RFC8_ID_PATTERN,
+    Collection,
+    Node,
+    OmePath,
+    Reference,
+    is_collection_node,
+    is_prefixed_identifier,
+)
+from .resolve import resolve_location, resolve_ome_document
+from .serialize import node_from_ome_dict, node_to_ome_dict
+from .validation import (
+    validate_collection,
+    validate_node_id_format,
+    validate_node_id_unique,
+    validate_node_name_required,
+    validate_node_name_unique,
+    validate_node_nodes_xor_path,
+    validate_node_type_required,
+    validate_path_type_known,
+)
+
+__all__ = [
+    "PATH_TYPE_JSON",
+    "PATH_TYPE_ZARR",
+    "RFC8_ID_PATTERN",
+    "Collection",
+    "NgffCollection",
+    "Node",
+    "OmePath",
+    "Reference",
+    "from_collection_json",
+    "from_collection_zarr",
+    "is_collection_node",
+    "is_prefixed_identifier",
+    "load_rfc8_node_schema",
+    "node_from_ome_dict",
+    "node_to_ome_dict",
+    "resolve_location",
+    "resolve_ome_document",
+    "to_collection_json",
+    "to_collection_zarr",
+    "validate_collection",
+    "validate_node_id_format",
+    "validate_node_id_unique",
+    "validate_node_name_required",
+    "validate_node_name_unique",
+    "validate_node_nodes_xor_path",
+    "validate_node_type_required",
+    "validate_path_type_known",
+]

--- a/py/ngff_zarr/rfc8/collection.py
+++ b/py/ngff_zarr/rfc8/collection.py
@@ -100,6 +100,16 @@ class NgffCollection:
                 for node in loaded.walk():
                     if node.id == target.id:
                         return loaded.load(node)
+                raise KeyError(
+                    f"Reference id {target.id!r} is not declared by the "
+                    f"document at {target.path.path!r}"
+                )
+            if isinstance(loaded, Node) and loaded.id != target.id:
+                raise KeyError(
+                    f"Reference id {target.id!r} is not declared by the "
+                    f"document at {target.path.path!r}"
+                )
+            # A multiscales image store predates RFC-8 and declares no ids.
             return loaded
         if target.path is not None:
             return self._load_document(target.path)

--- a/py/ngff_zarr/rfc8/collection.py
+++ b/py/ngff_zarr/rfc8/collection.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""The in-memory handle for an RFC-8 node document and its neighborhood."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Union
+
+from .._lru_cache import LRUCache
+from .._supported_versions import NgffVersion
+from .model import Node, OmePath, Reference, is_collection_node
+from .resolve import document_base, resolve_location, resolve_ome_document
+from .serialize import node_from_ome_dict
+
+#: What :meth:`NgffCollection.load` can hand back: a nested collection, a
+#: multiscales image read through :func:`ngff_zarr.from_ome_zarr`, or the
+#: parsed node itself when ngff-zarr has no richer model for its type yet.
+LoadedNode = Union["NgffCollection", "NgffMultiscales", Node]  # noqa: F821
+
+
+@dataclass
+class NgffCollection:
+    """An RFC-8 node document plus the context needed to resolve it.
+
+    ``root`` is typically a :class:`~ngff_zarr.rfc8.model.Collection` but may
+    be any node: RFC-8 lets every node type head a document. ``base`` anchors
+    relative path resolution: the Zarr group directory or URL the document's
+    ``zarr.json`` lives in, or a standalone JSON file's parent. ``None``
+    (a document built in memory) leaves relative paths unresolvable.
+
+    ``root_attributes`` carries the non-OME root attribute keys of the group
+    the document was read from, mirroring
+    :attr:`~ngff_zarr.multiscales.NgffMultiscales.root_attributes`.
+    """
+
+    root: Node
+    base: str | None = None
+    version: str = NgffVersion.V09dev3.value
+    root_attributes: dict[str, Any] | None = None
+    _cache: LRUCache = field(
+        default_factory=lambda: LRUCache(max_size=32),
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def walk(self) -> Iterator[Node]:
+        """Yield every node in the document, depth-first, root first."""
+
+        def _walk(node: Node) -> Iterator[Node]:
+            yield node
+            for child in node.nodes or ():
+                yield from _walk(child)
+
+        return _walk(self.root)
+
+    def node(self, id_or_name: str) -> Node:
+        """The document's node with the given ``id``, else with the ``name``.
+
+        Ids are unique within a document, so they are looked up first; names
+        are only unique among siblings, and the first match in depth-first
+        order wins.
+        """
+        for node in self.walk():
+            if node.id == id_or_name:
+                return node
+        for node in self.walk():
+            if node.name == id_or_name:
+                return node
+        raise KeyError(f"No node with id or name {id_or_name!r} in this document.")
+
+    def load(self, target: Node | Reference | str) -> LoadedNode:
+        """Materialize what ``target`` designates, dereferencing its path.
+
+        ``target`` may be a node of this document (or its ``id`` / ``name``
+        as a string), or a :class:`~ngff_zarr.rfc8.model.Reference`. What
+        comes back depends on what the dereferenced document holds:
+
+        - an RFC-8 collection document nests as another
+          :class:`NgffCollection`, its base moved to the referenced location;
+        - a multiscales image store (any OME-Zarr version up to 0.9.dev1)
+          reads through :func:`ngff_zarr.from_ome_zarr` into
+          :class:`~ngff_zarr.multiscales.NgffMultiscales`;
+        - any other RFC-8 node document returns its parsed root
+          :class:`~ngff_zarr.rfc8.model.Node`.
+
+        An inline node (no ``path``) stays in this document: a collection
+        nests sharing this base, and any other node is returned as parsed.
+        Dereferenced documents are cached per resolved location.
+        """
+        if isinstance(target, str):
+            target = self.node(target)
+        if isinstance(target, Reference):
+            if target.path is None:
+                return self.load(self.node(target.id))
+            loaded = self._load_document(target.path)
+            if isinstance(loaded, NgffCollection):
+                for node in loaded.walk():
+                    if node.id == target.id:
+                        return loaded.load(node)
+            return loaded
+        if target.path is not None:
+            return self._load_document(target.path)
+        if is_collection_node(target):
+            return NgffCollection(root=target, base=self.base, version=self.version)
+        return target
+
+    def _load_document(self, path: OmePath) -> LoadedNode:
+        location = resolve_location(path, base=self.base)
+        cached = self._cache.get((path.type, location))
+        if cached is not None:
+            return cached
+        location, document = resolve_ome_document(path, base=self.base)
+        loaded = self._dispatch_document(path, location, document)
+        self._cache.set((path.type, location), loaded)
+        return loaded
+
+    def _dispatch_document(
+        self, path: OmePath, location: str, document: Mapping[str, Any]
+    ) -> LoadedNode:
+        ome = document.get("ome")
+        node_shaped = (
+            isinstance(ome, Mapping) and "type" in ome and "multiscales" not in ome
+        )
+        if node_shaped:
+            root, declared = node_from_ome_dict(ome)
+            if is_collection_node(root):
+                return NgffCollection(
+                    root=root,
+                    base=document_base(path, location),
+                    version=declared or self.version,
+                )
+            return root
+        has_multiscales = "multiscales" in document or (
+            isinstance(ome, Mapping) and "multiscales" in ome
+        )
+        if has_multiscales:
+            if path.type != "zarr":
+                raise ValueError(
+                    f"The document at '{location}' holds multiscales image "
+                    f"metadata, which only a 'zarr' path can designate; got "
+                    f"path type {path.type!r}."
+                )
+            from ..from_ngff_zarr import from_ome_zarr
+
+            return from_ome_zarr(location)
+        raise ValueError(
+            f"The document at '{location}' is neither an RFC-8 node "
+            f"document nor a multiscales image."
+        )

--- a/py/ngff_zarr/rfc8/io.py
+++ b/py/ngff_zarr/rfc8/io.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Reading and writing RFC-8 node documents (OME-Zarr 0.9.dev3).
+
+The Zarr entry points handle documents stored in a group's ``attributes.ome``;
+the JSON entry points handle the RFC's standalone storage medium, a ``*.json``
+file with a root ``ome`` key. Writing is metadata-only: a collection document
+references image stores, it does not contain their arrays, so the referenced
+stores are written separately (:func:`ngff_zarr.to_ome_zarr`) at their own
+versions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from importlib_resources import files as file_resources
+
+from .._store_types import StoreLike
+from .._supported_versions import NgffVersion
+from .._zarrista_utils import (
+    OME_ROOT_KEYS,
+    consolidate_metadata,
+    create_zarrista_group,
+    has_consolidated_metadata,
+    normalize_store,
+)
+from .collection import NgffCollection
+from .model import Node
+from .resolve import _is_http, _read_json_document
+from .serialize import node_from_ome_dict, node_to_ome_dict
+from .validation import validate_collection
+
+
+def load_rfc8_node_schema() -> dict:
+    """Load the RFC-8 node JSON schema bundled with ngff-zarr.
+
+    RFC-8 has no normative upstream schema yet (the RFC is in draft and
+    ``ome/ngff-spec`` carries none), so unlike the vendored ``spec/0.x``
+    trees this schema is authored in this repository from the RFC text,
+    like the RFC-4 orientation schema beside it.
+    """
+    schema = (
+        file_resources("ngff_zarr")
+        .joinpath(Path("spec") / Path("rfc") / Path("8") / "node.schema.json")
+        .read_text()
+    )
+    return json.loads(schema)
+
+
+def _validate_document(ome: Mapping[str, Any], version: str | None) -> None:
+    """Run the structural rules, then the bundled schema, on a raw document.
+
+    The vendored ``spec/0.9`` tree cannot check a 0.9.dev3 document (its
+    ``_version`` schema enumerates only ``0.9.dev1``, and the tree stays
+    verbatim upstream), so :func:`ngff_zarr.validate` is never involved
+    here; the repo-authored RFC-8 schema is used instead.
+    """
+    validate_collection(ome, version=version)
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        raise ImportError(
+            "jsonschema is required to validate NGFF metadata - install the ngff-zarr[validate] extra"
+        )
+    validator = Draft202012Validator(load_rfc8_node_schema())
+    validator.validate(dict(ome))
+
+
+def _node_document_or_raise(attrs: Mapping[str, Any], where: str) -> Mapping[str, Any]:
+    """The ``ome`` node document in ``attrs``, or a pointed error."""
+    ome = attrs.get("ome")
+    is_image = "multiscales" in attrs or (
+        isinstance(ome, Mapping) and "multiscales" in ome
+    )
+    if is_image:
+        raise ValueError(
+            f"The input at {where} is a multiscales image store, not an "
+            "RFC-8 node document. Read it with from_ome_zarr()."
+        )
+    if not isinstance(ome, Mapping) or "type" not in ome:
+        raise ValueError(
+            f"The input at {where} carries no RFC-8 node document: expected "
+            "an 'ome' object with a 'type' key (OME-Zarr 0.9.dev3)."
+        )
+    return ome
+
+
+def from_collection_zarr(
+    store: StoreLike,
+    validate: bool = False,
+    storage_options: dict | None = None,
+) -> NgffCollection:
+    """Read an RFC-8 node document from a Zarr store's root group.
+
+    Parameters
+    ----------
+    store:
+        Local directory path, remote URL string, or key-to-bytes mapping of
+        a Zarr store whose root group attributes carry the document under
+        ``ome``. The root may be any node type; a collection is typical.
+    validate:
+        Run the RFC-8 structural rules and the bundled node schema against
+        the raw document before parsing.
+    storage_options:
+        Passed to the remote backend for URL stores, as in
+        :func:`ngff_zarr.from_ome_zarr`.
+
+    Returns
+    -------
+    NgffCollection
+        The parsed document with its resolution base set to the store, so
+        relative paths in the document dereference from it.
+    """
+    from .._remote_reader import RemoteZarrStore, remote_read_available
+    from ..from_ngff_zarr import (
+        REMOTE_URL_SCHEMES,
+        _open_root_node,
+        _remote_backend_import_error,
+    )
+
+    base: str | None = None
+    if isinstance(store, str) and store.startswith(REMOTE_URL_SCHEMES):
+        if not remote_read_available():
+            raise _remote_backend_import_error(store, None)
+        base = store.rstrip("/")
+        store = RemoteZarrStore(store, storage_options=storage_options)
+    elif isinstance(store, RemoteZarrStore):
+        base = store.url
+    elif isinstance(store, (str, os.PathLike)):
+        base = str(Path(store).resolve())
+
+    root = _open_root_node(store, None)
+    attrs = root.attrs.asdict()
+    ome = _node_document_or_raise(attrs, f"'{store}'")
+    declared = ome.get("version") if isinstance(ome.get("version"), str) else None
+    if validate:
+        _validate_document(ome, declared)
+    node, declared = node_from_ome_dict(ome)
+    root_attributes = {
+        key: value for key, value in attrs.items() if key not in OME_ROOT_KEYS
+    }
+    return NgffCollection(
+        root=node,
+        base=base,
+        version=declared or NgffVersion.V09dev3.value,
+        root_attributes=root_attributes or None,
+    )
+
+
+def from_collection_json(
+    source: str | os.PathLike | Mapping[str, Any],
+    validate: bool = False,
+) -> NgffCollection:
+    """Read an RFC-8 node document from standalone JSON.
+
+    ``source`` is the path or ``http(s)`` URL of a JSON file whose root
+    object carries the document under ``ome``, or such a parsed object
+    itself. For an in-memory mapping the collection has no resolution base,
+    so its relative paths cannot be dereferenced.
+    """
+    base: str | None = None
+    if isinstance(source, Mapping):
+        document: Mapping[str, Any] = source
+        where = "the given mapping"
+    else:
+        location = str(source)
+        if _is_http(location):
+            base = location.rsplit("/", 1)[0]
+        else:
+            location = str(Path(location).resolve())
+            base = str(Path(location).parent)
+        document = _read_json_document(location)
+        where = f"'{location}'"
+        if not isinstance(document, Mapping):
+            raise ValueError(f"The JSON document at {where} is not an object.")
+    ome = _node_document_or_raise(document, where)
+    declared = ome.get("version") if isinstance(ome.get("version"), str) else None
+    if validate:
+        _validate_document(ome, declared)
+    node, declared = node_from_ome_dict(ome)
+    return NgffCollection(
+        root=node,
+        base=base,
+        version=declared or NgffVersion.V09dev3.value,
+    )
+
+
+def _collection_root(collection: NgffCollection | Node) -> Node:
+    if isinstance(collection, NgffCollection):
+        return collection.root
+    if isinstance(collection, Node):
+        return collection
+    raise TypeError(
+        f"Expected an NgffCollection or a Node; got {type(collection).__name__}."
+    )
+
+
+def _check_collection_version(version: str) -> str:
+    if str(version) != NgffVersion.V09dev3.value:
+        raise ValueError(
+            f"Unsupported version for an RFC-8 node document: {version!r}. "
+            "Only '0.9.dev3' stores the node model."
+        )
+    return NgffVersion.V09dev3.value
+
+
+def to_collection_zarr(
+    store: StoreLike,
+    collection: NgffCollection | Node,
+    version: str = "0.9.dev3",
+    overwrite: bool = True,
+    validate: bool = True,
+    root_attributes: Mapping[str, Any] | None = None,
+) -> None:
+    """Write an RFC-8 node document as a Zarr store's root group.
+
+    Writes metadata only: a Zarr format 3 group whose ``attributes.ome`` is
+    the serialized document. The stores the document references are written
+    separately. ``root_attributes`` (or, when omitted, the collection's own
+    ``root_attributes``) are written beside the OME key.
+
+    ``overwrite`` replaces the root group's metadata document, keeping its
+    non-OME attributes; unlike :func:`ngff_zarr.to_ome_zarr` it never removes
+    the tree beneath the root, which commonly holds the very stores the
+    document references. Without ``overwrite`` the document is merged into an
+    existing root's attributes. Consolidated root metadata is refreshed when
+    the store already carries it.
+    """
+    from ..to_ngff_zarr import _check_root_attributes, _foreign_root_attrs
+
+    version = _check_collection_version(version)
+    root = _collection_root(collection)
+    if validate:
+        validate_collection(root, version=version)
+    if root_attributes is None and isinstance(collection, NgffCollection):
+        root_attributes = collection.root_attributes
+    store_path = normalize_store(store)
+    consolidated = has_consolidated_metadata(store_path, 3)
+    attributes: dict[str, Any] = {}
+    if overwrite:
+        # Replace the root metadata document, but never the tree beneath it:
+        # a collection root commonly holds the very stores its document
+        # references, so the recursive removal ``to_ome_zarr`` performs on
+        # overwrite would destroy them. Non-OME root attributes survive.
+        attributes.update(_foreign_root_attrs(store_path))
+        store_path.mkdir(parents=True, exist_ok=True)
+        (store_path / "zarr.json").unlink(missing_ok=True)
+    attributes.update(_check_root_attributes(root_attributes))
+    attributes["ome"] = node_to_ome_dict(root, version=version)
+    create_zarrista_group(store_path, attributes, 3)
+    if consolidated:
+        consolidate_metadata(store_path, zarr_format=3)
+
+
+def to_collection_json(
+    collection: NgffCollection | Node,
+    path: str | os.PathLike | None = None,
+    version: str = "0.9.dev3",
+    validate: bool = True,
+) -> dict[str, Any]:
+    """Serialize an RFC-8 node document to standalone JSON.
+
+    Returns the ``{"ome": ...}`` document; when ``path`` is given it is also
+    written there as UTF-8 JSON.
+    """
+    version = _check_collection_version(version)
+    root = _collection_root(collection)
+    if validate:
+        validate_collection(root, version=version)
+    document = {"ome": node_to_ome_dict(root, version=version)}
+    if path is not None:
+        Path(path).write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return document

--- a/py/ngff_zarr/rfc8/io.py
+++ b/py/ngff_zarr/rfc8/io.py
@@ -17,6 +17,7 @@ import os
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
 from importlib_resources import files as file_resources
 
@@ -170,7 +171,7 @@ def from_collection_json(
     else:
         location = str(source)
         if _is_http(location):
-            base = location.rsplit("/", 1)[0]
+            base = urljoin(location, ".").rstrip("/")
         else:
             location = str(Path(location).resolve())
             base = str(Path(location).parent)

--- a/py/ngff_zarr/rfc8/model.py
+++ b/py/ngff_zarr/rfc8/model.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""The RFC-8 node model: typed paths, references, nodes and collections.
+
+RFC-8 ("Collections and Extensibility",
+https://ngff.openmicroscopy.org/rfc/8/index.html) replaces the ``multiscales``
+wrapper with a typed node document stored under the ``ome`` key of a Zarr
+group's attributes or of a standalone JSON file. This module holds the
+in-memory model of that document; serialization lives in
+:mod:`ngff_zarr.rfc8.serialize` and the structural rules in
+:mod:`ngff_zarr.rfc8.validation`.
+
+The model is deliberately open-world. RFC-8 declares node types, attribute
+keys and path types as extension points, so a node of a type this package has
+no dedicated class for (a prefixed extension type, or ``"multiscale"`` /
+``"singlescale"`` until issue #714's later stages land) is carried as a
+generic :class:`Node` and round-trips unchanged, and ``attributes`` is opaque
+JSON whose prefixed extension keys (e.g. ``mobie:grid``) are preserved
+verbatim, never interpreted.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+#: The RFC-8 id production, shared by node ids and reference ids.
+RFC8_ID_PATTERN = re.compile(r"[a-zA-Z0-9\-_.]+\Z")
+
+#: Path type for a node stored in a Zarr group: implementations append
+#: ``zarr.json`` to the path to reach the metadata document.
+PATH_TYPE_ZARR = "zarr"
+
+#: Path type for a node stored in a standalone JSON file: the path is the
+#: metadata document itself.
+PATH_TYPE_JSON = "json"
+
+
+def is_prefixed_identifier(value: str) -> bool:
+    """Whether ``value`` is a prefixed extension identifier (``prefix:name``).
+
+    Unprefixed identifiers are reserved for the core specification; custom
+    extensions introduce prefixed ones, where the prefix names the user or
+    organization maintaining the extension.
+    """
+    prefix, separator, name = value.partition(":")
+    return bool(separator) and bool(prefix) and bool(name)
+
+
+@dataclass(frozen=True)
+class OmePath:
+    """RFC-8 ``Path``: a typed locator for out-of-document metadata.
+
+    ``type`` is :data:`PATH_TYPE_ZARR`, :data:`PATH_TYPE_JSON`, or a prefixed
+    extension type (e.g. ``"myorg:zip"``). ``path`` is a relative path
+    (IETF RFC 1808, resolved against the document that holds it), an absolute
+    ``file://`` path (IETF RFC 8089), or an ``http(s)://`` URL
+    (IETF RFC 1738).
+
+    Named ``OmePath`` rather than the RFC's bare ``Path``: half this package
+    imports :class:`pathlib.Path` unqualified.
+    """
+
+    type: str
+    path: str
+
+
+@dataclass(frozen=True)
+class Reference:
+    """RFC-8 ``Reference`` to a node or coordinate system by ``id``.
+
+    ``path`` locates the document that declares the referenced ``id``; it is
+    required for external references and omitted for in-document ones.
+    """
+
+    id: str
+    path: OmePath | None = None
+
+
+@dataclass
+class Node:
+    """RFC-8 ``Node``: the base of every 0.9.dev3 metadata document.
+
+    ``type`` and ``name`` are required by the RFC; ``id`` (unique within the
+    JSON document), ``attributes``, and the container fields ``nodes`` /
+    ``path`` are optional. Exactly one of ``nodes`` and ``path`` must be
+    present on the node types that define them; that is a validation rule
+    (:func:`ngff_zarr.rfc8.validate_collection`), not a constructor error, so
+    an invalid document can be parsed, inspected and repaired.
+
+    ``extra`` captures unrecognized top-level node keys on read and is
+    serialized back on write: unlike the ``extra`` of the multiscales
+    metadata models, RFC-8 extensions must survive a round trip. No node
+    carries a ``version`` field; the serializer stamps the root's.
+    """
+
+    type: str
+    name: str
+    id: str | None = field(default=None, kw_only=True)
+    attributes: dict[str, Any] | None = field(default=None, kw_only=True)
+    nodes: list[Node] | None = field(default=None, kw_only=True)
+    path: OmePath | None = field(default=None, kw_only=True)
+    extra: dict[str, Any] = field(default_factory=dict, kw_only=True, repr=False)
+
+
+@dataclass
+class Collection(Node):
+    """A ``type == "collection"`` node: an arbitrary group of nodes."""
+
+    type: str = field(default="collection", init=False)
+
+
+def is_collection_node(node: Node) -> bool:
+    """Whether ``node`` is a collection, whichever class carries it."""
+    return node.type == "collection"

--- a/py/ngff_zarr/rfc8/resolve.py
+++ b/py/ngff_zarr/rfc8/resolve.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Dereferencing of RFC-8 typed paths to the documents they locate.
+
+A resolved document is the raw mapping the path's type designates: a Zarr
+group's attribute dict for ``"zarr"`` (the group's ``zarr.json`` attributes,
+with a Zarr format 2 fallback), or a standalone JSON file's root object for
+``"json"``. Interpreting what the document holds -- an RFC-8 node, a
+multiscales image, something else -- is the caller's concern
+(:meth:`ngff_zarr.rfc8.NgffCollection.load`).
+
+Per the RFC's security considerations, nothing here restricts where a path
+may point: a relative path can climb out of the collection's directory and a
+URL can name any host. Callers resolving untrusted collection documents
+should check :func:`resolve_location` results before fetching.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+from urllib.request import url2pathname, urlopen
+
+from .._remote_reader import remote_read_available
+from .model import PATH_TYPE_JSON, PATH_TYPE_ZARR, OmePath
+
+_HTTP_SCHEMES = ("http://", "https://")
+
+
+def _is_http(location: str) -> bool:
+    return location.startswith(_HTTP_SCHEMES)
+
+
+def resolve_location(path: OmePath, *, base: str | None = None) -> str:
+    """Resolve a path's location string against the document base.
+
+    ``base`` is the directory-like location of the document that carries the
+    path: the Zarr group directory or URL for a document stored in group
+    attributes, the parent directory or URL of a standalone JSON file. A
+    relative path (IETF RFC 1808) is resolved against it; ``file://`` paths
+    (IETF RFC 8089) and ``http(s)://`` URLs stand alone.
+    """
+    location = path.path
+    if _is_http(location):
+        return location
+    if location.startswith("file://"):
+        parsed = urlparse(location)
+        # RFC 8089 permits a Windows drive in the authority position
+        # (``file://C:/...``); rejoin it with the path before decoding.
+        return url2pathname(f"{parsed.netloc}{parsed.path}")
+    if base is None:
+        return str(Path(location))
+    if _is_http(base):
+        return urljoin(base.rstrip("/") + "/", location)
+    return str((Path(base) / location).resolve())
+
+
+def document_base(path: OmePath, location: str) -> str:
+    """The base future relative paths in the resolved document count from.
+
+    A ``"zarr"`` path's document lives in the group's own attributes, so the
+    group location is the base; a ``"json"`` path's document is the file, so
+    its parent is.
+    """
+    if path.type == PATH_TYPE_ZARR:
+        return location
+    if _is_http(location):
+        return urljoin(location, ".").rstrip("/")
+    return str(Path(location).parent)
+
+
+def _read_zarr_document(location: str) -> dict[str, Any] | None:
+    if _is_http(location):
+        from .._remote_reader import RemoteZarrStore, open_remote_node
+
+        if not remote_read_available():
+            from ..from_ngff_zarr import _remote_backend_import_error
+
+            raise _remote_backend_import_error(location, None)
+        node = open_remote_node(RemoteZarrStore(location))
+        return None if node is None else node.attrs.asdict()
+
+    from .._zarrista_utils import read_group_attributes
+
+    attributes = read_group_attributes(location, zarr_format=3)
+    if not attributes:
+        # A bare or spuriously empty ``zarr.json``: take the format 2
+        # documents when they are actually there.
+        fallback = read_group_attributes(location, zarr_format=2)
+        if fallback is not None:
+            return fallback
+    return attributes
+
+
+def _read_json_document(location: str) -> Any:
+    if _is_http(location):
+        with urlopen(location) as response:
+            return json.loads(response.read().decode("utf-8"))
+    return json.loads(Path(location).read_text(encoding="utf-8"))
+
+
+def resolve_ome_document(
+    path: OmePath, *, base: str | None = None
+) -> tuple[str, dict[str, Any]]:
+    """Load the document an RFC-8 path locates.
+
+    Returns ``(resolved location, document)``, where the document is the Zarr
+    group's attribute mapping or the JSON file's root object. A prefixed
+    extension path type is opaque to this package and reported as such.
+    """
+    if path.type not in (PATH_TYPE_ZARR, PATH_TYPE_JSON):
+        raise ValueError(
+            f"Path type {path.type!r} is not resolvable by ngff-zarr; only "
+            f"'zarr' and 'json' paths are. A prefixed extension type is "
+            f"opaque to implementations that do not recognize it."
+        )
+    location = resolve_location(path, base=base)
+    if path.type == PATH_TYPE_ZARR:
+        document = _read_zarr_document(location)
+        if document is None:
+            raise ValueError(
+                f"No Zarr group with attributes found at '{location}' "
+                f"(resolved from path '{path.path}')."
+            )
+        return location, document
+    document = _read_json_document(location)
+    if not isinstance(document, dict):
+        raise ValueError(
+            f"The JSON document at '{location}' (resolved from path "
+            f"'{path.path}') is not an object."
+        )
+    return location, document

--- a/py/ngff_zarr/rfc8/resolve.py
+++ b/py/ngff_zarr/rfc8/resolve.py
@@ -51,6 +51,12 @@ def resolve_location(path: OmePath, *, base: str | None = None) -> str:
         # (``file://C:/...``); rejoin it with the path before decoding.
         return url2pathname(f"{parsed.netloc}{parsed.path}")
     if base is None:
+        if not Path(location).is_absolute():
+            raise ValueError(
+                f"The relative path {location!r} cannot be resolved: the "
+                "document has no resolution base (it was loaded from an "
+                "in-memory mapping)."
+            )
         return str(Path(location))
     if _is_http(base):
         return urljoin(base.rstrip("/") + "/", location)

--- a/py/ngff_zarr/rfc8/serialize.py
+++ b/py/ngff_zarr/rfc8/serialize.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Serialization between the RFC-8 node model and its ``ome`` document."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+from .model import Collection, Node, OmePath
+
+#: The node keys this package models; everything else round-trips through
+#: ``Node.extra``. ``version`` is the root-only key handled by the (de)serializer.
+_NODE_FIELDS = frozenset({"type", "id", "name", "attributes", "nodes", "path"})
+
+
+def node_to_ome_dict(node: Node, *, version: str | None = None) -> dict[str, Any]:
+    """Serialize a node tree to the dict stored as the ``ome`` value.
+
+    ``version`` stamps the root node (the RFC-8 root-only key) and is never
+    passed down to children. ``attributes`` is deep-copied verbatim, unknown
+    and prefixed keys included, and so are the ``extra`` keys, emitted after
+    the modeled ones in their captured order. ``None``-valued optional fields
+    are omitted rather than written as JSON ``null``.
+    """
+    out: dict[str, Any] = {}
+    if version is not None:
+        out["version"] = str(version)
+    out["type"] = node.type
+    if node.id is not None:
+        out["id"] = node.id
+    out["name"] = node.name
+    if node.attributes is not None:
+        out["attributes"] = copy.deepcopy(node.attributes)
+    if node.nodes is not None:
+        out["nodes"] = [node_to_ome_dict(child) for child in node.nodes]
+    if node.path is not None:
+        out["path"] = {"type": node.path.type, "path": node.path.path}
+    for key, value in node.extra.items():
+        out[key] = copy.deepcopy(value)
+    return out
+
+
+def _require_str(value: Any, key: str, location: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            f"An RFC-8 node must declare a non-empty string {key!r}; "
+            f"got {value!r} at {location}."
+        )
+    return value
+
+
+def _node_from_dict(data: Mapping[str, Any], location: str) -> Node:
+    """Parse one node dict, recursing into ``nodes``.
+
+    The parser guarantees the model invariants (well-typed core keys) and is
+    otherwise open-world: unknown keys land in ``extra`` and unknown node
+    types produce a generic :class:`Node`. Rule violations a document can
+    express without breaking the model, such as carrying both ``nodes`` and
+    ``path``, parse fine and are reported by
+    :func:`ngff_zarr.rfc8.validate_collection`.
+    """
+    node_type = _require_str(data.get("type"), "type", location)
+    name = _require_str(data.get("name"), "name", location)
+
+    node_id = data.get("id")
+    if node_id is not None and not isinstance(node_id, str):
+        raise ValueError(
+            f"An RFC-8 node 'id' must be a string; got {node_id!r} at {location}."
+        )
+
+    attributes = data.get("attributes")
+    if attributes is not None:
+        if not isinstance(attributes, Mapping):
+            raise ValueError(
+                f"An RFC-8 node 'attributes' must be an object; "
+                f"got {attributes!r} at {location}."
+            )
+        attributes = copy.deepcopy(dict(attributes))
+
+    raw_nodes = data.get("nodes")
+    nodes: list[Node] | None = None
+    if raw_nodes is not None:
+        if not isinstance(raw_nodes, list):
+            raise ValueError(
+                f"An RFC-8 node 'nodes' must be an array of nodes; "
+                f"got {raw_nodes!r} at {location}."
+            )
+        nodes = []
+        for index, child in enumerate(raw_nodes):
+            child_location = f"{location}.nodes[{index}]"
+            if not isinstance(child, Mapping):
+                raise ValueError(
+                    f"An RFC-8 node 'nodes' entry must be an object; "
+                    f"got {child!r} at {child_location}."
+                )
+            nodes.append(_node_from_dict(child, child_location))
+
+    raw_path = data.get("path")
+    path: OmePath | None = None
+    if raw_path is not None:
+        if not isinstance(raw_path, Mapping):
+            raise ValueError(
+                f"An RFC-8 node 'path' must be an object with 'type' and "
+                f"'path'; got {raw_path!r} at {location}."
+            )
+        path = OmePath(
+            type=_require_str(raw_path.get("type"), "path.type", location),
+            path=_require_str(raw_path.get("path"), "path.path", location),
+        )
+
+    extra = {
+        key: copy.deepcopy(value)
+        for key, value in data.items()
+        if key not in _NODE_FIELDS
+    }
+
+    if node_type == "collection":
+        node = Collection(
+            name,
+            id=node_id,
+            attributes=attributes,
+            nodes=nodes,
+            path=path,
+            extra=extra,
+        )
+    else:
+        node = Node(
+            type=node_type,
+            name=name,
+            id=node_id,
+            attributes=attributes,
+            nodes=nodes,
+            path=path,
+            extra=extra,
+        )
+    return node
+
+
+def node_from_ome_dict(data: Mapping[str, Any]) -> tuple[Node, str | None]:
+    """Parse an ``ome`` value into ``(root node, declared version)``.
+
+    The root's ``version`` key is returned separately rather than modeled on
+    the node: RFC-8 puts it on the root only, and the serializer stamps it
+    back. A non-string ``version`` is reported rather than carried.
+    """
+    if not isinstance(data, Mapping):
+        raise ValueError(f"An RFC-8 'ome' value must be an object; got {data!r}.")
+    version = data.get("version")
+    if version is not None and not isinstance(version, str):
+        raise ValueError(f"An RFC-8 'version' must be a string; got {version!r}.")
+    root_data = {key: value for key, value in data.items() if key != "version"}
+    return _node_from_dict(root_data, "ome"), version

--- a/py/ngff_zarr/rfc8/validation.py
+++ b/py/ngff_zarr/rfc8/validation.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Structural validation of RFC-8 node documents.
+
+The seven node/collection rules extend the canonical rule table in
+:mod:`ngff_zarr.structural_validation` (whose :class:`SpecRule` enum declares
+their identifiers) and are dispatched by :func:`validate_collection`, a
+sibling of ``validate_plate`` / ``validate_well`` for the RFC-8 document
+kind. The rules walk the raw ``ome`` dict rather than the parsed model, so a
+document the parser refuses (for instance one whose node lacks a ``type``)
+can still be diagnosed with a stable rule identifier.
+
+Shape errors beyond the rules, such as ``nodes`` not being an array, are the
+JSON-schema pass's concern; the walker skips what it cannot traverse.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+from ..structural_validation import (
+    SpecRule,
+    ValidateOptions,
+    ValidationError,
+    ValidationLevel,
+    is_rfc8_node_model,
+)
+from .model import RFC8_ID_PATTERN, Node, is_prefixed_identifier
+from .serialize import node_to_ome_dict
+
+#: The node types whose schema declares the ``nodes`` / ``path`` pair, and for
+#: which exactly one of the two must be present. Unknown and extension node
+#: types are exempt (open-world). Issue #714's multiscale stage adds
+#: ``"multiscale"`` here rather than introducing a new rule.
+XOR_NODE_TYPES = frozenset({"collection"})
+
+#: The unprefixed path types the core specification defines.
+CORE_PATH_TYPES = frozenset({"zarr", "json"})
+
+
+def _iter_nodes(
+    node: Mapping[str, Any], location: str
+) -> Iterator[tuple[str, Mapping[str, Any]]]:
+    """Yield ``(location, node_dict)`` over the tree, depth-first, root first."""
+    yield location, node
+    children = node.get("nodes")
+    if isinstance(children, list):
+        for index, child in enumerate(children):
+            if isinstance(child, Mapping):
+                yield from _iter_nodes(child, f"{location}.nodes[{index}]")
+
+
+def _require_nonempty_str(
+    document: Mapping[str, Any], key: str, rule: SpecRule
+) -> None:
+    for location, node in _iter_nodes(document, "ome"):
+        value = node.get(key)
+        if not isinstance(value, str) or not value:
+            raise ValidationError(
+                rule,
+                f"Node must declare a non-empty string {key!r}; got {value!r}.",
+                location,
+            )
+
+
+def validate_node_type_required(document: Mapping[str, Any]) -> None:
+    """Validate that every node declares a non-empty string ``type``.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.NODE_TYPE_REQUIRED` for the first node, in
+        depth-first order, whose ``type`` is missing, empty, or not a string;
+        location e.g. ``ome.nodes[1]``.
+    """
+    _require_nonempty_str(document, "type", SpecRule.NODE_TYPE_REQUIRED)
+
+
+def validate_node_name_required(document: Mapping[str, Any]) -> None:
+    """Validate that every node declares a non-empty string ``name``.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.NODE_NAME_REQUIRED` for the first node, in
+        depth-first order, whose ``name`` is missing, empty, or not a string;
+        location e.g. ``ome.nodes[1]``.
+    """
+    _require_nonempty_str(document, "name", SpecRule.NODE_NAME_REQUIRED)
+
+
+def validate_node_name_unique(document: Mapping[str, Any]) -> None:
+    """Validate that sibling nodes carry distinct names.
+
+    RFC-8 requires names to be unique within the enclosing collection; two
+    nodes in different collections may share one.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.NODE_NAME_UNIQUE` for the first child node, in
+        depth-first order, whose ``name`` repeats an earlier sibling's;
+        location e.g. ``ome.nodes[2]``.
+    """
+    for location, node in _iter_nodes(document, "ome"):
+        children = node.get("nodes")
+        if not isinstance(children, list):
+            continue
+        seen: set[str] = set()
+        for index, child in enumerate(children):
+            if not isinstance(child, Mapping):
+                continue
+            name = child.get("name")
+            if not isinstance(name, str):
+                continue
+            if name in seen:
+                raise ValidationError(
+                    SpecRule.NODE_NAME_UNIQUE,
+                    f"Node name {name!r} is repeated; node names must be "
+                    f"unique within the enclosing collection.",
+                    f"{location}.nodes[{index}]",
+                )
+            seen.add(name)
+
+
+def validate_node_id_format(document: Mapping[str, Any]) -> None:
+    """Validate that every declared node id matches ``[a-zA-Z0-9-_.]+``.
+
+    The id production is shared with references, so later RFC-8 stages
+    report reference ids under this same rule.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.NODE_ID_FORMAT` for the first node, in
+        depth-first order, whose ``id`` is not a match; location e.g.
+        ``ome.nodes[0].id``.
+    """
+    for location, node in _iter_nodes(document, "ome"):
+        value = node.get("id")
+        if value is None:
+            continue
+        if not isinstance(value, str) or not RFC8_ID_PATTERN.match(value):
+            raise ValidationError(
+                SpecRule.NODE_ID_FORMAT,
+                f"Id {value!r} does not match [a-zA-Z0-9-_.]+.",
+                f"{location}.id",
+            )
+
+
+def validate_node_id_unique(document: Mapping[str, Any]) -> None:
+    """Validate that ids are unique within the JSON document.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.NODE_ID_UNIQUE` for the first node, in
+        depth-first order, whose ``id`` repeats an earlier one; location
+        e.g. ``ome.nodes[3].id``.
+    """
+    seen: set[str] = set()
+    for location, node in _iter_nodes(document, "ome"):
+        value = node.get("id")
+        if not isinstance(value, str):
+            continue
+        if value in seen:
+            raise ValidationError(
+                SpecRule.NODE_ID_UNIQUE,
+                f"Id {value!r} is already used in this document; ids must "
+                f"be unique within the JSON document.",
+                f"{location}.id",
+            )
+        seen.add(value)
+
+
+def validate_node_nodes_xor_path(document: Mapping[str, Any]) -> None:
+    """Validate that a collection carries exactly one of ``nodes`` / ``path``.
+
+    Applies to the node types in :data:`XOR_NODE_TYPES`; unknown and
+    extension node types are exempt.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.NODE_NODES_XOR_PATH` for the first applicable
+        node, in depth-first order, declaring both or neither; location e.g.
+        ``ome.nodes[1]``.
+    """
+    for location, node in _iter_nodes(document, "ome"):
+        if node.get("type") not in XOR_NODE_TYPES:
+            continue
+        has_nodes = node.get("nodes") is not None
+        has_path = node.get("path") is not None
+        if has_nodes and has_path:
+            raise ValidationError(
+                SpecRule.NODE_NODES_XOR_PATH,
+                "Node declares both 'nodes' and 'path'; exactly one must be present.",
+                location,
+            )
+        if not has_nodes and not has_path:
+            raise ValidationError(
+                SpecRule.NODE_NODES_XOR_PATH,
+                "Node declares neither 'nodes' nor 'path'; exactly one must "
+                "be present.",
+                location,
+            )
+
+
+def validate_path_type_known(document: Mapping[str, Any]) -> None:
+    """Validate that every path ``type`` is ``zarr``, ``json``, or prefixed.
+
+    Unprefixed identifiers are reserved for the core specification, which
+    defines exactly ``zarr`` and ``json``; a prefixed identifier
+    (``prefix:name``) belongs to the extension that registered the prefix
+    and passes as opaque.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.PATH_TYPE_KNOWN` for the first node, in
+        depth-first order, whose path ``type`` is missing, empty, not a
+        string, or an unprefixed identifier outside the core set; location
+        e.g. ``ome.nodes[1].path.type``.
+    """
+    for location, node in _iter_nodes(document, "ome"):
+        path = node.get("path")
+        if not isinstance(path, Mapping):
+            continue
+        value = path.get("type")
+        if not isinstance(value, str) or not value:
+            raise ValidationError(
+                SpecRule.PATH_TYPE_KNOWN,
+                f"Path must declare a non-empty string 'type'; got {value!r}.",
+                f"{location}.path.type",
+            )
+        if value in CORE_PATH_TYPES or is_prefixed_identifier(value):
+            continue
+        raise ValidationError(
+            SpecRule.PATH_TYPE_KNOWN,
+            f"Path type {value!r} is not 'zarr', 'json', or a prefixed extension type.",
+            f"{location}.path.type",
+        )
+
+
+#: The RFC-8 rules in canonical evaluation order (the SpecRule declaration
+#: order), dispatched fail-fast by :func:`validate_collection`.
+_COLLECTION_RULES = (
+    validate_node_type_required,
+    validate_node_name_required,
+    validate_node_name_unique,
+    validate_node_id_format,
+    validate_node_id_unique,
+    validate_node_nodes_xor_path,
+    validate_path_type_known,
+)
+
+
+def validate_collection(
+    root: Mapping[str, Any] | Node,
+    version: object | None = None,
+    options: ValidateOptions | None = None,
+) -> None:
+    """Run the RFC-8 node/collection rules in canonical order, fail-fast.
+
+    ``root`` is either the raw ``ome`` dict or a parsed
+    :class:`~ngff_zarr.rfc8.model.Node` tree (serialized before checking, so
+    both forms are judged by the same walker). Names and ids are checked per
+    document: nodes a ``path`` points at live in their own documents and are
+    validated when those are read.
+
+    ``version`` gates the rules the RFC-4 way: they run when it is ``None``
+    (a document with no declared version gets the strict reading) or when
+    :func:`~ngff_zarr.structural_validation.is_rfc8_node_model` says the
+    version stores the node model, and are inert when an earlier version is
+    declared.
+
+    Raises
+    ------
+    ValidationError
+        From the first violated rule, with its :class:`SpecRule` and a
+        dotted-segment location.
+    """
+    options = options or ValidateOptions()
+    if options.level == ValidationLevel.SCHEMA_ONLY:
+        return
+    if version is not None and not is_rfc8_node_model(version):
+        return
+    document = node_to_ome_dict(root) if isinstance(root, Node) else root
+    for rule in _COLLECTION_RULES:
+        rule(document)

--- a/py/ngff_zarr/spec/rfc/8/node.schema.json
+++ b/py/ngff_zarr/spec/rfc/8/node.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://w3id.org/ome/ngff/rfc/8/node.schema.json",
+  "title": "RFC-8 node document",
+  "description": "The value of the `ome` key of an OME-Zarr 0.9.dev3 metadata document: a typed node, optionally a collection of nested or path-referenced nodes. Authored in ngff-zarr from the RFC-8 draft text (https://ngff.openmicroscopy.org/rfc/8/index.html); RFC-8 publishes no normative JSON schema yet.",
+  "$ref": "#/$defs/node",
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0.9.dev3"]
+    }
+  },
+  "required": ["version"],
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9\\-_.]+$"
+    },
+    "path": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "anyOf": [
+            { "enum": ["zarr", "json"] },
+            { "pattern": "^[^:]+:.+$" }
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["type", "path"],
+      "additionalProperties": false
+    },
+    "reference": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "path": { "$ref": "#/$defs/path" }
+      },
+      "required": ["id"]
+    },
+    "node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": { "$ref": "#/$defs/id" },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "attributes": {
+          "type": "object"
+        },
+        "nodes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/node" }
+        },
+        "path": { "$ref": "#/$defs/path" }
+      },
+      "required": ["type", "name"],
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "collection" } }
+          },
+          "then": {
+            "oneOf": [
+              { "required": ["nodes"], "not": { "required": ["path"] } },
+              { "required": ["path"], "not": { "required": ["nodes"] } }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/py/ngff_zarr/structural_validation.py
+++ b/py/ngff_zarr/structural_validation.py
@@ -81,6 +81,27 @@ violation, in canonical spec-MUST order.
 #   well-acquisition-missing
 #       each well image references an acquisition when the plate declares many
 #       e.g. well.images[0].acquisition
+#   node-type-required
+#       every RFC-8 node declares a non-empty string type; from 0.9.dev3
+#       e.g. ome.nodes[1]
+#   node-name-required
+#       every RFC-8 node declares a non-empty string name; from 0.9.dev3
+#       e.g. ome.nodes[1]
+#   node-name-unique
+#       sibling RFC-8 nodes carry distinct names; from 0.9.dev3
+#       e.g. ome.nodes[2]
+#   node-id-format
+#       RFC-8 node and reference ids match [a-zA-Z0-9-_.]+; from 0.9.dev3
+#       e.g. ome.nodes[0].id
+#   node-id-unique
+#       RFC-8 ids are unique within the JSON document; from 0.9.dev3
+#       e.g. ome.nodes[3].id
+#   node-nodes-xor-path
+#       a collection carries exactly one of nodes or path; from 0.9.dev3
+#       e.g. ome.nodes[1]
+#   path-type-known
+#       an RFC-8 path type is zarr, json, or prefixed; from 0.9.dev3
+#       e.g. ome.nodes[1].path.type
 
 from __future__ import annotations
 
@@ -88,7 +109,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from ._supported_versions import NgffVersion, is_v06_version
+from ._supported_versions import V09_DEV_SERIES, NgffVersion, is_v06_version
 
 if TYPE_CHECKING:
     from .v04.zarr_metadata import Axis, Dataset, Metadata, Plate, Transform, Well
@@ -118,6 +139,13 @@ class SpecRule(StrEnum):
     OME_NAMESPACE = "ome-namespace"
     PLATE_ROW_INDEX_CONSISTENCY = "plate-row-index-consistency"
     WELL_ACQUISITION_MISSING = "well-acquisition-missing"
+    NODE_TYPE_REQUIRED = "node-type-required"
+    NODE_NAME_REQUIRED = "node-name-required"
+    NODE_NAME_UNIQUE = "node-name-unique"
+    NODE_ID_FORMAT = "node-id-format"
+    NODE_ID_UNIQUE = "node-id-unique"
+    NODE_NODES_XOR_PATH = "node-nodes-xor-path"
+    PATH_TYPE_KNOWN = "path-type-known"
 
 
 class ValidationLevel(StrEnum):
@@ -355,34 +383,52 @@ def _takes_array_schema_branch(axes: list, version: object | None) -> bool:
 def is_rfc3_axis_model_allowed(version: object | None = None) -> bool:
     """Whether ``version`` adopts the RFC-3 free-form axis model.
 
-    Only OME-Zarr ``0.9.dev1`` does: the bundled 0.4, 0.5 and 0.6 ``axes``
-    schemas all cap the axis count at 5, and require 2 or 3 ``space`` axes
-    (0.6 excepted for an ``array`` coordinate system, see
+    Only the OME-Zarr 0.9 development series does: the bundled 0.4, 0.5 and
+    0.6 ``axes`` schemas all cap the axis count at 5, and require 2 or 3
+    ``space`` axes (0.6 excepted for an ``array`` coordinate system, see
     :func:`_takes_array_schema_branch`). ``None`` applies the restrictions.
 
-    Compared by string equality: a dev release precedes its release, so
-    ``packaging.version.parse("0.9.dev1")`` sorts below ``0.9`` and a ``>=``
-    test against ``"0.9"`` is ``False``.
+    Compared by string equality against each series member: a dev release
+    precedes its release, so ``packaging.version.parse("0.9.dev1")`` sorts
+    below ``0.9`` and a ``>=`` test against ``"0.9"`` is ``False``.
     """
-    return version is not None and version == NgffVersion.V09dev1
+    return version is not None and version in V09_DEV_SERIES
 
 
 def is_rfc4_orientation_enforced(version: object | None = None) -> bool:
     """Whether ``version`` makes the RFC-4 orientation rules normative.
 
-    Only OME-Zarr ``0.9.dev1`` does (``ome/ngff-spec#190`` folds RFC-4 into
-    it): the released 0.4, 0.5 and 0.6 specs give ``orientation`` no normative
-    status, so when the caller declares one of those versions the orientation
-    rules are inert. ``None`` keeps them on: with no declared version,
-    enforcement is a strictness choice, exactly like ``axis-names-unique``
-    below 0.9.dev1 (see docs/validation/rule-reference.md).
+    Only the OME-Zarr 0.9 development series does (``ome/ngff-spec#190``
+    folds RFC-4 into 0.9.dev1, and 0.9.dev3 extends 0.9.dev1): the released
+    0.4, 0.5 and 0.6 specs give ``orientation`` no normative status, so when
+    the caller declares one of those versions the orientation rules are
+    inert. ``None`` keeps them on: with no declared version, enforcement is a
+    strictness choice, exactly like ``axis-names-unique`` below 0.9.dev1 (see
+    docs/validation/rule-reference.md).
 
     The gate points the opposite way from :func:`is_rfc3_axis_model_allowed`:
     at 0.9.dev1 RFC-3 *lifts* the axis restrictions while RFC-4 *adds* the
     orientation requirements, so the rules exit early below 0.9.dev1 rather
     than at it.
     """
-    return version is None or version == NgffVersion.V09dev1
+    return version is None or version in V09_DEV_SERIES
+
+
+def is_rfc8_node_model(version: object | None = None) -> bool:
+    """Whether ``version`` stores the RFC-8 node model under ``ome``.
+
+    Only OME-Zarr ``0.9.dev3`` does: RFC-8 replaces the ``multiscales``
+    wrapper with a typed node document, so this predicate answers a
+    structural question (which document shape a version stores) rather than
+    gating a strictness rule, and ``None`` is ``False``: with no declared
+    version nothing says the document is node-shaped. The RFC-8 collection
+    rules gate themselves the RFC-4 way instead (see
+    :func:`ngff_zarr.rfc8.validate_collection`).
+
+    Compared by equality like the other predicates: a dev release precedes
+    its release under ``packaging.version``, so a ``>=`` test is wrong.
+    """
+    return version is not None and version == NgffVersion.V09dev3
 
 
 def validate_axis_count(metadata: Metadata, version: object | None = None) -> None:

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -292,6 +292,15 @@ def _validate_ngff_parameters(
     if isinstance(version, str):
         version = NgffVersion(version)
 
+    if version == NgffVersion.V09dev3:
+        raise ValueError(
+            'version="0.9.dev3" stores the RFC-8 node model in place of the '
+            "multiscales metadata; writing images at 0.9.dev3 is not "
+            "implemented yet (issue #714). Write the image at 0.9.dev1 and "
+            "reference it from a 0.9.dev3 collection with "
+            "to_collection_zarr()."
+        )
+
     if version not in [
         NgffVersion.V04,
         NgffVersion.V05,

--- a/py/test/fixtures/rfc8/README.md
+++ b/py/test/fixtures/rfc8/README.md
@@ -1,0 +1,19 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# RFC-8 collection example fixtures
+
+Copies of the example documents in
+<https://github.com/normanrz/ngff-rfc8-collection-examples> at commit
+`54250e21f79cbe5d68f20b07dcb00079ef781b4a`, with one normalization: every
+`ome.version` string is set to `0.9.dev3` (the sources carry the draft tags
+`0.8` and `1.0dev891342`), which is the version ngff-zarr gates the RFC-8
+node model on. Everything else is byte-identical to upstream, including the
+extension attributes (`ngio:source`, `webknossos:*`, `mobie:*`) and the
+`mobie_image_labels_table.json` extension path type (`google-sheet`, an
+unprefixed extension identifier that fails `path-type-known` on purpose).
+
+`webknossos_inline_multiscale.json` is a full `zarr.json` document (the
+Zarr-group storage medium); the others are standalone JSON documents with a
+root `ome` key. The TypeScript test suite reads these files from the Python
+tree, like the RFC-5 transform cases.

--- a/py/test/fixtures/rfc8/README.md
+++ b/py/test/fixtures/rfc8/README.md
@@ -5,10 +5,12 @@
 
 Copies of the example documents in
 <https://github.com/normanrz/ngff-rfc8-collection-examples> at commit
-`54250e21f79cbe5d68f20b07dcb00079ef781b4a`, with one normalization: every
+`54250e21f79cbe5d68f20b07dcb00079ef781b4a`, with two normalizations: every
 `ome.version` string is set to `0.9.dev3` (the sources carry the draft tags
 `0.8` and `1.0dev891342`), which is the version ngff-zarr gates the RFC-8
-node model on. Everything else is byte-identical to upstream, including the
+node model on, and the `node_type` of `webknossos_inline_multiscale.json`
+is set to `"group"` (the source carries `"zarr"`, which Zarr v3 does not
+define). Everything else is byte-identical to upstream, including the
 extension attributes (`ngio:source`, `webknossos:*`, `mobie:*`) and the
 `mobie_image_labels_table.json` extension path type (`google-sheet`, an
 unprefixed extension identifier that fails `path-type-known` on purpose).

--- a/py/test/fixtures/rfc8/base_multiscale_collection.json
+++ b/py/test/fixtures/rfc8/base_multiscale_collection.json
@@ -1,0 +1,34 @@
+{
+    "ome": {
+        "id": "7fa2f064-62c5-4d55-9e6c-25acc1aa3a31",
+        "type": "collection",
+        "name": "base-collection",
+        "version": "0.9.dev3",
+        "nodes": [
+            {
+                "id": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad",
+                "type": "multiscale",
+                "name": "image",
+                "path": {
+                    "type": "zarr",
+                    "path": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/"
+                },
+                "attributes": {}
+            },
+            {
+                "id": "5e6979ce-915f-480e-bc4a-695713402968",
+                "type": "multiscale",
+                "name": "image-label",
+                "path": {
+                    "type": "zarr",
+                    "path": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/labels/0/"
+                },
+                "attributes": {
+                    "ngio:source": {
+                        "ref": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/py/test/fixtures/rfc8/external_collection/child_collection.json
+++ b/py/test/fixtures/rfc8/external_collection/child_collection.json
@@ -1,0 +1,35 @@
+{
+    "ome": {
+        "id": "5e6979ce-915f-480e-bc4a-695713402968",
+        "type": "collection",
+        "version": "0.9.dev3",
+        "name": "sub-collection",
+        "nodes": [
+            {
+                "id": "a1b2c3d4-e5f6-7890-1234-56789abcdef0",
+                "type": "multiscale",
+                "name": "image-label",
+                "path": {
+                    "type": "zarr",
+                    "path": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/labels/0/"
+                },
+                "attributes": {
+                    "ngio:source": {
+                        "ref": {
+                            "path": {
+                                "type": "json",
+                                "path": "./parent_collection.json"
+                            },
+                            "id": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad"
+                        }
+                    }
+                }
+            }
+        ],
+        "attributes": {
+            "ex:a": 0,
+            "ex:b": 0,
+            "ex:c": 3
+        }
+    }
+}

--- a/py/test/fixtures/rfc8/external_collection/parent_collection.json
+++ b/py/test/fixtures/rfc8/external_collection/parent_collection.json
@@ -1,0 +1,33 @@
+{
+    "ome": {
+        "id": "7fa2f064-62c5-4d55-9e6c-25acc1aa3a31",
+        "type": "collection",
+        "name": "base-collection",
+        "version": "0.9.dev3",
+        "nodes": [
+            {
+                "id": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad",
+                "type": "multiscale",
+                "name": "image",
+                "path": {
+                    "type": "zarr",
+                    "path": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/"
+                },
+                "attributes": {}
+            },
+            {
+                "id": "5e6979ce-915f-480e-bc4a-695713402968",
+                "type": "collection",
+                "name": "sub-collection",
+                "path": {
+                    "type": "json",
+                    "path": "./child_collection.json"
+                },
+                "attributes": {
+                    "ex:a": 1,
+                    "ex:b": 2
+                }
+            }
+        ]
+    }
+}

--- a/py/test/fixtures/rfc8/external_collection/resolved_collection.json
+++ b/py/test/fixtures/rfc8/external_collection/resolved_collection.json
@@ -1,0 +1,41 @@
+{
+    "ome": {
+        "id": "7fa2f064-62c5-4d55-9e6c-25acc1aa3a31",
+        "type": "collection",
+        "name": "base-collection",
+        "version": "0.9.dev3",
+        "nodes": [
+            {
+                "id": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad",
+                "type": "multiscale",
+                "name": "image",
+                "path": {
+                    "type": "zarr",
+                    "path": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/"
+                },
+                "attributes": {}
+            },
+            {
+                "id": "5e6979ce-915f-480e-bc4a-695713402968",
+                "type": "collection",
+                "name": "sub-collection",
+                "nodes": [
+                    {
+                        "id": "a1b2c3d4-e5f6-7890-1234-56789abcdef0",
+                        "type": "multiscale",
+                        "name": "image-label",
+                        "path": {
+                            "type": "zarr",
+                            "path": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/labels/0/"
+                        },
+                        "attributes": {
+                            "ngio:source": {
+                                "ref": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad"
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/py/test/fixtures/rfc8/mobie_image_labels_table.json
+++ b/py/test/fixtures/rfc8/mobie_image_labels_table.json
@@ -1,0 +1,47 @@
+{
+    "ome": {
+        "id": "7fa2f064-62c5-4d55-9e6c-25acc1aa3a31",
+        "type": "collection",
+        "name": "em_labels_table",
+        "version": "0.9.dev3",
+        "nodes": [
+            {
+                "id": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad",
+                "type": "multiscale",
+                "name": "image",
+                "path": {
+                    "type": "zarr",
+                    "path": "https://s3.embl.de/i2k-2020/platy-raw.ome.zarr"
+                },
+                "attributes": {}
+            },
+            {
+                "id": "5e6979ce-915f-480e-bc4a-695713402968",
+                "type": "multiscale",
+                "name": "labels",
+                "path": {
+                    "type": "zarr",
+                    "path": "https://s3.embl.de/i2k-2020/platy-raw.ome.zarr/labels/cells"
+                },
+                "attributes": {
+                    "mobie:labels_table": {
+                        "ref": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad",
+                        "path": {
+                            "type": "google-sheet",
+                            "path": "https://docs.google.com/spreadsheets/d/1xZ4Zfpg0RUwhPZVCUrX_whB0QGztLN_VVNLx89_rZs4/edit?gid=890359520#gid=890359520"
+                        }
+                    }
+                }
+            },
+            {
+                "id": "5e6979ce-915f-480e-bc4a-695713402969",
+                "type": "mobie:spots_table",
+                "name": "spots",
+                "path": {
+                    "type": "google-sheet",
+                    "path": "https://docs.google.com/spreadsheets/d/1xZ4Zfpg0RUwhPZVCUrX_whB0QGztLN_VVNLx89_rZs4/edit?gid=1367078606#gid=1367078606"
+                }
+            }
+        ]
+    }
+}

--- a/py/test/fixtures/rfc8/nested_collection.json
+++ b/py/test/fixtures/rfc8/nested_collection.json
@@ -1,0 +1,41 @@
+{
+    "ome": {
+        "id": "7fa2f064-62c5-4d55-9e6c-25acc1aa3a31",
+        "type": "collection",
+        "name": "base-collection",
+        "version": "0.9.dev3",
+        "nodes": [
+            {
+                "id": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad",
+                "type": "multiscale",
+                "name": "image",
+                "path": {
+                    "type": "zarr",
+                    "path": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/"
+                },
+                "attributes": {}
+            },
+            {
+                "id": "5e6979ce-915f-480e-bc4a-695713402968",
+                "type": "collection",
+                "name": "sub-collection",
+                "nodes": [
+                    {
+                        "id": "a1b2c3d4-e5f6-7890-1234-56789abcdef0",
+                        "type": "multiscale",
+                        "name": "image-label",
+                        "path": {
+                            "type": "zarr",
+                            "path": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/labels/0/"
+                        },
+                        "attributes": {
+                            "ngio:source": {
+                                "ref": "e4f1e2ee-a52f-46b5-ae1a-543e689cecad"
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/py/test/fixtures/rfc8/webknossos_inline_multiscale.json
+++ b/py/test/fixtures/rfc8/webknossos_inline_multiscale.json
@@ -1,6 +1,6 @@
 {
     "zarr_format": 3,
-    "node_type": "zarr",
+    "node_type": "group",
     "attributes": {
         "ome": {
             "version": "0.9.dev3",

--- a/py/test/fixtures/rfc8/webknossos_inline_multiscale.json
+++ b/py/test/fixtures/rfc8/webknossos_inline_multiscale.json
@@ -1,0 +1,397 @@
+{
+    "zarr_format": 3,
+    "node_type": "zarr",
+    "attributes": {
+        "ome": {
+            "version": "0.9.dev3",
+            "id": "af92b1d8-1b02-46d5-884c-de92b215edb0",
+            "type": "collection",
+            "name": "l4dense_motta_et_al_dev_v2",
+            "attributes": {
+                "webknossos:rendering": {
+                    "coordinate_system": {
+                        "$ref": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e"
+                    },
+                    "position": {
+                        "x": 2850,
+                        "y": 4318,
+                        "z": 1770
+                    },
+                    "zoom": 1.3
+                },
+                "coordinateSystems": [
+                    {
+                        "id": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e",
+                        "name": "world",
+                        "axes": [
+                            {
+                                "name": "c",
+                                "type": "channel"
+                            },
+                            {
+                                "name": "x",
+                                "type": "space",
+                                "unit": "nanometer"
+                            },
+                            {
+                                "name": "y",
+                                "type": "space",
+                                "unit": "nanometer"
+                            },
+                            {
+                                "name": "z",
+                                "type": "space",
+                                "unit": "nanometer"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "nodes": [
+                {
+                    "id": "65d8484b-3792-4eb8-9d4e-e9fbee3a5458",
+                    "type": "multiscale",
+                    "name": "color",
+                    "attributes": {
+                        "webknossos:category": "color",
+                        "webknossos:bounding_box": {
+                            "topleft": {
+                                "x": 128,
+                                "y": 128,
+                                "z": 128
+                            },
+                            "size": {
+                                "x": 5445,
+                                "y": 8380,
+                                "z": 3285
+                            }
+                        },
+                        "webknossos:data_type": "uint8"
+                    },
+                    "nodes": [
+                        {
+                            "id": "4ec0b506-ad9f-404f-b106-9e66246b00e1",
+                            "type": "singlescale",
+                            "name": "1",
+                            "path": {
+                                "type": "zarr",
+                                "path": "/absolute/path/to/l4dense_motta_et_al_demo/color/1"
+                            },
+                            "attributes": {
+                                "coordinateTransformations": [
+                                    {
+                                        "type": "scale",
+                                        "scale": [
+                                            1.0,
+                                            11.239999771118164,
+                                            11.239999771118164,
+                                            28.0
+                                        ],
+                                        "input": {
+                                            "type": "singlescale",
+                                            "$ref": "4ec0b506-ad9f-404f-b106-9e66246b00e1"
+                                        },
+                                        "output": {
+                                            "type": "coordinateSystem",
+                                            "$ref": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "1a612389-20f5-4af1-b125-8bed8a5d7e85",
+                            "type": "singlescale",
+                            "name": "2-2-1",
+                            "path": {
+                                "type": "zarr",
+                                "path": "/absolute/path/to/l4dense_motta_et_al_demo/color/2-2-1"
+                            },
+                            "attributes": {
+                                "coordinateTransformations": [
+                                    {
+                                        "type": "scale",
+                                        "scale": [
+                                            1.0,
+                                            22.479999542236328,
+                                            22.479999542236328,
+                                            28.0
+                                        ],
+                                        "input": {
+                                            "type": "singlescale",
+                                            "$ref": "1a612389-20f5-4af1-b125-8bed8a5d7e85"
+                                        },
+                                        "output": {
+                                            "type": "coordinateSystem",
+                                            "$ref": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "3967cf03-0ca0-49f0-a0c6-27f105724ab7",
+                    "type": "multiscale",
+                    "name": "segmentation",
+                    "attributes": {
+                        "webknossos:category": "segmentation",
+                        "webknossos:bounding_box": {
+                            "topleft": {
+                                "x": 0,
+                                "y": 0,
+                                "z": 0
+                            },
+                            "size": {
+                                "x": 5632,
+                                "y": 8704,
+                                "z": 3584
+                            }
+                        },
+                        "webknossos:data_type": "uint32",
+                        "webknossos:values": {
+                            "max": 100000
+                        }
+                    },
+                    "nodes": [
+                        {
+                            "id": "00b522ce-9e08-4838-936e-8302cb0f43c1",
+                            "type": "singlescale",
+                            "name": "1",
+                            "path": {
+                                "type": "zarr",
+                                "path": "./segmentation/1"
+                            },
+                            "attributes": {
+                                "coordinateTransformations": [
+                                    {
+                                        "type": "scale",
+                                        "scale": [
+                                            1.0,
+                                            11.239999771118164,
+                                            11.239999771118164,
+                                            28.0
+                                        ],
+                                        "input": {
+                                            "type": "singlescale",
+                                            "$ref": "00b522ce-9e08-4838-936e-8302cb0f43c1"
+                                        },
+                                        "output": {
+                                            "type": "coordinateSystem",
+                                            "$ref": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "92d5c223-cc30-4e4c-92ed-629e41acc139",
+                            "type": "singlescale",
+                            "name": "2-2-1",
+                            "path": {
+                                "type": "zarr",
+                                "path": "./segmentation/2-2-1"
+                            },
+                            "attributes": {
+                                "coordinateTransformations": [
+                                    {
+                                        "type": "scale",
+                                        "scale": [
+                                            1.0,
+                                            22.479999542236328,
+                                            22.479999542236328,
+                                            28.0
+                                        ],
+                                        "input": {
+                                            "type": "singlescale",
+                                            "$ref": "92d5c223-cc30-4e4c-92ed-629e41acc139"
+                                        },
+                                        "output": {
+                                            "type": "coordinateSystem",
+                                            "$ref": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "194888b2-656d-4d8c-81db-0d38ac2eecd6",
+                            "type": "singlescale",
+                            "name": "4-4-2",
+                            "path": {
+                                "type": "zarr",
+                                "path": "./segmentation/4-4-2"
+                            },
+                            "attributes": {
+                                "coordinateTransformations": [
+                                    {
+                                        "type": "scale",
+                                        "scale": [
+                                            1.0,
+                                            44.959999084472656,
+                                            44.959999084472656,
+                                            56.0
+                                        ],
+                                        "input": {
+                                            "type": "singlescale",
+                                            "$ref": "194888b2-656d-4d8c-81db-0d38ac2eecd6"
+                                        },
+                                        "output": {
+                                            "type": "coordinateSystem",
+                                            "$ref": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "webknossos:mesh",
+                    "name": "meshfile_4-4-2",
+                    "path": {
+                        "type": "zarr",
+                        "path": "./segmentation/zarr/meshes/meshfile_4-4-2"
+                    },
+                    "attributes": {
+                        "webknossos:parent": {
+                            "type": "multiscale",
+                            "$ref": "3967cf03-0ca0-49f0-a0c6-27f105724ab7"
+                        }
+                    }
+                },
+                {
+                    "type": "webknossos:agglomeration",
+                    "name": "agglomerate_view_5",
+                    "path": {
+                        "type": "zarr",
+                        "path": "./segmentation/zarr/agglomerates/agglomerate_view_5"
+                    },
+                    "attributes": {
+                        "webknossos:parent": {
+                            "type": "multiscale",
+                            "$ref": "3967cf03-0ca0-49f0-a0c6-27f105724ab7"
+                        }
+                    }
+                },
+                {
+                    "type": "webknossos:segment_index",
+                    "name": "segmentIndex",
+                    "path": {
+                        "type": "zarr",
+                        "path": "./segmentation/zarr/segmentIndex/segmentIndex"
+                    },
+                    "attributes": {
+                        "webknossos:parent": {
+                            "type": "multiscale",
+                            "$ref": "3967cf03-0ca0-49f0-a0c6-27f105724ab7"
+                        }
+                    }
+                },
+                {
+                    "type": "webknossos:connectome",
+                    "name": "paper_l4_full_connectome",
+                    "path": {
+                        "type": "zarr",
+                        "path": "./segmentation/zarr/connectomes/paper_l4_full_connectome"
+                    },
+                    "attributes": {
+                        "webknossos:parent": {
+                            "type": "multiscale",
+                            "$ref": "3967cf03-0ca0-49f0-a0c6-27f105724ab7"
+                        }
+                    }
+                },
+                {
+                    "id": "294cdc31-8362-4d67-be14-57a74d2bc2fa",
+                    "type": "multiscale",
+                    "name": "prediction",
+                    "attributes": {
+                        "webknossos:category": "color",
+                        "webknossos:bounding_box": {
+                            "topleft": {
+                                "c": 0,
+                                "x": 128,
+                                "y": 128,
+                                "z": 128
+                            },
+                            "size": {
+                                "c": 3,
+                                "x": 5445,
+                                "y": 8380,
+                                "z": 3285
+                            }
+                        },
+                        "webknossos:data_type": "uint8",
+                        "webknossos:rendering": {
+                            "is_disabled": true
+                        }
+                    },
+                    "nodes": [
+                        {
+                            "id": "556d7d8d-ca99-44b6-be1b-62fbcf1eba5e",
+                            "type": "singlescale",
+                            "name": "1",
+                            "path": {
+                                "type": "zarr",
+                                "path": "./prediction/1"
+                            },
+                            "attributes": {
+                                "coordinateTransformations": [
+                                    {
+                                        "type": "scale",
+                                        "scale": [
+                                            1.0,
+                                            11.239999771118164,
+                                            11.239999771118164,
+                                            28.0
+                                        ],
+                                        "input": {
+                                            "type": "singlescale",
+                                            "$ref": "556d7d8d-ca99-44b6-be1b-62fbcf1eba5e"
+                                        },
+                                        "output": {
+                                            "type": "coordinateSystem",
+                                            "$ref": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "6550f3d2-5d65-4668-82c1-e2fb16370449",
+                            "type": "singlescale",
+                            "name": "2-2-1",
+                            "path": {
+                                "type": "zarr",
+                                "path": "./prediction/2-2-1"
+                            },
+                            "attributes": {
+                                "coordinateTransformations": [
+                                    {
+                                        "type": "scale",
+                                        "scale": [
+                                            1.0,
+                                            22.479999542236328,
+                                            22.479999542236328,
+                                            28.0
+                                        ],
+                                        "input": {
+                                            "type": "singlescale",
+                                            "$ref": "6550f3d2-5d65-4668-82c1-e2fb16370449"
+                                        },
+                                        "output": {
+                                            "type": "coordinateSystem",
+                                            "$ref": "fa8a2d0a-0f4a-4c95-bf5b-a9528433653e"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/py/test/rfc8_collection_cases.json
+++ b/py/test/rfc8_collection_cases.json
@@ -1,0 +1,347 @@
+{
+  "$comment": "Shared RFC-8 validation cases consumed by both py/test/test_rfc8_validation.py and ts/test/rfc8_validation_test.ts. The message and location strings pin the cross-language byte contract: both ports must raise them verbatim. A case without a version validates with no declared version (the strict default).",
+  "cases": [
+    {
+      "name": "minimal collection with empty nodes",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": []
+      },
+      "version": "0.9.dev3",
+      "ok": true
+    },
+    {
+      "name": "collection referencing its nodes by path",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "path": {
+          "type": "json",
+          "path": "./nodes.json"
+        }
+      },
+      "version": "0.9.dev3",
+      "ok": true
+    },
+    {
+      "name": "prefixed extension path type passes as opaque",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "mobie:spots_table",
+            "name": "spots",
+            "path": {
+              "type": "myorg:sheet",
+              "path": "./spots"
+            }
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "ok": true
+    },
+    {
+      "name": "names may repeat across sibling collections",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "collection",
+            "name": "a",
+            "nodes": [
+              {
+                "type": "multiscale",
+                "name": "img"
+              }
+            ]
+          },
+          {
+            "type": "collection",
+            "name": "b",
+            "nodes": [
+              {
+                "type": "multiscale",
+                "name": "img"
+              }
+            ]
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "ok": true
+    },
+    {
+      "name": "a non-collection node may carry neither nodes nor path",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "multiscale",
+            "name": "img"
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "ok": true
+    },
+    {
+      "name": "the rules are inert when an earlier version is declared",
+      "ome": {
+        "type": "collection",
+        "nodes": [
+          {
+            "type": "multiscale",
+            "name": "a",
+            "id": "dup"
+          },
+          {
+            "type": "multiscale",
+            "name": "a",
+            "id": "dup"
+          }
+        ]
+      },
+      "version": "0.6",
+      "ok": true
+    },
+    {
+      "name": "missing type on the root node",
+      "ome": {
+        "name": "c",
+        "nodes": []
+      },
+      "rule": "node-type-required",
+      "message": "Spec rule [node-type-required] violated: Node must declare a non-empty string 'type'; got None.",
+      "location": "ome"
+    },
+    {
+      "name": "empty type string",
+      "ome": {
+        "type": "",
+        "name": "c",
+        "nodes": []
+      },
+      "version": "0.9.dev3",
+      "rule": "node-type-required",
+      "message": "Spec rule [node-type-required] violated: Node must declare a non-empty string 'type'; got ''.",
+      "location": "ome"
+    },
+    {
+      "name": "non-string type on a child node",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": 5,
+            "name": "img"
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "rule": "node-type-required",
+      "message": "Spec rule [node-type-required] violated: Node must declare a non-empty string 'type'; got 5.",
+      "location": "ome.nodes[0]"
+    },
+    {
+      "name": "missing name on the root node",
+      "ome": {
+        "type": "collection",
+        "nodes": []
+      },
+      "version": "0.9.dev3",
+      "rule": "node-name-required",
+      "message": "Spec rule [node-name-required] violated: Node must declare a non-empty string 'name'; got None.",
+      "location": "ome"
+    },
+    {
+      "name": "empty name on a child node",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "multiscale",
+            "name": ""
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "rule": "node-name-required",
+      "message": "Spec rule [node-name-required] violated: Node must declare a non-empty string 'name'; got ''.",
+      "location": "ome.nodes[0]"
+    },
+    {
+      "name": "sibling nodes sharing a name",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "multiscale",
+            "name": "img"
+          },
+          {
+            "type": "multiscale",
+            "name": "img"
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "rule": "node-name-unique",
+      "message": "Spec rule [node-name-unique] violated: Node name 'img' is repeated; node names must be unique within the enclosing collection.",
+      "location": "ome.nodes[1]"
+    },
+    {
+      "name": "id with characters outside the production",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "id": "a b",
+        "nodes": []
+      },
+      "version": "0.9.dev3",
+      "rule": "node-id-format",
+      "message": "Spec rule [node-id-format] violated: Id 'a b' does not match [a-zA-Z0-9-_.]+.",
+      "location": "ome.id"
+    },
+    {
+      "name": "non-string id",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "multiscale",
+            "name": "img",
+            "id": 7
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "rule": "node-id-format",
+      "message": "Spec rule [node-id-format] violated: Id 7 does not match [a-zA-Z0-9-_.]+.",
+      "location": "ome.nodes[0].id"
+    },
+    {
+      "name": "id repeated across the document",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "id": "n1",
+        "nodes": [
+          {
+            "type": "collection",
+            "name": "sub",
+            "nodes": [
+              {
+                "type": "multiscale",
+                "name": "img",
+                "id": "n1"
+              }
+            ]
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "rule": "node-id-unique",
+      "message": "Spec rule [node-id-unique] violated: Id 'n1' is already used in this document; ids must be unique within the JSON document.",
+      "location": "ome.nodes[0].nodes[0].id"
+    },
+    {
+      "name": "collection declaring both nodes and path",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [],
+        "path": {
+          "type": "json",
+          "path": "./nodes.json"
+        }
+      },
+      "version": "0.9.dev3",
+      "rule": "node-nodes-xor-path",
+      "message": "Spec rule [node-nodes-xor-path] violated: Node declares both 'nodes' and 'path'; exactly one must be present.",
+      "location": "ome"
+    },
+    {
+      "name": "collection declaring neither nodes nor path",
+      "ome": {
+        "type": "collection",
+        "name": "c"
+      },
+      "version": "0.9.dev3",
+      "rule": "node-nodes-xor-path",
+      "message": "Spec rule [node-nodes-xor-path] violated: Node declares neither 'nodes' nor 'path'; exactly one must be present.",
+      "location": "ome"
+    },
+    {
+      "name": "path without a type",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "multiscale",
+            "name": "img",
+            "path": {
+              "path": "./img.zarr"
+            }
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "rule": "path-type-known",
+      "message": "Spec rule [path-type-known] violated: Path must declare a non-empty string 'type'; got None.",
+      "location": "ome.nodes[0].path.type"
+    },
+    {
+      "name": "unprefixed path type outside the core set",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "multiscale",
+            "name": "img",
+            "path": {
+              "type": "google-sheet",
+              "path": "./sheet"
+            }
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "rule": "path-type-known",
+      "message": "Spec rule [path-type-known] violated: Path type 'google-sheet' is not 'zarr', 'json', or a prefixed extension type.",
+      "location": "ome.nodes[0].path.type"
+    },
+    {
+      "name": "name uniqueness reported before the id format",
+      "ome": {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+          {
+            "type": "multiscale",
+            "name": "img",
+            "id": "bad id"
+          },
+          {
+            "type": "multiscale",
+            "name": "img"
+          }
+        ]
+      },
+      "version": "0.9.dev3",
+      "rule": "node-name-unique",
+      "message": "Spec rule [node-name-unique] violated: Node name 'img' is repeated; node names must be unique within the enclosing collection.",
+      "location": "ome.nodes[1]"
+    }
+  ]
+}

--- a/py/test/test_rfc8_io.py
+++ b/py/test/test_rfc8_io.py
@@ -178,6 +178,45 @@ def test_external_collection_fixture_layout(tmp_path):
     assert child.base == str(tmp_path.resolve())
 
 
+def test_external_reference_with_undeclared_id_raises(tmp_path):
+    to_collection_json(
+        Collection("child", nodes=[Node(type="multiscale", name="img", id="img")]),
+        tmp_path / "child.json",
+    )
+    parent = NgffCollection(root=Collection("parent", nodes=[]), base=str(tmp_path))
+    reference = Reference("missing", OmePath("json", "./child.json"))
+    with pytest.raises(KeyError, match="missing"):
+        parent.load(reference)
+
+
+def test_in_memory_collection_cannot_resolve_relative_paths():
+    collection = from_collection_json(
+        {
+            "ome": {
+                "version": "0.9.dev3",
+                "type": "collection",
+                "name": "c",
+                "nodes": [
+                    {
+                        "type": "collection",
+                        "name": "n",
+                        "path": {"type": "json", "path": "./other.json"},
+                    }
+                ],
+            }
+        }
+    )
+    with pytest.raises(ValueError, match="resolution base"):
+        collection.load("n")
+
+
+def test_lru_cache_requires_a_positive_size():
+    from ngff_zarr._lru_cache import LRUCache
+
+    with pytest.raises(ValueError, match="positive"):
+        LRUCache(0)
+
+
 def test_node_lookup_prefers_ids(tmp_path):
     collection = NgffCollection(
         root=Collection(

--- a/py/test/test_rfc8_io.py
+++ b/py/test/test_rfc8_io.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""RFC-8 collection reading, writing, path resolution and lazy loading."""
+
+import json
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+from ngff_zarr import (
+    Collection,
+    NgffCollection,
+    NgffMultiscales,
+    Node,
+    OmePath,
+    Reference,
+    from_collection_json,
+    from_collection_zarr,
+    from_ome_zarr,
+    to_collection_json,
+    to_collection_zarr,
+    to_multiscales,
+    to_ngff_image,
+    to_ome_zarr,
+    upgrade_ome_zarr,
+)
+from ngff_zarr.structural_validation import ValidationError
+
+FIXTURES = Path(__file__).parent / "fixtures" / "rfc8"
+
+
+def _image_multiscales():
+    image = to_ngff_image(np.arange(16, dtype=np.uint8).reshape(4, 4), dims=("y", "x"))
+    return to_multiscales(image, scale_factors=[])
+
+
+def _study_collection() -> Collection:
+    return Collection(
+        "study",
+        id="study",
+        attributes={"mobie:grid": "true"},
+        nodes=[
+            Node(
+                type="multiscale",
+                name="raw",
+                id="raw",
+                path=OmePath("zarr", "./raw"),
+            ),
+            Collection(
+                "nested",
+                path=OmePath("json", "./nested_collection.json"),
+            ),
+        ],
+    )
+
+
+def test_zarr_round_trip(tmp_path):
+    store = tmp_path / "collection.ome.zarr"
+    root = _study_collection()
+    to_collection_zarr(store, root, root_attributes={"lab": "fideus"})
+
+    document = json.loads((store / "zarr.json").read_text())
+    assert document["zarr_format"] == 3
+    assert document["node_type"] == "group"
+    assert document["attributes"]["ome"]["version"] == "0.9.dev3"
+    assert document["attributes"]["lab"] == "fideus"
+
+    collection = from_collection_zarr(store, validate=True)
+    assert collection.root == root
+    assert collection.version == "0.9.dev3"
+    assert collection.base == str(store.resolve())
+    assert collection.root_attributes == {"lab": "fideus"}
+
+
+def test_overwrite_never_removes_the_tree_beneath_the_root(tmp_path):
+    store = tmp_path / "collection.ome.zarr"
+    to_collection_zarr(store, _study_collection())
+    to_ome_zarr(store / "raw", _image_multiscales(), version="0.9.dev1")
+
+    to_collection_zarr(store, _study_collection(), overwrite=True)
+    assert (store / "raw" / "zarr.json").exists()
+    loaded = from_collection_zarr(store).load("raw")
+    assert isinstance(loaded, NgffMultiscales)
+
+
+def test_collection_writer_accepts_only_dev3(tmp_path):
+    with pytest.raises(ValueError, match="0.9.dev3"):
+        to_collection_zarr(
+            tmp_path / "c.ome.zarr", _study_collection(), version="0.9.dev1"
+        )
+
+
+def test_collection_writer_validates_by_default(tmp_path):
+    invalid = Collection("c")  # neither nodes nor path
+    with pytest.raises(ValidationError):
+        to_collection_zarr(tmp_path / "c.ome.zarr", invalid)
+    to_collection_zarr(tmp_path / "c.ome.zarr", invalid, validate=False)
+
+
+def test_json_round_trip(tmp_path):
+    root = _study_collection()
+    document = to_collection_json(root)
+    assert document["ome"]["version"] == "0.9.dev3"
+
+    path = tmp_path / "collection.json"
+    to_collection_json(root, path)
+    collection = from_collection_json(path, validate=True)
+    assert collection.root == root
+    assert collection.base == str(tmp_path.resolve())
+
+    from_mapping = from_collection_json(document)
+    assert from_mapping.root == root
+    assert from_mapping.base is None
+
+
+def test_from_ome_zarr_names_the_collection_reader(tmp_path):
+    store = tmp_path / "collection.ome.zarr"
+    to_collection_zarr(store, _study_collection())
+    with pytest.raises(ValueError, match="from_collection_zarr"):
+        from_ome_zarr(store)
+
+
+def test_from_collection_zarr_names_the_image_reader(tmp_path):
+    store = tmp_path / "image.ome.zarr"
+    to_ome_zarr(store, _image_multiscales(), version="0.5")
+    with pytest.raises(ValueError, match="from_ome_zarr"):
+        from_collection_zarr(store)
+
+
+def test_to_ome_zarr_refuses_dev3_with_guidance(tmp_path):
+    with pytest.raises(ValueError, match="to_collection_zarr"):
+        to_ome_zarr(
+            tmp_path / "image.ome.zarr", _image_multiscales(), version="0.9.dev3"
+        )
+
+
+def test_upgrade_does_not_offer_dev3(tmp_path):
+    store = tmp_path / "image.ome.zarr"
+    to_ome_zarr(store, _image_multiscales(), version="0.5")
+    with pytest.raises(ValueError):
+        upgrade_ome_zarr(store, tmp_path / "out.ome.zarr", version="0.9.dev3")
+
+
+def test_load_resolves_inline_and_referenced_nodes(tmp_path):
+    store = tmp_path / "collection.ome.zarr"
+    root = _study_collection()
+    to_collection_zarr(store, root)
+    to_ome_zarr(store / "raw", _image_multiscales(), version="0.9.dev1")
+    to_collection_json(Collection("nested", nodes=[]), store / "nested_collection.json")
+
+    collection = from_collection_zarr(store)
+
+    image = collection.load("raw")
+    assert isinstance(image, NgffMultiscales)
+    assert image.images[0].data.shape == (4, 4)
+    # Loaded documents are cached per resolved location.
+    assert collection.load("raw") is image
+    assert collection.load(Reference("raw")) is image
+
+    nested = collection.load("nested")
+    assert isinstance(nested, NgffCollection)
+    assert nested.base == str((store / "nested_collection.json").parent.resolve())
+
+
+def test_external_collection_fixture_layout(tmp_path):
+    # The upstream external_collection example: a parent document whose
+    # sub-collection lives in a sibling JSON file.
+    for name in ("parent_collection.json", "child_collection.json"):
+        shutil.copy(FIXTURES / "external_collection" / name, tmp_path / name)
+
+    parent = from_collection_json(tmp_path / "parent_collection.json")
+    child = parent.load("sub-collection")
+    assert isinstance(child, NgffCollection)
+    assert child.root.name == "sub-collection"
+    assert child.root.nodes[0].name == "image-label"
+    # The child collection resolves its own relative paths from its file.
+    assert child.base == str(tmp_path.resolve())
+
+
+def test_node_lookup_prefers_ids(tmp_path):
+    collection = NgffCollection(
+        root=Collection(
+            "c",
+            nodes=[
+                Node(type="multiscale", name="a", id="b"),
+                Node(type="multiscale", name="b", id="c"),
+            ],
+        )
+    )
+    assert collection.node("b").name == "a"
+    assert collection.node("a").name == "a"
+    with pytest.raises(KeyError):
+        collection.node("missing")
+
+
+def test_collection_reader_never_uses_the_versioned_schema_pass(tmp_path, monkeypatch):
+    # The vendored spec/0.9 tree enumerates only 0.9.dev1, so routing a
+    # 0.9.dev3 document through ngff_zarr.validate would fail on the version
+    # enum with a misleading error; the RFC-8 reader must not call it.
+    import importlib
+
+    validate_module = importlib.import_module("ngff_zarr.validate")
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("validate_ngff must not see RFC-8 documents")
+
+    monkeypatch.setattr(validate_module, "validate", _forbidden)
+    store = tmp_path / "collection.ome.zarr"
+    to_collection_zarr(store, _study_collection())
+    pytest.importorskip("jsonschema")
+    from_collection_zarr(store, validate=True)
+
+
+def test_validate_true_runs_the_bundled_node_schema(tmp_path):
+    pytest.importorskip("jsonschema")
+    import jsonschema
+
+    store = tmp_path / "collection.ome.zarr"
+    to_collection_zarr(store, _study_collection())
+    # Corrupt the document below the structural rules' radar: a non-object
+    # ``attributes`` passes no structural rule but fails the schema.
+    document = json.loads((store / "zarr.json").read_text())
+    document["attributes"]["ome"]["attributes"] = "not-an-object"
+    (store / "zarr.json").write_text(json.dumps(document))
+    with pytest.raises((jsonschema.ValidationError, ValueError)):
+        from_collection_zarr(store, validate=True)

--- a/py/test/test_rfc8_model.py
+++ b/py/test/test_rfc8_model.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""RFC-8 node model: construction, parsing and serialization round trips."""
+
+import json
+from pathlib import Path
+
+import pytest
+from ngff_zarr import Collection, Node, OmePath, Reference
+from ngff_zarr.rfc8 import (
+    RFC8_ID_PATTERN,
+    is_collection_node,
+    is_prefixed_identifier,
+    node_from_ome_dict,
+    node_to_ome_dict,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "rfc8"
+
+#: Every checked-in example document; ``webknossos_inline_multiscale.json``
+#: is a full ``zarr.json`` (the Zarr-group storage medium), the others are
+#: standalone documents with a root ``ome`` key.
+FIXTURE_FILES = [
+    "base_multiscale_collection.json",
+    "nested_collection.json",
+    "external_collection/parent_collection.json",
+    "external_collection/child_collection.json",
+    "external_collection/resolved_collection.json",
+    "webknossos_inline_multiscale.json",
+    "mobie_image_labels_table.json",
+]
+
+
+def _ome_value(document: dict) -> dict:
+    if "attributes" in document:
+        return document["attributes"]["ome"]
+    return document["ome"]
+
+
+def test_collection_constructor_shape():
+    collection = Collection("study", id="c1")
+    assert collection.type == "collection"
+    assert collection.name == "study"
+    assert collection.nodes is None
+    assert collection.path is None
+    assert is_collection_node(collection)
+    # ``type`` is pinned by the class, not an init parameter.
+    with pytest.raises(TypeError):
+        Collection(type="collection", name="study")
+
+
+def test_node_requires_type_and_name():
+    node = Node(type="multiscale", name="raw")
+    assert not is_collection_node(node)
+    with pytest.raises(TypeError):
+        Node(name="raw")
+
+
+def test_reference_and_path_are_frozen_values():
+    path = OmePath("zarr", "./raw")
+    assert Reference("raw", path) == Reference("raw", OmePath("zarr", "./raw"))
+    with pytest.raises(AttributeError):
+        path.path = "./other"
+
+
+def test_id_pattern_matches_the_rfc_production():
+    for accepted in ("s0", "A-1_b.2", "7fa2f064-62c5-4d55-9e6c-25acc1aa3a31"):
+        assert RFC8_ID_PATTERN.match(accepted)
+    for rejected in ("a b", "a/b", "", "é"):
+        assert not RFC8_ID_PATTERN.match(rejected)
+
+
+def test_prefixed_identifier_detection():
+    assert is_prefixed_identifier("myorg:zip")
+    assert is_prefixed_identifier("webknossos:settings")
+    assert not is_prefixed_identifier("zip")
+    assert not is_prefixed_identifier(":zip")
+    assert not is_prefixed_identifier("myorg:")
+
+
+def test_collection_parses_to_collection_class():
+    node, version = node_from_ome_dict(
+        {"version": "0.9.dev3", "type": "collection", "name": "c", "nodes": []}
+    )
+    assert isinstance(node, Collection)
+    assert version == "0.9.dev3"
+    assert node.nodes == []
+
+
+def test_unknown_node_type_parses_as_generic_node():
+    node, _ = node_from_ome_dict({"type": "mobie:spots_table", "name": "spots"})
+    assert type(node) is Node
+    assert node.type == "mobie:spots_table"
+
+
+def test_unknown_keys_round_trip_through_extra():
+    document = {
+        "type": "collection",
+        "name": "c",
+        "nodes": [],
+        "future-key": {"nested": [1, None, "x"]},
+    }
+    node, _ = node_from_ome_dict(document)
+    assert node.extra == {"future-key": {"nested": [1, None, "x"]}}
+    assert node_to_ome_dict(node) == document
+
+
+def test_attributes_are_opaque_and_deep_copied():
+    attributes = {"mobie:grid": "true", "nested": {"value": None}}
+    node, _ = node_from_ome_dict(
+        {"type": "collection", "name": "c", "nodes": [], "attributes": attributes}
+    )
+    assert node.attributes == attributes
+    assert node.attributes is not attributes
+    node.attributes["nested"]["value"] = 1
+    assert attributes["nested"]["value"] is None
+    out = node_to_ome_dict(node)
+    out["attributes"]["nested"]["value"] = 2
+    assert node.attributes["nested"]["value"] == 1
+
+
+def test_version_is_not_stamped_on_children():
+    root = Collection("c", nodes=[Collection("sub", nodes=[])])
+    document = node_to_ome_dict(root, version="0.9.dev3")
+    assert document["version"] == "0.9.dev3"
+    assert "version" not in document["nodes"][0]
+
+
+def test_parser_reports_malformed_core_keys():
+    with pytest.raises(ValueError, match="'type'"):
+        node_from_ome_dict({"name": "c"})
+    with pytest.raises(ValueError, match="'name'"):
+        node_from_ome_dict({"type": "collection"})
+    with pytest.raises(ValueError, match="'id'"):
+        node_from_ome_dict({"type": "collection", "name": "c", "id": 7})
+    with pytest.raises(ValueError, match="ome.nodes\\[0\\]"):
+        node_from_ome_dict(
+            {"type": "collection", "name": "c", "nodes": [{"name": "x"}]}
+        )
+    with pytest.raises(ValueError, match="'path'"):
+        node_from_ome_dict({"type": "collection", "name": "c", "path": "./x.json"})
+    with pytest.raises(ValueError, match="'version'"):
+        node_from_ome_dict({"type": "collection", "name": "c", "version": 9})
+
+
+@pytest.mark.parametrize("fixture", FIXTURE_FILES)
+def test_fixture_documents_round_trip(fixture):
+    document = json.loads((FIXTURES / fixture).read_text())
+    ome = _ome_value(document)
+    node, version = node_from_ome_dict(ome)
+    assert version == "0.9.dev3"
+    assert node_to_ome_dict(node, version=version) == ome

--- a/py/test/test_rfc8_validation.py
+++ b/py/test/test_rfc8_validation.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""RFC-8 structural rules, driven by the shared cross-language case table.
+
+``rfc8_collection_cases.json`` pins the rule, message and location bytes both
+ports must produce; ``ts/test/rfc8_validation_test.ts`` drives the identical
+file.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from ngff_zarr import (
+    Collection,
+    Node,
+    OmePath,
+    ValidateOptions,
+    ValidationLevel,
+    validate_collection,
+)
+from ngff_zarr.structural_validation import ValidationError, is_rfc8_node_model
+
+CASES_PATH = Path(__file__).parent / "rfc8_collection_cases.json"
+CASES = json.loads(CASES_PATH.read_text())["cases"]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[case["name"] for case in CASES])
+def test_shared_case(case):
+    version = case.get("version")
+    if case.get("ok"):
+        validate_collection(case["ome"], version=version)
+        return
+    with pytest.raises(ValidationError) as exc_info:
+        validate_collection(case["ome"], version=version)
+    error = exc_info.value
+    assert error.rule.value == case["rule"]
+    assert str(error) == case["message"]
+    assert error.location == case["location"]
+
+
+def test_every_rule_is_exercised_by_the_shared_cases():
+    exercised = {case["rule"] for case in CASES if "rule" in case}
+    assert exercised == {
+        "node-type-required",
+        "node-name-required",
+        "node-name-unique",
+        "node-id-format",
+        "node-id-unique",
+        "node-nodes-xor-path",
+        "path-type-known",
+    }
+
+
+def test_is_rfc8_node_model_is_a_dispatch_predicate():
+    # Unlike the RFC-4 gate, ``None`` is not node-shaped: the predicate says
+    # which document shape a version stores, and the orchestrator handles
+    # the no-version strictness default itself.
+    assert is_rfc8_node_model("0.9.dev3")
+    assert not is_rfc8_node_model("0.9.dev1")
+    assert not is_rfc8_node_model("0.6")
+    assert not is_rfc8_node_model(None)
+
+
+def test_validate_collection_accepts_a_parsed_node_tree():
+    root = Collection(
+        "c",
+        nodes=[
+            Node(type="multiscale", name="img"),
+            Node(type="multiscale", name="img"),
+        ],
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_collection(root, version="0.9.dev3")
+    assert exc_info.value.rule.value == "node-name-unique"
+    assert exc_info.value.location == "ome.nodes[1]"
+
+
+def test_schema_only_level_skips_the_rules():
+    root = Collection("c", nodes=None, path=None)
+    validate_collection(
+        root, options=ValidateOptions(level=ValidationLevel.SCHEMA_ONLY)
+    )
+    with pytest.raises(ValidationError):
+        validate_collection(root)
+
+
+def test_prefixed_path_types_pass_and_core_types_pass():
+    for path_type in ("zarr", "json", "myorg:zip"):
+        validate_collection(Collection("c", path=OmePath(path_type, "./somewhere")))
+
+
+def test_mobie_fixture_fails_on_its_unprefixed_extension_path_type():
+    # The upstream example uses the unprefixed extension identifier
+    # ``google-sheet``, which the RFC's naming scheme reserves for the core
+    # specification; the rule reports it (see fixtures/rfc8/README.md).
+    document = json.loads(
+        (
+            Path(__file__).parent
+            / "fixtures"
+            / "rfc8"
+            / "mobie_image_labels_table.json"
+        ).read_text()
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_collection(document["ome"], version="0.9.dev3")
+    assert exc_info.value.rule.value == "path-type-known"
+
+
+def test_remaining_fixture_documents_validate():
+    fixtures = Path(__file__).parent / "fixtures" / "rfc8"
+    for name in (
+        "base_multiscale_collection.json",
+        "nested_collection.json",
+        "external_collection/parent_collection.json",
+        "external_collection/child_collection.json",
+        "external_collection/resolved_collection.json",
+    ):
+        document = json.loads((fixtures / name).read_text())
+        validate_collection(document["ome"], version="0.9.dev3")
+    webknossos = json.loads(
+        (fixtures / "webknossos_inline_multiscale.json").read_text()
+    )
+    validate_collection(webknossos["attributes"]["ome"], version="0.9.dev3")

--- a/py/test/test_structural_validation_parity.py
+++ b/py/test/test_structural_validation_parity.py
@@ -26,6 +26,7 @@ from ngff_zarr import (
     ValidationError,
     ValidationLevel,
     structural_validation,
+    validate_collection,
     validate_structural,
 )
 from ngff_zarr.v04.zarr_metadata import (
@@ -44,8 +45,9 @@ from ngff_zarr.v04.zarr_metadata import (
 # so the two are directly comparable. The first thirteen entries are the
 # image/multiscales rules dispatched by validate_structural -- the first eleven
 # are the v0.4 rules and the next two (zarr-format, ome-namespace) are the v0.5
-# namespacing rules, inert for v0.4; the final two are the HCS plate/well rules
-# dispatched by validate_plate / validate_well.
+# namespacing rules, inert for v0.4; the next two are the HCS plate/well rules
+# dispatched by validate_plate / validate_well; the final seven are the RFC-8
+# node/collection rules dispatched by validate_collection.
 CANONICAL_SPEC_RULE_IDS = [
     "axis-count",
     "axis-type",
@@ -62,6 +64,13 @@ CANONICAL_SPEC_RULE_IDS = [
     "ome-namespace",
     "plate-row-index-consistency",
     "well-acquisition-missing",
+    "node-type-required",
+    "node-name-required",
+    "node-name-unique",
+    "node-id-format",
+    "node-id-unique",
+    "node-nodes-xor-path",
+    "path-type-known",
 ]
 
 
@@ -73,6 +82,7 @@ CANONICAL_SPEC_RULE_IDS = [
 # never inert (see docs/validation/rule-reference.md).
 CANONICAL_RFC3_VERSIONS = [
     "0.9.dev1",
+    "0.9.dev3",
 ]
 
 # Every other supported version, plus the no-version default, must enforce the
@@ -93,6 +103,7 @@ NON_RFC3_VERSIONS = [
 # keeps them on, as a strictness choice (like axis-names-unique).
 CANONICAL_RFC4_VERSIONS = [
     "0.9.dev1",
+    "0.9.dev3",
 ]
 
 # Every other supported version must leave the orientation rules inert. Read
@@ -102,6 +113,23 @@ PRE_RFC4_VERSIONS = [
     version.value
     for version in SUPPORTED_VERSIONS
     if version.value not in CANONICAL_RFC4_VERSIONS
+]
+
+# The locked RFC-8 version manifest: the versions that store the node model
+# under ``ome``, at which the seven node/collection rules are normative. This
+# identical literal list appears in the Deno mirror test. Like the RFC-4
+# rules, the collection rules stay on when no version is declared.
+CANONICAL_RFC8_VERSIONS = [
+    "0.9.dev3",
+]
+
+# Every other supported version must leave the collection rules inert. Read
+# off SUPPORTED_VERSIONS so a newly supported version has to be classified
+# here rather than silently defaulting to either side.
+PRE_RFC8_VERSIONS = [
+    version.value
+    for version in SUPPORTED_VERSIONS
+    if version.value not in CANONICAL_RFC8_VERSIONS
 ]
 
 # The canonical fail-fast evaluation order of the image/multiscales
@@ -527,6 +555,39 @@ def test_rfc4_orientation_version_manifest_is_locked():
         # ...and inert at every earlier supported version.
         for version in PRE_RFC4_VERSIONS:
             validate_structural(_orientation_metadata(build_axes()), version=version)
+
+
+# ---------------------------------------------------------------------------
+# Manifest: the locked RFC-8 collection version set
+# ---------------------------------------------------------------------------
+
+
+def _invalid_collection_document() -> dict:
+    """A collection whose sibling nodes share a name, and nothing else wrong.
+
+    Trips :attr:`SpecRule.NODE_NAME_UNIQUE` exactly when the RFC-8 rules run,
+    so the orchestrator accepts it exactly when they are inert.
+    """
+    return {
+        "type": "collection",
+        "name": "c",
+        "nodes": [
+            {"type": "multiscale", "name": "img"},
+            {"type": "multiscale", "name": "img"},
+        ],
+    }
+
+
+def test_rfc8_collection_version_manifest_is_locked():
+    # Enforced at the manifest versions, and when no version is given...
+    for version in [*CANONICAL_RFC8_VERSIONS, None]:
+        with pytest.raises(ValidationError) as exc_info:
+            validate_collection(_invalid_collection_document(), version=version)
+        assert exc_info.value.rule == SpecRule.NODE_NAME_UNIQUE, version
+    # ...and inert at every other supported version, 0.9.dev1 included:
+    # RFC-8 lands at 0.9.dev3.
+    for version in PRE_RFC8_VERSIONS:
+        validate_collection(_invalid_collection_document(), version=version)
 
 
 def _commented_rule_ids() -> list[str]:

--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -18,6 +18,26 @@ export {
   type FromOmeZarrOptions,
   type MemoryStore,
 } from "./io/from_ngff_zarr-browser.ts";
+export {
+  browserCollectionIo,
+  fromCollectionJson,
+  fromCollectionZarr,
+  loadCollectionNode,
+} from "./io/from_collection_zarr-browser.ts";
+export type { FromCollectionOptions } from "./io/from_collection_zarr-browser.ts";
+export {
+  documentBase,
+  nodeDocumentOrThrow,
+  nodeFromOmeDict,
+  nodeToOmeDict,
+  OME_ROOT_KEYS,
+  parseCollectionJsonDocument,
+  parseCollectionRootAttrs,
+  resolveLocation,
+  resolveOmeDocument,
+  toCollectionJsonDocument,
+} from "./io/collection_common.ts";
+export type { CollectionIo, LoadedNode } from "./io/collection_common.ts";
 // ITK-Wasm conversion utilities
 export {
   itkImageToNgffImage,
@@ -66,6 +86,14 @@ export {
   toOmeZarrOzx,
   type ToOmeZarrOzxOptions,
 } from "./io/to_ngff_zarr-browser.ts";
+export {
+  toCollectionJson,
+  toCollectionZarr,
+} from "./io/to_collection_zarr-browser.ts";
+export type {
+  ToCollectionJsonOptions,
+  ToCollectionOptions,
+} from "./io/to_collection_zarr-browser.ts";
 // upgradeOmeZarr: spec-version upgrade (in-place metadata rewrite or
 // write-to-new-store). In the browser only MemoryStore inputs/outputs are
 // supported; in-place upgrade of a local *path* store is Node/Deno-only.
@@ -84,9 +112,17 @@ export * from "./schemas/zarr_metadata.ts";
 export * from "./types/array_interface.ts";
 export * from "./types/methods.ts";
 export * from "./types/multiscales.ts";
+export * from "./types/rfc8.ts";
 export * from "./types/ngff_image.ts";
 export * from "./types/units.ts";
 export * from "./types/zarr_metadata.ts";
+export {
+  OmeNodeDocumentSchema,
+  OmeNodeSchema,
+  OmePathSchema,
+  ReferenceSchema,
+  Rfc8IdSchema,
+} from "./schemas/rfc8.ts";
 export type { CodecName, ZarrCodec } from "./utils/codecs.ts";
 export {
   AVAILABLE_CODECS,
@@ -127,6 +163,18 @@ export {
   createNgffMultiscales,
 } from "./utils/factory.ts";
 export { getMethodMetadata } from "./utils/method_metadata.ts";
+export {
+  CORE_PATH_TYPES,
+  validateCollection,
+  validateNodeIdFormat,
+  validateNodeIdUnique,
+  validateNodeNameRequired,
+  validateNodeNameUnique,
+  validateNodeNodesXorPath,
+  validateNodeTypeRequired,
+  validatePathTypeKnown,
+  XOR_NODE_TYPES,
+} from "./utils/rfc8_validation.ts";
 export {
   SpecRule,
   type ValidateOptions,

--- a/ts/src/io/collection_common.ts
+++ b/ts/src/io/collection_common.ts
@@ -214,8 +214,16 @@ function joinLocalPath(base: string, relative: string): string {
       continue;
     }
     if (segment === "..") {
-      if (out.length > 1 || (out.length === 1 && out[0] !== "")) {
+      const last = out[out.length - 1];
+      if (out.length === 1 && out[0] === "") {
+        // The filesystem root has no parent.
+        continue;
+      }
+      if (out.length > 0 && last !== "..") {
         out.pop();
+      } else {
+        // A relative base cannot absorb the traversal; keep it.
+        out.push("..");
       }
       continue;
     }
@@ -268,7 +276,14 @@ export function documentBase(path: OmePath, location: string): string {
     return new URL(".", location).href.replace(/\/+$/, "");
   }
   const separator = location.lastIndexOf("/");
-  return separator <= 0 ? location : location.slice(0, separator);
+  if (separator === -1) {
+    // A bare filename lives in the current directory.
+    return ".";
+  }
+  if (separator === 0) {
+    return "/";
+  }
+  return location.slice(0, separator);
 }
 
 /** The environment-specific access a collection loader needs. */
@@ -427,7 +442,18 @@ export async function loadCollectionNodeWith(
           return loadCollectionNodeWith(loaded, node, io);
         }
       }
+      throw new Error(
+        `Reference id "${reference.id}" is not declared by the document ` +
+          `at "${reference.path.path}"`,
+      );
     }
+    if ("type" in loaded && loaded.id !== reference.id) {
+      throw new Error(
+        `Reference id "${reference.id}" is not declared by the document ` +
+          `at "${reference.path.path}"`,
+      );
+    }
+    // A multiscales image store predates RFC-8 and declares no ids.
     return loaded;
   }
   const node = target as OmeNode;

--- a/ts/src/io/collection_common.ts
+++ b/ts/src/io/collection_common.ts
@@ -1,0 +1,551 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Environment-agnostic core of the RFC-8 collection readers and writers.
+ *
+ * Parsing, serialization, location resolution and document dispatch live
+ * here, mirroring the Python port's `ngff_zarr.rfc8.serialize` / `resolve` /
+ * `collection` modules; the store- and file-access differences between the
+ * Node/Deno and browser entry points are injected through
+ * {@link CollectionIo}.
+ */
+
+import type { NgffMultiscales } from "../types/multiscales.ts";
+import { OmeNodeDocumentSchema } from "../schemas/rfc8.ts";
+import { validateCollection } from "../utils/rfc8_validation.ts";
+import {
+  isCollectionNode,
+  NgffCollection,
+  type OmeNode,
+  type OmePath,
+  PATH_TYPE_JSON,
+  PATH_TYPE_ZARR,
+  type Reference,
+} from "../types/rfc8.ts";
+import { NgffVersion } from "../types/supported_versions.ts";
+
+/**
+ * The node keys this package models; everything else round-trips through
+ * `extra`. `version` is the root-only key handled by the (de)serializer.
+ */
+const NODE_FIELDS = new Set([
+  "type",
+  "id",
+  "name",
+  "attributes",
+  "nodes",
+  "path",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Serialize a node tree to the object stored as the `ome` value.
+ *
+ * `version` stamps the root node (the RFC-8 root-only key) and is never
+ * passed down to children. `attributes` is deep-copied verbatim, unknown and
+ * prefixed keys included, and so are the `extra` keys, emitted after the
+ * modeled ones in their captured order. Absent optional fields are omitted
+ * rather than written as JSON `null`.
+ */
+export function nodeToOmeDict(
+  node: OmeNode,
+  version?: string,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (version !== undefined) {
+    out.version = version;
+  }
+  out.type = node.type;
+  if (node.id !== undefined) {
+    out.id = node.id;
+  }
+  out.name = node.name;
+  if (node.attributes !== undefined) {
+    out.attributes = structuredClone(node.attributes);
+  }
+  if (node.nodes !== undefined) {
+    out.nodes = node.nodes.map((child) => nodeToOmeDict(child));
+  }
+  if (node.path !== undefined) {
+    out.path = { type: node.path.type, path: node.path.path };
+  }
+  for (const [key, value] of Object.entries(node.extra ?? {})) {
+    out[key] = structuredClone(value);
+  }
+  return out;
+}
+
+function requireString(value: unknown, key: string, location: string): string {
+  if (typeof value !== "string" || value === "") {
+    throw new Error(
+      `An RFC-8 node must declare a non-empty string '${key}'; got ` +
+        `${JSON.stringify(value)} at ${location}.`,
+    );
+  }
+  return value;
+}
+
+function nodeFromDict(
+  data: Record<string, unknown>,
+  location: string,
+): OmeNode {
+  const nodeType = requireString(data.type, "type", location);
+  const name = requireString(data.name, "name", location);
+
+  const nodeId = data.id;
+  if (nodeId !== undefined && typeof nodeId !== "string") {
+    throw new Error(
+      `An RFC-8 node 'id' must be a string; got ${JSON.stringify(nodeId)} ` +
+        `at ${location}.`,
+    );
+  }
+
+  let attributes: Record<string, unknown> | undefined;
+  if (data.attributes !== undefined) {
+    if (!isRecord(data.attributes)) {
+      throw new Error(
+        `An RFC-8 node 'attributes' must be an object; got ` +
+          `${JSON.stringify(data.attributes)} at ${location}.`,
+      );
+    }
+    attributes = structuredClone(data.attributes);
+  }
+
+  let nodes: OmeNode[] | undefined;
+  if (data.nodes !== undefined) {
+    if (!Array.isArray(data.nodes)) {
+      throw new Error(
+        `An RFC-8 node 'nodes' must be an array of nodes; got ` +
+          `${JSON.stringify(data.nodes)} at ${location}.`,
+      );
+    }
+    nodes = data.nodes.map((child, index) => {
+      const childLocation = `${location}.nodes[${index}]`;
+      if (!isRecord(child)) {
+        throw new Error(
+          `An RFC-8 node 'nodes' entry must be an object; got ` +
+            `${JSON.stringify(child)} at ${childLocation}.`,
+        );
+      }
+      return nodeFromDict(child, childLocation);
+    });
+  }
+
+  let path: OmePath | undefined;
+  if (data.path !== undefined) {
+    if (!isRecord(data.path)) {
+      throw new Error(
+        `An RFC-8 node 'path' must be an object with 'type' and 'path'; ` +
+          `got ${JSON.stringify(data.path)} at ${location}.`,
+      );
+    }
+    path = {
+      type: requireString(data.path.type, "path.type", location),
+      path: requireString(data.path.path, "path.path", location),
+    };
+  }
+
+  const extra: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!NODE_FIELDS.has(key)) {
+      extra[key] = structuredClone(value);
+    }
+  }
+
+  return {
+    type: nodeType,
+    name,
+    ...(nodeId !== undefined && { id: nodeId }),
+    ...(attributes !== undefined && { attributes }),
+    ...(nodes !== undefined && { nodes }),
+    ...(path !== undefined && { path }),
+    ...(Object.keys(extra).length > 0 && { extra }),
+  };
+}
+
+/**
+ * Parse an `ome` value into the root node and the declared version.
+ *
+ * The root's `version` key is returned separately rather than modeled on
+ * the node: RFC-8 puts it on the root only, and the serializer stamps it
+ * back. A non-string `version` is reported rather than carried.
+ */
+export function nodeFromOmeDict(
+  data: unknown,
+): { node: OmeNode; version?: string | undefined } {
+  if (!isRecord(data)) {
+    throw new Error(
+      `An RFC-8 'ome' value must be an object; got ${JSON.stringify(data)}.`,
+    );
+  }
+  const version = data.version;
+  if (version !== undefined && typeof version !== "string") {
+    throw new Error(
+      `An RFC-8 'version' must be a string; got ${JSON.stringify(version)}.`,
+    );
+  }
+  const rootData = Object.fromEntries(
+    Object.entries(data).filter(([key]) => key !== "version"),
+  );
+  return {
+    node: nodeFromDict(rootData, "ome"),
+    ...(version !== undefined && { version }),
+  };
+}
+
+const HTTP_SCHEMES = ["http://", "https://"];
+
+function isHttp(location: string): boolean {
+  return HTTP_SCHEMES.some((scheme) => location.startsWith(scheme));
+}
+
+function joinLocalPath(base: string, relative: string): string {
+  const segments = [...base.split("/"), ...relative.split("/")];
+  const out: string[] = [];
+  for (const [index, segment] of segments.entries()) {
+    if (segment === "" && index > 0) {
+      continue;
+    }
+    if (segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      if (out.length > 1 || (out.length === 1 && out[0] !== "")) {
+        out.pop();
+      }
+      continue;
+    }
+    out.push(segment);
+  }
+  return out.join("/");
+}
+
+/**
+ * Resolve a path's location string against the document base.
+ *
+ * `base` is the directory-like location of the document that carries the
+ * path: the Zarr group directory or URL for a document stored in group
+ * attributes, the parent directory or URL of a standalone JSON file. A
+ * relative path (IETF RFC 1808) is resolved against it; `file://` paths
+ * (IETF RFC 8089) and `http(s)://` URLs stand alone.
+ */
+export function resolveLocation(path: OmePath, base?: string): string {
+  const location = path.path;
+  if (isHttp(location)) {
+    return location;
+  }
+  if (location.startsWith("file://")) {
+    const parsed = new URL(location);
+    // RFC 8089 permits a Windows drive in the authority position
+    // (`file://C:/...`); rejoin it with the path before decoding.
+    return decodeURIComponent(`${parsed.host}${parsed.pathname}`);
+  }
+  if (base === undefined) {
+    return location;
+  }
+  if (isHttp(base)) {
+    return new URL(location, `${base.replace(/\/+$/, "")}/`).href;
+  }
+  return joinLocalPath(base, location);
+}
+
+/**
+ * The base future relative paths in the resolved document count from.
+ *
+ * A `"zarr"` path's document lives in the group's own attributes, so the
+ * group location is the base; a `"json"` path's document is the file, so
+ * its parent is.
+ */
+export function documentBase(path: OmePath, location: string): string {
+  if (path.type === PATH_TYPE_ZARR) {
+    return location;
+  }
+  if (isHttp(location)) {
+    return new URL(".", location).href.replace(/\/+$/, "");
+  }
+  const separator = location.lastIndexOf("/");
+  return separator <= 0 ? location : location.slice(0, separator);
+}
+
+/** The environment-specific access a collection loader needs. */
+export interface CollectionIo {
+  /** Root group attributes of the Zarr store at `location`, or undefined. */
+  readZarrAttrs(
+    location: string,
+  ): Promise<Record<string, unknown> | undefined>;
+  /** The parsed JSON document at `location`. */
+  readJsonDocument(location: string): Promise<unknown>;
+  /** A multiscales image store at `location`, via the OME-Zarr reader. */
+  readImage(location: string): Promise<NgffMultiscales>;
+}
+
+/**
+ * Load the document an RFC-8 path locates.
+ *
+ * Returns the resolved location and the raw document: the Zarr group's
+ * attribute mapping or the JSON file's root object. A prefixed extension
+ * path type is opaque to this package and reported as such.
+ */
+export async function resolveOmeDocument(
+  path: OmePath,
+  base: string | undefined,
+  io: CollectionIo,
+): Promise<{ location: string; document: Record<string, unknown> }> {
+  if (path.type !== PATH_TYPE_ZARR && path.type !== PATH_TYPE_JSON) {
+    throw new Error(
+      `Path type '${path.type}' is not resolvable by ngff-zarr; only ` +
+        `'zarr' and 'json' paths are. A prefixed extension type is opaque ` +
+        `to implementations that do not recognize it.`,
+    );
+  }
+  const location = resolveLocation(path, base);
+  if (path.type === PATH_TYPE_ZARR) {
+    const document = await io.readZarrAttrs(location);
+    if (document === undefined) {
+      throw new Error(
+        `No Zarr group with attributes found at '${location}' (resolved ` +
+          `from path '${path.path}').`,
+      );
+    }
+    return { location, document };
+  }
+  const document = await io.readJsonDocument(location);
+  if (!isRecord(document)) {
+    throw new Error(
+      `The JSON document at '${location}' (resolved from path ` +
+        `'${path.path}') is not an object.`,
+    );
+  }
+  return { location, document };
+}
+
+/** What loading a node can produce; mirrors the Python `LoadedNode`. */
+export type LoadedNode = NgffCollection | NgffMultiscales | OmeNode;
+
+function dispatchDocument(
+  path: OmePath,
+  location: string,
+  document: Record<string, unknown>,
+  fallbackVersion: string,
+  io: CollectionIo,
+): Promise<LoadedNode> | LoadedNode {
+  const ome = document.ome;
+  const nodeShaped = isRecord(ome) && "type" in ome && !("multiscales" in ome);
+  if (nodeShaped) {
+    const { node, version } = nodeFromOmeDict(ome);
+    if (isCollectionNode(node)) {
+      return new NgffCollection({
+        root: node,
+        base: documentBase(path, location),
+        version: version ?? fallbackVersion,
+      });
+    }
+    return node;
+  }
+  const hasMultiscales = "multiscales" in document ||
+    (isRecord(ome) && "multiscales" in ome);
+  if (hasMultiscales) {
+    if (path.type !== PATH_TYPE_ZARR) {
+      throw new Error(
+        `The document at '${location}' holds multiscales image metadata, ` +
+          `which only a 'zarr' path can designate; got path type ` +
+          `'${path.type}'.`,
+      );
+    }
+    return io.readImage(location);
+  }
+  throw new Error(
+    `The document at '${location}' is neither an RFC-8 node document nor ` +
+      `a multiscales image.`,
+  );
+}
+
+async function loadDocument(
+  collection: NgffCollection,
+  path: OmePath,
+  io: CollectionIo,
+): Promise<LoadedNode> {
+  const cacheKey = `${path.type}\u0000${
+    resolveLocation(path, collection.base)
+  }`;
+  const cached = collection.cache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached as LoadedNode;
+  }
+  const { location, document } = await resolveOmeDocument(
+    path,
+    collection.base,
+    io,
+  );
+  const loaded = await dispatchDocument(
+    path,
+    location,
+    document,
+    collection.version,
+    io,
+  );
+  collection.cache.set(cacheKey, loaded);
+  return loaded;
+}
+
+/**
+ * Materialize what `target` designates, dereferencing its path.
+ *
+ * `target` is a node of `collection` (or its `id` / `name` as a string), or
+ * a reference. A dereferenced collection document nests as another
+ * {@link NgffCollection} with its base moved to the referenced location; a
+ * multiscales image store (any OME-Zarr version up to 0.9.dev1) reads
+ * through the OME-Zarr reader; any other RFC-8 node document returns its
+ * parsed root node. An inline node (no `path`) stays in this document.
+ * Dereferenced documents are cached per resolved location.
+ */
+export async function loadCollectionNodeWith(
+  collection: NgffCollection,
+  target: OmeNode | Reference | string,
+  io: CollectionIo,
+): Promise<LoadedNode> {
+  if (typeof target === "string") {
+    target = collection.node(target);
+  }
+  if (!("type" in target)) {
+    const reference = target as Reference;
+    if (reference.path === undefined) {
+      return loadCollectionNodeWith(
+        collection,
+        collection.node(reference.id),
+        io,
+      );
+    }
+    const loaded = await loadDocument(collection, reference.path, io);
+    if (loaded instanceof NgffCollection) {
+      for (const node of loaded.walk()) {
+        if (node.id === reference.id) {
+          return loadCollectionNodeWith(loaded, node, io);
+        }
+      }
+    }
+    return loaded;
+  }
+  const node = target as OmeNode;
+  if (node.path !== undefined) {
+    return loadDocument(collection, node.path, io);
+  }
+  if (isCollectionNode(node)) {
+    return new NgffCollection({
+      root: node,
+      base: collection.base,
+      version: collection.version,
+    });
+  }
+  return node;
+}
+
+/**
+ * The `ome` node document in `attrs`, or a pointed error naming the reader
+ * that fits what the input actually is.
+ */
+export function nodeDocumentOrThrow(
+  attrs: Record<string, unknown>,
+  where: string,
+): Record<string, unknown> {
+  const ome = attrs.ome;
+  const isImage = "multiscales" in attrs ||
+    (isRecord(ome) && "multiscales" in ome);
+  if (isImage) {
+    throw new Error(
+      `The input at ${where} is a multiscales image store, not an RFC-8 ` +
+        `node document. Read it with fromOmeZarr().`,
+    );
+  }
+  if (!isRecord(ome) || !("type" in ome)) {
+    throw new Error(
+      `The input at ${where} carries no RFC-8 node document: expected an ` +
+        `'ome' object with a 'type' key (OME-Zarr 0.9.dev3).`,
+    );
+  }
+  return ome;
+}
+
+/** Root attribute keys the OME-Zarr writers own, across every version. */
+export const OME_ROOT_KEYS: ReadonlySet<string> = new Set([
+  "multiscales",
+  "omero",
+  "ome",
+]);
+
+/**
+ * Parse the root attributes of a collection store: the node document under
+ * `ome` plus the non-OME root attribute keys. With `validate` the raw
+ * document runs the RFC-8 structural rules, then the node schema.
+ */
+export function parseCollectionRootAttrs(
+  attrs: Record<string, unknown>,
+  where: string,
+  validate: boolean,
+): {
+  node: OmeNode;
+  version?: string | undefined;
+  rootAttributes?: Record<string, unknown> | undefined;
+} {
+  const ome = nodeDocumentOrThrow(attrs, where);
+  if (validate) {
+    const declared = typeof ome.version === "string" ? ome.version : undefined;
+    validateCollection(ome, declared);
+    OmeNodeDocumentSchema.parse(ome);
+  }
+  const rootAttributes = Object.fromEntries(
+    Object.entries(attrs).filter(([key]) => !OME_ROOT_KEYS.has(key)),
+  );
+  return {
+    ...nodeFromOmeDict(ome),
+    ...(Object.keys(rootAttributes).length > 0 && { rootAttributes }),
+  };
+}
+
+/**
+ * Parse a standalone JSON document: the node document under the root `ome`
+ * key. With `validate` the raw document runs the RFC-8 structural rules,
+ * then the node schema.
+ */
+export function parseCollectionJsonDocument(
+  document: unknown,
+  where: string,
+  validate: boolean,
+): { node: OmeNode; version?: string | undefined } {
+  if (!isRecord(document)) {
+    throw new Error(`The JSON document at ${where} is not an object.`);
+  }
+  const ome = nodeDocumentOrThrow(document, where);
+  if (validate) {
+    const declared = typeof ome.version === "string" ? ome.version : undefined;
+    validateCollection(ome, declared);
+    OmeNodeDocumentSchema.parse(ome);
+  }
+  return nodeFromOmeDict(ome);
+}
+
+/** Reject a collection write at any version but 0.9.dev3. */
+export function checkCollectionVersion(version: string): string {
+  if (version !== NgffVersion.V09dev3) {
+    throw new Error(
+      `Unsupported version for an RFC-8 node document: '${version}'. Only ` +
+        `'0.9.dev3' stores the node model.`,
+    );
+  }
+  return version;
+}
+
+/**
+ * Serialize an RFC-8 node document to its standalone JSON form,
+ * `{"ome": ...}`.
+ */
+export function toCollectionJsonDocument(
+  root: OmeNode,
+  version: string,
+): Record<string, unknown> {
+  return { ome: nodeToOmeDict(root, checkCollectionVersion(version)) };
+}

--- a/ts/src/io/from_collection_zarr-browser.ts
+++ b/ts/src/io/from_collection_zarr-browser.ts
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Reading RFC-8 node documents (OME-Zarr 0.9.dev3) in the browser.
+ *
+ * The environment-agnostic parsing, resolution and dispatch live in
+ * `collection_common.ts`; this module supplies fetch-based access only
+ * (http(s) URLs and in-memory stores; no local file system).
+ */
+
+import * as zarr from "zarrita";
+
+import { NgffCollection, type OmeNode, type Reference } from "../types/rfc8.ts";
+import {
+  type CollectionIo,
+  loadCollectionNodeWith as loadWithIo,
+  type LoadedNode,
+  parseCollectionJsonDocument,
+  parseCollectionRootAttrs,
+} from "./collection_common.ts";
+import { fromOmeZarr, type MemoryStore } from "./from_ngff_zarr-browser.ts";
+
+function isHttp(location: string): boolean {
+  return location.startsWith("http://") || location.startsWith("https://");
+}
+
+function resolveReadStore(
+  store: string | MemoryStore | zarr.Readable,
+): zarr.Readable {
+  if (typeof store !== "string") {
+    return store as zarr.Readable;
+  }
+  if (isHttp(store)) {
+    return new zarr.FetchStore(store);
+  }
+  throw new Error(
+    "Local file paths are not supported in browser environments. Use a " +
+      "MemoryStore or an http(s) URL instead.",
+  );
+}
+
+async function readJsonDocument(location: string): Promise<unknown> {
+  if (!isHttp(location)) {
+    throw new Error(
+      "Local file paths are not supported in browser environments; " +
+        `cannot read '${location}'.`,
+    );
+  }
+  const response = await fetch(location);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch '${location}': HTTP ${response.status}`);
+  }
+  return await response.json();
+}
+
+/** The browser environment access for the collection loader. */
+export const browserCollectionIo: CollectionIo = {
+  readZarrAttrs: async (location) => {
+    try {
+      const root = await zarr.open(resolveReadStore(location), {
+        kind: "group",
+      });
+      return root.attrs as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  },
+  readJsonDocument,
+  readImage: (location) => fromOmeZarr(location),
+};
+
+export interface FromCollectionOptions {
+  /** Run the RFC-8 structural rules and schema against the raw document. */
+  validate?: boolean;
+}
+
+/**
+ * Read an RFC-8 node document from a Zarr store's root group. See the
+ * Node.js/Deno `fromCollectionZarr` for the semantics; this variant reads
+ * http(s) URLs and in-memory stores only.
+ */
+export async function fromCollectionZarr(
+  store: string | MemoryStore | zarr.Readable,
+  options: FromCollectionOptions = {},
+): Promise<NgffCollection> {
+  const base = typeof store === "string"
+    ? store.replace(/\/+$/, "")
+    : undefined;
+  const root = await zarr.open(resolveReadStore(store), { kind: "group" });
+  const attrs = root.attrs as Record<string, unknown>;
+  const { node, version, rootAttributes } = parseCollectionRootAttrs(
+    attrs,
+    `'${store}'`,
+    options.validate ?? false,
+  );
+  return new NgffCollection({ root: node, base, version, rootAttributes });
+}
+
+/**
+ * Read an RFC-8 node document from standalone JSON: an http(s) URL or an
+ * already-parsed object.
+ */
+export async function fromCollectionJson(
+  source: string | Record<string, unknown>,
+  options: FromCollectionOptions = {},
+): Promise<NgffCollection> {
+  let document: unknown;
+  let base: string | undefined;
+  let where: string;
+  if (typeof source === "string") {
+    document = await readJsonDocument(source);
+    where = `'${source}'`;
+    base = new URL(".", source).href.replace(/\/+$/, "");
+  } else {
+    document = source;
+    where = "the given object";
+  }
+  const { node, version } = parseCollectionJsonDocument(
+    document,
+    where,
+    options.validate ?? false,
+  );
+  return new NgffCollection({ root: node, base, version });
+}
+
+/**
+ * Materialize what `target` designates within `collection`, dereferencing
+ * its path over fetch. See `loadCollectionNode` in `collection_common.ts`
+ * for the dispatch rules.
+ */
+export function loadCollectionNode(
+  collection: NgffCollection,
+  target: OmeNode | Reference | string,
+): Promise<LoadedNode> {
+  return loadWithIo(collection, target, browserCollectionIo);
+}

--- a/ts/src/io/from_collection_zarr.ts
+++ b/ts/src/io/from_collection_zarr.ts
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Reading RFC-8 node documents (OME-Zarr 0.9.dev3) in Node.js/Deno.
+ *
+ * The environment-agnostic parsing, resolution and dispatch live in
+ * `collection_common.ts`; this module supplies local-file and network
+ * access. The browser build uses `from_collection_zarr-browser.ts`.
+ */
+
+import * as zarr from "zarrita";
+
+import { NgffCollection, type OmeNode, type Reference } from "../types/rfc8.ts";
+import {
+  type CollectionIo,
+  loadCollectionNodeWith as loadWithIo,
+  type LoadedNode,
+  parseCollectionJsonDocument,
+  parseCollectionRootAttrs,
+} from "./collection_common.ts";
+import { fromOmeZarr, type MemoryStore } from "./from_ngff_zarr.ts";
+
+function isHttp(location: string): boolean {
+  return location.startsWith("http://") || location.startsWith("https://");
+}
+
+async function resolveReadStore(
+  store: string | MemoryStore | zarr.Readable,
+): Promise<zarr.Readable> {
+  if (typeof store !== "string") {
+    return store as zarr.Readable;
+  }
+  if (isHttp(store)) {
+    return new zarr.FetchStore(store);
+  }
+  if (typeof window !== "undefined") {
+    throw new Error(
+      "Local file paths are not supported in browser environments. Use a " +
+        "MemoryStore or an http(s) URL instead.",
+    );
+  }
+  const { FileSystemStore } = await import("@zarrita/storage");
+  const normalizedPath = store.replace(/^\/([A-Za-z]:)/, "$1");
+  return new FileSystemStore(normalizedPath) as unknown as zarr.Readable;
+}
+
+async function readZarrAttrs(
+  location: string,
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    const store = await resolveReadStore(location);
+    const root = await zarr.open(store, { kind: "group" });
+    return root.attrs as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readJsonDocument(location: string): Promise<unknown> {
+  if (isHttp(location)) {
+    const response = await fetch(location);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch '${location}': HTTP ${response.status}`,
+      );
+    }
+    return await response.json();
+  }
+  const { readFile } = await import("node:fs/promises");
+  return JSON.parse(await readFile(location, "utf-8"));
+}
+
+/** The Node.js/Deno environment access for the collection loader. */
+export const nodeCollectionIo: CollectionIo = {
+  readZarrAttrs,
+  readJsonDocument,
+  readImage: (location) => fromOmeZarr(location),
+};
+
+export interface FromCollectionOptions {
+  /** Run the RFC-8 structural rules and schema against the raw document. */
+  validate?: boolean;
+}
+
+/**
+ * Read an RFC-8 node document from a Zarr store's root group.
+ *
+ * The store is a local directory path, an http(s) URL, or a key-to-bytes
+ * store whose root group attributes carry the document under `ome`. The
+ * root may be any node type; a collection is typical. The returned
+ * collection's resolution base is the store, so relative paths in the
+ * document dereference from it.
+ */
+export async function fromCollectionZarr(
+  store: string | MemoryStore | zarr.Readable,
+  options: FromCollectionOptions = {},
+): Promise<NgffCollection> {
+  const base = typeof store === "string"
+    ? store.replace(/\/+$/, "")
+    : undefined;
+  const resolvedStore = await resolveReadStore(store);
+  const root = await zarr.open(resolvedStore, { kind: "group" });
+  const attrs = root.attrs as Record<string, unknown>;
+  const { node, version, rootAttributes } = parseCollectionRootAttrs(
+    attrs,
+    `'${store}'`,
+    options.validate ?? false,
+  );
+  return new NgffCollection({ root: node, base, version, rootAttributes });
+}
+
+/**
+ * Read an RFC-8 node document from standalone JSON.
+ *
+ * `source` is the path or http(s) URL of a JSON file whose root object
+ * carries the document under `ome`, or such a parsed object itself. For an
+ * in-memory object the collection has no resolution base, so its relative
+ * paths cannot be dereferenced.
+ */
+export async function fromCollectionJson(
+  source: string | Record<string, unknown>,
+  options: FromCollectionOptions = {},
+): Promise<NgffCollection> {
+  let document: unknown;
+  let base: string | undefined;
+  let where: string;
+  if (typeof source === "string") {
+    document = await readJsonDocument(source);
+    where = `'${source}'`;
+    if (isHttp(source)) {
+      base = new URL(".", source).href.replace(/\/+$/, "");
+    } else {
+      const separator = source.lastIndexOf("/");
+      base = separator <= 0 ? "." : source.slice(0, separator);
+    }
+  } else {
+    document = source;
+    where = "the given object";
+  }
+  const { node, version } = parseCollectionJsonDocument(
+    document,
+    where,
+    options.validate ?? false,
+  );
+  return new NgffCollection({ root: node, base, version });
+}
+
+/**
+ * Materialize what `target` designates within `collection`, dereferencing
+ * its path with local-file and network access. See `loadCollectionNode` in
+ * `collection_common.ts` for the dispatch rules.
+ */
+export function loadCollectionNode(
+  collection: NgffCollection,
+  target: OmeNode | Reference | string,
+): Promise<LoadedNode> {
+  return loadWithIo(collection, target, nodeCollectionIo);
+}

--- a/ts/src/io/from_ngff_zarr-browser.ts
+++ b/ts/src/io/from_ngff_zarr-browser.ts
@@ -11,7 +11,11 @@ import type { AxisUnit } from "../types/units.ts";
 import type { Metadata, Omero } from "../types/zarr_metadata.ts";
 import { extractMethodMetadata } from "../utils/parse_metadata.ts";
 import { fromZarrAttrsV06 } from "../utils/from_zarr_attrs.ts";
-import { isV06Version, NgffVersion } from "../types/supported_versions.ts";
+import {
+  type ImageVersion,
+  isV06Version,
+  NgffVersion,
+} from "../types/supported_versions.ts";
 
 export type { ChunkCache } from "../utils/worker_pool.ts";
 
@@ -19,7 +23,7 @@ export interface FromOmeZarrOptions {
   /** Enable schema validation of OME-Zarr metadata. */
   validate?: boolean;
   /** Expected OME-Zarr version. */
-  version?: "0.4" | "0.5" | "0.6" | "0.9.dev1";
+  version?: ImageVersion;
   /**
    * Optional decoded-chunk cache passed to `zarrGet` calls.
    *
@@ -102,6 +106,21 @@ export async function fromOmeZarr(
       omeForVersion && typeof omeForVersion.version === "string"
         ? omeForVersion.version
         : undefined;
+    // RFC-8: at 0.9.dev3 the root `ome` value is a typed node document, not
+    // a multiscales wrapper, so neither delegate below can parse it; without
+    // this guard the store would die on the generic no-multiscales error
+    // instead of naming the collection reader.
+    if (onDiskVersion === NgffVersion.V09dev3) {
+      const nodeType = omeForVersion?.type;
+      throw new Error(
+        `The input is an OME-Zarr 0.9.dev3 store whose root is a ` +
+          `'${nodeType}' node. 0.9.dev3 stores the RFC-8 node model in ` +
+          `place of the multiscales metadata; use fromCollectionZarr() to ` +
+          `read it. fromOmeZarr() reads multiscale image stores written at ` +
+          `earlier versions.`,
+      );
+    }
+
     // 0.9.dev1 carries the same coordinateSystems layout as v0.6, so it reads
     // through the same delegate. Without this the store falls through to the
     // v0.4/v0.5 parser below, which expects a flat `axes` entry and cannot read

--- a/ts/src/io/from_ngff_zarr.ts
+++ b/ts/src/io/from_ngff_zarr.ts
@@ -3,7 +3,11 @@
 import * as zarr from "zarrita";
 
 import { NgffMultiscales } from "../types/multiscales.ts";
-import { isV06Version, NgffVersion } from "../types/supported_versions.ts";
+import {
+  type ImageVersion,
+  isV06Version,
+  NgffVersion,
+} from "../types/supported_versions.ts";
 import {
   fromZarrAttrsV04,
   fromZarrAttrsV05,
@@ -21,7 +25,7 @@ export interface FromOmeZarrOptions {
   /** Enable schema validation of OME-Zarr metadata. */
   validate?: boolean;
   /** Expected OME-Zarr version. */
-  version?: "0.4" | "0.5" | "0.6" | "0.9.dev1";
+  version?: ImageVersion;
   /**
    * Optional decoded-chunk cache passed to `zarrGet` calls.
    *
@@ -119,6 +123,25 @@ export async function fromOmeZarr(
     const multiscalesSource = hasOmeWrapper
       ? (rootAttrs.ome as Record<string, unknown>)
       : rootAttrs;
+
+    // RFC-8: at 0.9.dev3 the root `ome` value is a typed node document, not
+    // a multiscales wrapper, so the multiscales readers below cannot parse
+    // it; without this guard the store would die on the generic no-multiscales
+    // error instead of naming the collection reader.
+    if (
+      hasOmeWrapper &&
+      (rootAttrs.ome as Record<string, unknown>).version ===
+        NgffVersion.V09dev3
+    ) {
+      const nodeType = (rootAttrs.ome as Record<string, unknown>).type;
+      throw new Error(
+        `The input is an OME-Zarr 0.9.dev3 store whose root is a ` +
+          `'${nodeType}' node. 0.9.dev3 stores the RFC-8 node model in ` +
+          `place of the multiscales metadata; use fromCollectionZarr() to ` +
+          `read it. fromOmeZarr() reads multiscale image stores written at ` +
+          `earlier versions.`,
+      );
+    }
 
     if (!multiscalesSource.multiscales) {
       throw new Error("No multiscales metadata found in Zarr store");

--- a/ts/src/io/to_collection_zarr-browser.ts
+++ b/ts/src/io/to_collection_zarr-browser.ts
@@ -58,7 +58,24 @@ export async function toCollectionZarr(
         `writer derives the OME metadata from the collection.`,
     );
   }
-  const attributes: Record<string, unknown> = { ...(rootAttributes ?? {}) };
+  const attributes: Record<string, unknown> = {};
+  try {
+    const existing = await zarr.open(store as zarr.Readable, {
+      kind: "group",
+    });
+    for (
+      const [key, value] of Object.entries(
+        existing.attrs as Record<string, unknown>,
+      )
+    ) {
+      if (!OME_ROOT_KEYS.has(key)) {
+        attributes[key] = value;
+      }
+    }
+  } catch {
+    // No existing root group: nothing to preserve.
+  }
+  Object.assign(attributes, rootAttributes ?? {});
   attributes.ome = nodeToOmeDict(root, version);
   const location = zarr.root(store);
   await zarr.create(location, { attributes });

--- a/ts/src/io/to_collection_zarr-browser.ts
+++ b/ts/src/io/to_collection_zarr-browser.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Writing RFC-8 node documents (OME-Zarr 0.9.dev3) in the browser: into an
+ * in-memory store, or to a standalone JSON document the caller persists.
+ */
+
+import * as zarr from "zarrita";
+
+import { NgffCollection, type OmeNode } from "../types/rfc8.ts";
+import { validateCollection } from "../utils/rfc8_validation.ts";
+import {
+  checkCollectionVersion,
+  nodeToOmeDict,
+  OME_ROOT_KEYS,
+  toCollectionJsonDocument,
+} from "./collection_common.ts";
+import type { MemoryStore } from "./from_ngff_zarr-browser.ts";
+
+export interface ToCollectionOptions {
+  /** Version to stamp on the root node. Only `"0.9.dev3"` is accepted. */
+  version?: string;
+  /** Run the RFC-8 structural rules on the outgoing document. */
+  validate?: boolean;
+  /** Root attribute keys written beside the OME key. */
+  rootAttributes?: Record<string, unknown> | undefined;
+}
+
+function collectionRoot(collection: NgffCollection | OmeNode): OmeNode {
+  return collection instanceof NgffCollection ? collection.root : collection;
+}
+
+/**
+ * Write an RFC-8 node document as the root group of an in-memory store.
+ * See the Node.js/Deno `toCollectionZarr` for the semantics.
+ */
+export async function toCollectionZarr(
+  store: MemoryStore,
+  collection: NgffCollection | OmeNode,
+  options: ToCollectionOptions = {},
+): Promise<void> {
+  const version = checkCollectionVersion(options.version ?? "0.9.dev3");
+  const root = collectionRoot(collection);
+  if (options.validate ?? true) {
+    validateCollection(nodeToOmeDict(root), version);
+  }
+  const rootAttributes = options.rootAttributes ??
+    (collection instanceof NgffCollection
+      ? collection.rootAttributes
+      : undefined);
+  const owned = Object.keys(rootAttributes ?? {}).filter((key) =>
+    OME_ROOT_KEYS.has(key)
+  );
+  if (owned.length > 0) {
+    throw new Error(
+      `rootAttributes cannot set ${JSON.stringify(owned.sort())}: the ` +
+        `writer derives the OME metadata from the collection.`,
+    );
+  }
+  const attributes: Record<string, unknown> = { ...(rootAttributes ?? {}) };
+  attributes.ome = nodeToOmeDict(root, version);
+  const location = zarr.root(store);
+  await zarr.create(location, { attributes });
+}
+
+export interface ToCollectionJsonOptions {
+  /** Version to stamp on the root node. Only `"0.9.dev3"` is accepted. */
+  version?: string;
+  /** Run the RFC-8 structural rules on the outgoing document. */
+  validate?: boolean;
+}
+
+/** Serialize an RFC-8 node document to its standalone JSON form. */
+export function toCollectionJson(
+  collection: NgffCollection | OmeNode,
+  options: ToCollectionJsonOptions = {},
+): Record<string, unknown> {
+  const version = options.version ?? "0.9.dev3";
+  const root = collectionRoot(collection);
+  if (options.validate ?? true) {
+    validateCollection(nodeToOmeDict(root), checkCollectionVersion(version));
+  }
+  return toCollectionJsonDocument(root, version);
+}

--- a/ts/src/io/to_collection_zarr.ts
+++ b/ts/src/io/to_collection_zarr.ts
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Writing RFC-8 node documents (OME-Zarr 0.9.dev3) in Node.js/Deno.
+ *
+ * Writing is metadata-only: a collection document references image stores,
+ * it does not contain their arrays, so the referenced stores are written
+ * separately (`toOmeZarr`) at their own versions.
+ */
+
+import * as zarr from "zarrita";
+
+import { NgffCollection, type OmeNode } from "../types/rfc8.ts";
+import { validateCollection } from "../utils/rfc8_validation.ts";
+import {
+  checkCollectionVersion,
+  nodeToOmeDict,
+  OME_ROOT_KEYS,
+  toCollectionJsonDocument,
+} from "./collection_common.ts";
+import type { MemoryStore } from "./from_ngff_zarr.ts";
+
+export interface ToCollectionOptions {
+  /** Version to stamp on the root node. Only `"0.9.dev3"` is accepted. */
+  version?: string;
+  /** Run the RFC-8 structural rules on the outgoing document. */
+  validate?: boolean;
+  /** Root attribute keys written beside the OME key. */
+  rootAttributes?: Record<string, unknown> | undefined;
+}
+
+function collectionRoot(collection: NgffCollection | OmeNode): OmeNode {
+  return collection instanceof NgffCollection ? collection.root : collection;
+}
+
+async function resolveWriteStore(
+  store: string | MemoryStore,
+): Promise<MemoryStore | unknown> {
+  if (store instanceof Map) {
+    return store;
+  }
+  if (
+    typeof store === "string" &&
+    (store.startsWith("http://") || store.startsWith("https://"))
+  ) {
+    throw new Error(
+      "HTTP/HTTPS URLs are read-only and cannot be used for writing. Use a " +
+        "local file path instead.",
+    );
+  }
+  if (typeof window !== "undefined") {
+    throw new Error(
+      "Local file paths are not supported in browser environments. Use a " +
+        "MemoryStore instead.",
+    );
+  }
+  const { FileSystemStore } = await import("@zarrita/storage");
+  const normalizedPath = (store as string).replace(/^\/([A-Za-z]:)/, "$1");
+  return new FileSystemStore(normalizedPath);
+}
+
+/**
+ * Write an RFC-8 node document as a Zarr store's root group.
+ *
+ * Writes metadata only: a Zarr format 3 group whose `attributes.ome` is the
+ * serialized document. Unlike `toOmeZarr` nothing beneath the root is ever
+ * removed, so a collection root can hold the very stores its document
+ * references. Non-OME attributes of an existing root survive;
+ * `rootAttributes` (or, when omitted, the collection's own
+ * `rootAttributes`) are written over them, and the OME key over both.
+ */
+export async function toCollectionZarr(
+  store: string | MemoryStore,
+  collection: NgffCollection | OmeNode,
+  options: ToCollectionOptions = {},
+): Promise<void> {
+  const version = checkCollectionVersion(options.version ?? "0.9.dev3");
+  const root = collectionRoot(collection);
+  if (options.validate ?? true) {
+    validateCollection(nodeToOmeDict(root), version);
+  }
+  const rootAttributes = options.rootAttributes ??
+    (collection instanceof NgffCollection
+      ? collection.rootAttributes
+      : undefined);
+  const owned = Object.keys(rootAttributes ?? {}).filter((key) =>
+    OME_ROOT_KEYS.has(key)
+  );
+  if (owned.length > 0) {
+    throw new Error(
+      `rootAttributes cannot set ${JSON.stringify(owned.sort())}: the ` +
+        `writer derives the OME metadata from the collection.`,
+    );
+  }
+  const resolvedStore = await resolveWriteStore(store);
+  const attributes: Record<string, unknown> = {};
+  try {
+    const existing = await zarr.open(resolvedStore as zarr.Readable, {
+      kind: "group",
+    });
+    for (
+      const [key, value] of Object.entries(
+        existing.attrs as Record<string, unknown>,
+      )
+    ) {
+      if (!OME_ROOT_KEYS.has(key)) {
+        attributes[key] = value;
+      }
+    }
+  } catch {
+    // No existing root group: nothing to preserve.
+  }
+  Object.assign(attributes, rootAttributes ?? {});
+  attributes.ome = nodeToOmeDict(root, version);
+  const location = zarr.root(resolvedStore as MemoryStore);
+  await zarr.create(location, { attributes });
+}
+
+export interface ToCollectionJsonOptions {
+  /** Version to stamp on the root node. Only `"0.9.dev3"` is accepted. */
+  version?: string;
+  /** Run the RFC-8 structural rules on the outgoing document. */
+  validate?: boolean;
+  /** Also write the document to this local file path. */
+  path?: string;
+}
+
+/**
+ * Serialize an RFC-8 node document to standalone JSON.
+ *
+ * Returns the `{"ome": ...}` document; when `path` is given it is also
+ * written there as UTF-8 JSON.
+ */
+export async function toCollectionJson(
+  collection: NgffCollection | OmeNode,
+  options: ToCollectionJsonOptions = {},
+): Promise<Record<string, unknown>> {
+  const version = options.version ?? "0.9.dev3";
+  const root = collectionRoot(collection);
+  if (options.validate ?? true) {
+    validateCollection(nodeToOmeDict(root), checkCollectionVersion(version));
+  }
+  const document = toCollectionJsonDocument(root, version);
+  if (options.path !== undefined) {
+    if (typeof window !== "undefined") {
+      throw new Error(
+        "Local file paths are not supported in browser environments. Use " +
+          "the returned document instead.",
+      );
+    }
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(
+      options.path,
+      `${JSON.stringify(document, null, 2)}\n`,
+      "utf-8",
+    );
+  }
+  return document;
+}

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -5,6 +5,7 @@
 import * as zarr from "zarrita";
 
 import type { NgffMultiscales } from "../types/multiscales.ts";
+import type { ImageVersion } from "../types/supported_versions.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
@@ -20,7 +21,7 @@ export { isOzxPath } from "./rfc9_zip.ts";
 
 export interface ToOmeZarrOptions {
   overwrite?: boolean;
-  version?: "0.4" | "0.5" | "0.6" | "0.9.dev1";
+  version?: ImageVersion;
   chunksPerShard?: number | number[] | Record<string, number>;
   /**
    * Custom codec pipeline for array compression. When omitted the default

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -3,6 +3,7 @@
 import * as zarr from "zarrita";
 
 import type { NgffMultiscales } from "../types/multiscales.ts";
+import type { ImageVersion } from "../types/supported_versions.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
@@ -23,7 +24,7 @@ export interface ToOmeZarrOptions {
    * it defaults to 0.5. If explicitly set to any other value for .ozx files,
    * an error will be thrown.
    */
-  version?: "0.4" | "0.5" | "0.6" | "0.9.dev1";
+  version?: ImageVersion;
   chunksPerShard?: number | number[] | Record<string, number>;
   /**
    * Custom codec pipeline for array compression. When omitted the default

--- a/ts/src/io/to_ngff_zarr_ozx_common.ts
+++ b/ts/src/io/to_ngff_zarr_ozx_common.ts
@@ -18,6 +18,7 @@ import {
   legacyTopLevelTransforms,
 } from "../utils/v06_metadata.ts";
 import {
+  type ImageVersion,
   NgffVersion,
   V06_ONDISK_VERSION,
 } from "../types/supported_versions.ts";
@@ -171,8 +172,20 @@ export function processAxes(
  */
 export function buildRootAttributes(
   metadata: MetadataInterface,
-  version: "0.4" | "0.5" | "0.6" | "0.9.dev1",
+  version: ImageVersion,
 ): Record<string, unknown> {
+  // The ImageVersion union excludes "0.9.dev3" at compile time, but plain
+  // JavaScript callers can still pass it; without this runtime refusal the
+  // string would fall through to the bare-multiscales v0.4 arm below.
+  if ((version as string) === NgffVersion.V09dev3) {
+    throw new Error(
+      'version="0.9.dev3" stores the RFC-8 node model in place of the ' +
+        "multiscales metadata; writing images at 0.9.dev3 is not " +
+        "implemented yet (issue #714). Write the image at 0.9.dev1 and " +
+        "reference it from a 0.9.dev3 collection with toCollectionZarr().",
+    );
+  }
+
   gateAxisModel(metadata, version);
 
   // Process axes (orientation included when present).

--- a/ts/src/io/upgrade_ome_zarr_common.ts
+++ b/ts/src/io/upgrade_ome_zarr_common.ts
@@ -19,6 +19,7 @@ import type { NgffMultiscales } from "../types/multiscales.ts";
 import type { MemoryStore } from "./rfc9_zip.ts";
 import { detectVersion } from "../utils/parse_metadata.ts";
 import {
+  type ImageVersion,
   isV06Version,
   V06_ONDISK_VERSION,
 } from "../types/supported_versions.ts";
@@ -40,7 +41,7 @@ export interface UpgradeOmeZarrOptions {
    */
   output?: string | MemoryStore;
   /** Target OME-Zarr specification version. Defaults to `"0.6"`. */
-  version?: "0.4" | "0.5" | "0.6" | "0.9.dev1";
+  version?: ImageVersion;
   /** Validate the source metadata against the NGFF schema while reading. */
   validate?: boolean;
   /**
@@ -57,7 +58,7 @@ export interface UpgradeOmeZarrDeps {
     store: UpgradeInput,
     options?: {
       validate?: boolean;
-      version?: "0.4" | "0.5" | "0.6" | "0.9.dev1";
+      version?: ImageVersion;
     },
   ) => Promise<NgffMultiscales>;
   toOmeZarr: (
@@ -65,7 +66,7 @@ export interface UpgradeOmeZarrDeps {
     multiscales: NgffMultiscales,
     options?: {
       overwrite?: boolean;
-      version?: "0.4" | "0.5" | "0.6" | "0.9.dev1";
+      version?: ImageVersion;
     },
   ) => Promise<void>;
   /**
@@ -110,7 +111,7 @@ function onDiskVersion(rootAttrs: Record<string, unknown>): string | undefined {
  * `_ondisk_version_for`.
  */
 function onDiskVersionFor(
-  version: "0.4" | "0.5" | "0.6" | "0.9.dev1",
+  version: ImageVersion,
 ): string {
   return version === "0.6" ? V06_ONDISK_VERSION : version;
 }

--- a/ts/src/mod.ts
+++ b/ts/src/mod.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 export { config, setWorkerPoolSize } from "./config.ts";
+export * from "./io/collection_common.ts";
+export * from "./io/from_collection_zarr.ts";
 export * from "./io/from_ngff_zarr.ts";
 export * from "./io/hcs.ts";
 export * from "./io/itk_image_to_ngff_image.ts";
@@ -18,6 +20,7 @@ export {
   readOzxJsonFirst,
   readOzxVersion,
 } from "./io/rfc9_zip.ts";
+export * from "./io/to_collection_zarr.ts";
 export * from "./io/to_ngff_zarr.ts";
 // upgradeOmeZarr: spec-version upgrade (in-place metadata rewrite or
 // write-to-new-store). In-place upgrade of a local *path* store is Node/Deno-
@@ -32,6 +35,7 @@ export * from "./process/to_multiscales-node.ts";
 export * from "./schemas/methods.ts";
 export * from "./schemas/multiscales.ts";
 export * from "./schemas/ngff_image.ts";
+export * from "./schemas/rfc8.ts";
 export * from "./schemas/units.ts";
 export * from "./schemas/zarr_metadata.ts";
 export * from "./types/array_interface.ts";
@@ -40,6 +44,7 @@ export * from "./types/methods.ts";
 export * from "./types/multiscales.ts";
 export * from "./types/ngff_image.ts";
 export * from "./types/rfc4.ts";
+export * from "./types/rfc8.ts";
 export * from "./types/supported_versions.ts";
 export * from "./types/units.ts";
 export * from "./types/zarr_metadata.ts";
@@ -99,6 +104,18 @@ export {
   extractMethodMetadata,
   parseOmero,
 } from "./utils/parse_metadata.ts";
+export {
+  CORE_PATH_TYPES,
+  validateCollection,
+  validateNodeIdFormat,
+  validateNodeIdUnique,
+  validateNodeNameRequired,
+  validateNodeNameUnique,
+  validateNodeNodesXorPath,
+  validateNodeTypeRequired,
+  validatePathTypeKnown,
+  XOR_NODE_TYPES,
+} from "./utils/rfc8_validation.ts";
 export {
   SpecRule,
   type ValidateOptions,

--- a/ts/src/schemas/index.ts
+++ b/ts/src/schemas/index.ts
@@ -39,6 +39,7 @@ export {
 
 // Coordinate systems (RFC5)
 export * from "./coordinate_systems.ts";
+export * from "./rfc8.ts";
 
 // Zarr metadata schemas (with RFC4 integration)
 export {

--- a/ts/src/schemas/rfc8.ts
+++ b/ts/src/schemas/rfc8.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Zod schemas for the RFC-8 node model (OME-Zarr 0.9.dev3).
+ *
+ * Loose objects throughout: RFC-8 declares node types, attribute keys and
+ * path types as extension points, so unknown and prefixed keys must pass
+ * through untouched. The node schema is recursive (`nodes` holds nodes) and
+ * therefore stays a plain `z.lazy` rather than joining the compiled-schema
+ * set. The Python port validates the same shape with the repo-authored
+ * `spec/rfc/8/node.schema.json`.
+ */
+
+import { z } from "zod";
+
+/** The RFC-8 id production, shared by node ids and reference ids. */
+export const Rfc8IdSchema = z.string().regex(
+  /^[a-zA-Z0-9\-_.]+$/,
+  "an RFC-8 id must match [a-zA-Z0-9-_.]+",
+);
+
+/** RFC-8 `Path`: `zarr`, `json`, or a prefixed extension type. */
+export const OmePathSchema = z.strictObject({
+  type: z.string().min(1).refine(
+    (value) => value === "zarr" || value === "json" || /^[^:]+:.+$/.test(value),
+    "a path type must be 'zarr', 'json', or a prefixed extension type",
+  ),
+  path: z.string().min(1),
+});
+
+/** RFC-8 `Reference`: an id plus, for external references, a path. */
+export const ReferenceSchema = z.looseObject({
+  id: Rfc8IdSchema,
+  path: OmePathSchema.optional(),
+});
+
+/**
+ * RFC-8 `Node`: `type` and `name` required, everything else optional and
+ * open-world. `nodes`-XOR-`path` and id uniqueness are structural rules
+ * (`validateCollection`), not schema constraints, matching the split in the
+ * Python port.
+ */
+export const OmeNodeSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.looseObject({
+    type: z.string().min(1),
+    id: Rfc8IdSchema.optional(),
+    name: z.string().min(1),
+    attributes: z.record(z.string(), z.unknown()).optional(),
+    nodes: z.array(OmeNodeSchema).optional(),
+    path: OmePathSchema.optional(),
+  })
+);
+
+/**
+ * The root `ome` value of a stored 0.9.dev3 document: a node that also
+ * carries the root-only `version` key.
+ */
+export const OmeNodeDocumentSchema = z.intersection(
+  OmeNodeSchema,
+  z.looseObject({ version: z.literal("0.9.dev3") }),
+);

--- a/ts/src/types/rfc8.ts
+++ b/ts/src/types/rfc8.ts
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * The RFC-8 node model: typed paths, references, nodes and collections.
+ *
+ * RFC-8 ("Collections and Extensibility",
+ * https://ngff.openmicroscopy.org/rfc/8/index.html) replaces the
+ * `multiscales` wrapper with a typed node document stored under the `ome`
+ * key of a Zarr group's attributes or of a standalone JSON file. This module
+ * mirrors the Python port's `ngff_zarr.rfc8.model`.
+ *
+ * The model is deliberately open-world: a node of a type this package has no
+ * dedicated handling for (a prefixed extension type, or `"multiscale"` /
+ * `"singlescale"` until issue #714's later stages land) is carried as a
+ * generic {@link OmeNode} and round-trips unchanged, and `attributes` is
+ * opaque JSON whose prefixed extension keys (e.g. `mobie:grid`) are
+ * preserved verbatim, never interpreted.
+ */
+
+import { NgffVersion } from "./supported_versions.ts";
+
+/** The RFC-8 id production, shared by node ids and reference ids. */
+export const RFC8_ID_PATTERN = /^[a-zA-Z0-9\-_.]+$/;
+
+/**
+ * Path type for a node stored in a Zarr group: implementations append
+ * `zarr.json` to the path to reach the metadata document.
+ */
+export const PATH_TYPE_ZARR = "zarr";
+
+/**
+ * Path type for a node stored in a standalone JSON file: the path is the
+ * metadata document itself.
+ */
+export const PATH_TYPE_JSON = "json";
+
+/**
+ * Whether a value is a prefixed extension identifier (`prefix:name`).
+ *
+ * Unprefixed identifiers are reserved for the core specification; custom
+ * extensions introduce prefixed ones, where the prefix names the user or
+ * organization maintaining the extension.
+ */
+export function isPrefixedIdentifier(value: string): boolean {
+  const separator = value.indexOf(":");
+  return separator > 0 && separator < value.length - 1;
+}
+
+/**
+ * RFC-8 `Path`: a typed locator for out-of-document metadata.
+ *
+ * `type` is {@link PATH_TYPE_ZARR}, {@link PATH_TYPE_JSON}, or a prefixed
+ * extension type (e.g. `"myorg:zip"`). `path` is a relative path
+ * (IETF RFC 1808, resolved against the document that holds it), an absolute
+ * `file://` path (IETF RFC 8089), or an `http(s)://` URL (IETF RFC 1738).
+ *
+ * Named `OmePath` like the Python port's class (whose bare `Path` would
+ * collide with `pathlib`), so the two ports read alike.
+ */
+export interface OmePath {
+  type: string;
+  path: string;
+}
+
+/**
+ * RFC-8 `Reference` to a node or coordinate system by `id`.
+ *
+ * `path` locates the document that declares the referenced `id`; it is
+ * required for external references and omitted for in-document ones.
+ */
+export interface Reference {
+  id: string;
+  path?: OmePath | undefined;
+}
+
+/**
+ * RFC-8 `Node`: the base of every 0.9.dev3 metadata document.
+ *
+ * `type` and `name` are required by the RFC; `id` (unique within the JSON
+ * document), `attributes`, and the container fields `nodes` / `path` are
+ * optional. Exactly one of `nodes` and `path` must be present on the node
+ * types that define them; that is a validation rule (`validateCollection`),
+ * not a parse error, so an invalid document can be parsed, inspected and
+ * repaired.
+ *
+ * `extra` captures unrecognized top-level node keys on read and is
+ * serialized back on write: RFC-8 extensions must survive a round trip. No
+ * node carries a `version` field; the serializer stamps the root's.
+ *
+ * Exported as `OmeNode` rather than the RFC's bare `Node`, which would
+ * collide with the DOM `Node` type in browser consumers.
+ */
+export interface OmeNode {
+  type: string;
+  name: string;
+  id?: string | undefined;
+  attributes?: Record<string, unknown> | undefined;
+  nodes?: OmeNode[] | undefined;
+  path?: OmePath | undefined;
+  extra?: Record<string, unknown> | undefined;
+}
+
+/** Whether a node is a collection, whichever object carries it. */
+export function isCollectionNode(node: OmeNode): boolean {
+  return node.type === "collection";
+}
+
+/**
+ * An RFC-8 node document plus the context needed to resolve it.
+ *
+ * `root` is typically a collection node but may be any node: RFC-8 lets
+ * every node type head a document. `base` anchors relative path resolution:
+ * the Zarr group directory or URL the document's `zarr.json` lives in, or a
+ * standalone JSON file's parent. `undefined` (a document built in memory)
+ * leaves relative paths unresolvable.
+ *
+ * `rootAttributes` carries the non-OME root attribute keys of the group the
+ * document was read from, mirroring `NgffMultiscales.rootAttributes`.
+ */
+export class NgffCollection {
+  root: OmeNode;
+  base?: string | undefined;
+  version: string;
+  rootAttributes?: Record<string, unknown> | undefined;
+  /** Dereferenced documents, cached per resolved location. */
+  readonly cache = new Map<string, unknown>();
+
+  constructor(options: {
+    root: OmeNode;
+    base?: string | undefined;
+    version?: string | undefined;
+    rootAttributes?: Record<string, unknown> | undefined;
+  }) {
+    this.root = options.root;
+    this.base = options.base;
+    this.version = options.version ?? NgffVersion.V09dev3;
+    this.rootAttributes = options.rootAttributes;
+  }
+
+  /** Every node in the document, depth-first, root first. */
+  *walk(): Generator<OmeNode> {
+    function* walkNode(node: OmeNode): Generator<OmeNode> {
+      yield node;
+      for (const child of node.nodes ?? []) {
+        yield* walkNode(child);
+      }
+    }
+    yield* walkNode(this.root);
+  }
+
+  /**
+   * The document's node with the given `id`, else with the `name`.
+   *
+   * Ids are unique within a document, so they are looked up first; names
+   * are only unique among siblings, and the first match in depth-first
+   * order wins.
+   */
+  node(idOrName: string): OmeNode {
+    for (const node of this.walk()) {
+      if (node.id === idOrName) {
+        return node;
+      }
+    }
+    for (const node of this.walk()) {
+      if (node.name === idOrName) {
+        return node;
+      }
+    }
+    throw new Error(`No node with id or name '${idOrName}' in this document.`);
+  }
+}

--- a/ts/src/types/supported_versions.ts
+++ b/ts/src/types/supported_versions.ts
@@ -24,8 +24,31 @@ export enum NgffVersion {
    * {@link LATEST} stays `0.6rc0`, so 0.9.dev1 is opt-in.
    */
   V09dev1 = "0.9.dev1",
+  /**
+   * 0.9.dev1 plus RFC-8: the root `ome` value becomes a typed node
+   * (collections, references, typed paths) in place of the multiscales
+   * wrapper. Also opt-in; {@link LATEST} stays `0.6rc0`.
+   */
+  V09dev3 = "0.9.dev3",
   LATEST = "0.6rc0",
 }
+
+/**
+ * The versions an image (multiscales) store can carry, as the readers,
+ * writers and upgraders accept them. Widens to `"0.9.dev3"` when the RFC-8
+ * multiscale node model lands (issue #714); until then images are written at
+ * 0.9.dev1 and referenced from 0.9.dev3 collections.
+ */
+export type ImageVersion = "0.4" | "0.5" | "0.6" | "0.9.dev1";
+
+/**
+ * The OME-Zarr 0.9 development series, oldest first. Each tag extends the
+ * one before: dev1 is 0.6 plus RFC-3 and RFC-4, dev3 is dev1 plus RFC-8.
+ */
+export const V09_DEV_SERIES: readonly string[] = [
+  NgffVersion.V09dev1,
+  NgffVersion.V09dev3,
+] as const;
 
 /**
  * The on-disk `ome.version` string written for OME-Zarr v0.6. The v0.6 spec
@@ -49,6 +72,7 @@ export const SUPPORTED_VERSIONS: readonly NgffVersion[] = [
   NgffVersion.V06dev4,
   NgffVersion.V06rc0,
   NgffVersion.V09dev1,
+  NgffVersion.V09dev3,
 ] as const;
 
 /**
@@ -71,20 +95,21 @@ export function isV06Version(version: string): boolean {
 /**
  * Whether a version adopts the RFC-3 free-form axis model.
  *
- * Only `0.9.dev1` does: the bundled 0.4, 0.5 and 0.6 axes schemas all cap the
- * axis count at 5, and require 2-3 `space` axes (0.6 excepted for an `array`
- * coordinate system, see `takesArraySchemaBranch`). `undefined` applies the
- * restrictions.
+ * Only the OME-Zarr 0.9 development series does: the bundled 0.4, 0.5 and
+ * 0.6 axes schemas all cap the axis count at 5, and require 2-3 `space` axes
+ * (0.6 excepted for an `array` coordinate system, see
+ * `takesArraySchemaBranch`). `undefined` applies the restrictions.
  */
 export function isRfc3AxisModelAllowed(version?: string): boolean {
-  return version !== undefined && version === NgffVersion.V09dev1;
+  return version !== undefined && V09_DEV_SERIES.includes(version);
 }
 
 /**
  * Whether a version makes the RFC-4 orientation rules normative.
  *
- * Only `0.9.dev1` does (ome/ngff-spec#190 folds RFC-4 into it): the released
- * 0.4, 0.5 and 0.6 specs give `orientation` no normative status, so when the
+ * Only the OME-Zarr 0.9 development series does (ome/ngff-spec#190 folds
+ * RFC-4 into 0.9.dev1, and 0.9.dev3 extends 0.9.dev1): the released 0.4,
+ * 0.5 and 0.6 specs give `orientation` no normative status, so when the
  * caller declares one of those versions the orientation rules are inert.
  * `undefined` keeps them on: with no declared version, enforcement is a
  * strictness choice, exactly like `axis-names-unique` below 0.9.dev1 (see
@@ -96,5 +121,19 @@ export function isRfc3AxisModelAllowed(version?: string): boolean {
  * than at it.
  */
 export function isRfc4OrientationEnforced(version?: string): boolean {
-  return version === undefined || version === NgffVersion.V09dev1;
+  return version === undefined || V09_DEV_SERIES.includes(version);
+}
+
+/**
+ * Whether a version stores the RFC-8 node model under `ome`.
+ *
+ * Only `0.9.dev3` does: RFC-8 replaces the multiscales wrapper with a typed
+ * node document, so this predicate answers a structural question (which
+ * document shape a version stores) rather than gating a strictness rule,
+ * and `undefined` is `false`: with no declared version nothing says the
+ * document is node-shaped. The RFC-8 collection rules gate themselves the
+ * RFC-4 way instead (see `validateCollection`).
+ */
+export function isRfc8NodeModel(version?: string): boolean {
+  return version !== undefined && version === NgffVersion.V09dev3;
 }

--- a/ts/src/utils/rfc8_validation.ts
+++ b/ts/src/utils/rfc8_validation.ts
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Structural validation of RFC-8 node documents.
+ *
+ * The seven node/collection rules extend the canonical rule table in
+ * `structural_validation.ts` (whose `SpecRule` object declares their
+ * identifiers) and are dispatched by {@link validateCollection}, a sibling
+ * of `validatePlate` / `validateWell` for the RFC-8 document kind. The rules
+ * walk the raw `ome` object rather than the parsed model, so a document the
+ * parser refuses (for instance one whose node lacks a `type`) can still be
+ * diagnosed with a stable rule identifier.
+ *
+ * Rule, message and location bytes are kept identical to the Python port's
+ * `ngff_zarr.rfc8.validation`, pinned by the shared
+ * `py/test/rfc8_collection_cases.json` fixture both test suites drive.
+ *
+ * Shape errors beyond the rules, such as `nodes` not being an array, are
+ * the schema pass's concern; the walker skips what it cannot traverse.
+ */
+
+import {
+  isPrefixedIdentifier,
+  type OmeNode,
+  RFC8_ID_PATTERN,
+} from "../types/rfc8.ts";
+import { isRfc8NodeModel } from "../types/supported_versions.ts";
+import { pyRepr } from "./py_format.ts";
+import {
+  SpecRule,
+  ValidateOptions,
+  ValidationError,
+  ValidationLevel,
+} from "./structural_validation.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Render a raw metadata value the way Python's `repr()` renders it in the
+ * rule messages: `None` for a missing value, quoted strings, bare numbers.
+ */
+function pyReprValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return "None";
+  }
+  if (typeof value === "string") {
+    return pyRepr(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "True" : "False";
+  }
+  return String(value);
+}
+
+/**
+ * The node types whose schema declares the `nodes` / `path` pair, and for
+ * which exactly one of the two must be present. Unknown and extension node
+ * types are exempt (open-world). Issue #714's multiscale stage adds
+ * `"multiscale"` here rather than introducing a new rule.
+ */
+export const XOR_NODE_TYPES: ReadonlySet<string> = new Set(["collection"]);
+
+/** The unprefixed path types the core specification defines. */
+export const CORE_PATH_TYPES: ReadonlySet<string> = new Set(["zarr", "json"]);
+
+function* iterNodes(
+  node: Record<string, unknown>,
+  location: string,
+): Generator<[string, Record<string, unknown>]> {
+  yield [location, node];
+  const children = node.nodes;
+  if (Array.isArray(children)) {
+    for (const [index, child] of children.entries()) {
+      if (isRecord(child)) {
+        yield* iterNodes(child, `${location}.nodes[${index}]`);
+      }
+    }
+  }
+}
+
+function requireNonemptyString(
+  document: Record<string, unknown>,
+  key: string,
+  rule: SpecRule,
+): void {
+  for (const [location, node] of iterNodes(document, "ome")) {
+    const value = node[key];
+    if (typeof value !== "string" || value === "") {
+      throw new ValidationError(
+        rule,
+        `Node must declare a non-empty string ${pyRepr(key)}; got ` +
+          `${pyReprValue(value)}.`,
+        location,
+      );
+    }
+  }
+}
+
+/** Every node declares a non-empty string `type` (`node-type-required`). */
+export function validateNodeTypeRequired(
+  document: Record<string, unknown>,
+): void {
+  requireNonemptyString(document, "type", SpecRule.NodeTypeRequired);
+}
+
+/** Every node declares a non-empty string `name` (`node-name-required`). */
+export function validateNodeNameRequired(
+  document: Record<string, unknown>,
+): void {
+  requireNonemptyString(document, "name", SpecRule.NodeNameRequired);
+}
+
+/**
+ * Sibling nodes carry distinct names (`node-name-unique`); nodes of
+ * different collections may share one.
+ */
+export function validateNodeNameUnique(
+  document: Record<string, unknown>,
+): void {
+  for (const [location, node] of iterNodes(document, "ome")) {
+    const children = node.nodes;
+    if (!Array.isArray(children)) {
+      continue;
+    }
+    const seen = new Set<string>();
+    for (const [index, child] of children.entries()) {
+      if (!isRecord(child)) {
+        continue;
+      }
+      const name = child.name;
+      if (typeof name !== "string") {
+        continue;
+      }
+      if (seen.has(name)) {
+        throw new ValidationError(
+          SpecRule.NodeNameUnique,
+          `Node name ${pyRepr(name)} is repeated; node names must be ` +
+            `unique within the enclosing collection.`,
+          `${location}.nodes[${index}]`,
+        );
+      }
+      seen.add(name);
+    }
+  }
+}
+
+/**
+ * Every declared id matches `[a-zA-Z0-9-_.]+` (`node-id-format`). The id
+ * production is shared with references, so later RFC-8 stages report
+ * reference ids under this same rule.
+ */
+export function validateNodeIdFormat(
+  document: Record<string, unknown>,
+): void {
+  for (const [location, node] of iterNodes(document, "ome")) {
+    const value = node.id;
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (typeof value !== "string" || !RFC8_ID_PATTERN.test(value)) {
+      throw new ValidationError(
+        SpecRule.NodeIdFormat,
+        `Id ${pyReprValue(value)} does not match [a-zA-Z0-9-_.]+.`,
+        `${location}.id`,
+      );
+    }
+  }
+}
+
+/** Ids are unique within the JSON document (`node-id-unique`). */
+export function validateNodeIdUnique(
+  document: Record<string, unknown>,
+): void {
+  const seen = new Set<string>();
+  for (const [location, node] of iterNodes(document, "ome")) {
+    const value = node.id;
+    if (typeof value !== "string") {
+      continue;
+    }
+    if (seen.has(value)) {
+      throw new ValidationError(
+        SpecRule.NodeIdUnique,
+        `Id ${pyRepr(value)} is already used in this document; ids must ` +
+          `be unique within the JSON document.`,
+        `${location}.id`,
+      );
+    }
+    seen.add(value);
+  }
+}
+
+/**
+ * A collection carries exactly one of `nodes` / `path`
+ * (`node-nodes-xor-path`). Applies to the node types in
+ * {@link XOR_NODE_TYPES}; unknown and extension node types are exempt.
+ */
+export function validateNodeNodesXorPath(
+  document: Record<string, unknown>,
+): void {
+  for (const [location, node] of iterNodes(document, "ome")) {
+    if (typeof node.type !== "string" || !XOR_NODE_TYPES.has(node.type)) {
+      continue;
+    }
+    const hasNodes = node.nodes !== undefined && node.nodes !== null;
+    const hasPath = node.path !== undefined && node.path !== null;
+    if (hasNodes && hasPath) {
+      throw new ValidationError(
+        SpecRule.NodeNodesXorPath,
+        "Node declares both 'nodes' and 'path'; exactly one must be " +
+          "present.",
+        location,
+      );
+    }
+    if (!hasNodes && !hasPath) {
+      throw new ValidationError(
+        SpecRule.NodeNodesXorPath,
+        "Node declares neither 'nodes' nor 'path'; exactly one must be " +
+          "present.",
+        location,
+      );
+    }
+  }
+}
+
+/**
+ * Every path `type` is `zarr`, `json`, or a prefixed extension identifier
+ * (`path-type-known`). Unprefixed identifiers are reserved for the core
+ * specification; a prefixed identifier (`prefix:name`) belongs to the
+ * extension that registered the prefix and passes as opaque.
+ */
+export function validatePathTypeKnown(
+  document: Record<string, unknown>,
+): void {
+  for (const [location, node] of iterNodes(document, "ome")) {
+    const path = node.path;
+    if (!isRecord(path)) {
+      continue;
+    }
+    const value = path.type;
+    if (typeof value !== "string" || value === "") {
+      throw new ValidationError(
+        SpecRule.PathTypeKnown,
+        `Path must declare a non-empty string 'type'; got ` +
+          `${pyReprValue(value)}.`,
+        `${location}.path.type`,
+      );
+    }
+    if (CORE_PATH_TYPES.has(value) || isPrefixedIdentifier(value)) {
+      continue;
+    }
+    throw new ValidationError(
+      SpecRule.PathTypeKnown,
+      `Path type ${pyRepr(value)} is not 'zarr', 'json', or a prefixed ` +
+        `extension type.`,
+      `${location}.path.type`,
+    );
+  }
+}
+
+/**
+ * The RFC-8 rules in canonical evaluation order (the SpecRule declaration
+ * order), dispatched fail-fast by {@link validateCollection}.
+ */
+const COLLECTION_RULES = [
+  validateNodeTypeRequired,
+  validateNodeNameRequired,
+  validateNodeNameUnique,
+  validateNodeIdFormat,
+  validateNodeIdUnique,
+  validateNodeNodesXorPath,
+  validatePathTypeKnown,
+] as const;
+
+/**
+ * Run the RFC-8 node/collection rules in canonical order, fail-fast.
+ *
+ * `root` is either the raw `ome` object or a parsed node tree (serialized
+ * before checking, so both forms are judged by the same walker). Names and
+ * ids are checked per document: nodes a `path` points at live in their own
+ * documents and are validated when those are read.
+ *
+ * `version` gates the rules the RFC-4 way: they run when it is `undefined`
+ * (a document with no declared version gets the strict reading) or when
+ * `isRfc8NodeModel` says the version stores the node model, and are inert
+ * when an earlier version is declared.
+ */
+export function validateCollection(
+  root: Record<string, unknown> | OmeNode,
+  version?: string,
+  options?: ValidateOptions,
+): void {
+  const level = options?.level ?? ValidationLevel.Strict;
+  if (level === ValidationLevel.SchemaOnly) {
+    return;
+  }
+  if (version !== undefined && !isRfc8NodeModel(version)) {
+    return;
+  }
+  // A parsed node is structurally a document already: it carries the same
+  // modeled keys, and the keys the parser tucks under `extra` are ones no
+  // rule reads. The Python port serializes its dataclass first; walking the
+  // object directly yields the same verdicts, so both forms share one path.
+  const document = root as Record<string, unknown>;
+  for (const rule of COLLECTION_RULES) {
+    rule(document);
+  }
+}

--- a/ts/src/utils/structural_validation.ts
+++ b/ts/src/utils/structural_validation.ts
@@ -83,6 +83,20 @@ export const SpecRule = {
   PlateRowIndexConsistency: "plate-row-index-consistency",
   /** Each well image references an acquisition when the plate declares many. */
   WellAcquisitionMissing: "well-acquisition-missing",
+  /** Every RFC-8 node declares a non-empty string type; from 0.9.dev3. */
+  NodeTypeRequired: "node-type-required",
+  /** Every RFC-8 node declares a non-empty string name; from 0.9.dev3. */
+  NodeNameRequired: "node-name-required",
+  /** Sibling RFC-8 nodes carry distinct names; from 0.9.dev3. */
+  NodeNameUnique: "node-name-unique",
+  /** RFC-8 node and reference ids match [a-zA-Z0-9-_.]+; from 0.9.dev3. */
+  NodeIdFormat: "node-id-format",
+  /** RFC-8 ids are unique within the JSON document; from 0.9.dev3. */
+  NodeIdUnique: "node-id-unique",
+  /** A collection carries exactly one of nodes or path; from 0.9.dev3. */
+  NodeNodesXorPath: "node-nodes-xor-path",
+  /** An RFC-8 path type is zarr, json, or prefixed; from 0.9.dev3. */
+  PathTypeKnown: "path-type-known",
 } as const;
 
 /** Union of the {@link SpecRule} string values. */

--- a/ts/test/rfc8_io_test.ts
+++ b/ts/test/rfc8_io_test.ts
@@ -20,6 +20,7 @@ import {
   toOmeZarr,
 } from "../src/mod.ts";
 import { buildRootAttributes } from "../src/io/to_ngff_zarr_ozx_common.ts";
+import { documentBase, resolveLocation } from "../src/io/collection_common.ts";
 import type { ImageVersion } from "../src/types/supported_versions.ts";
 import type { MemoryStore } from "../src/io/from_ngff_zarr.ts";
 
@@ -204,4 +205,72 @@ Deno.test("the external collection fixture layout loads", async () => {
   } finally {
     await Deno.remove(tmp, { recursive: true });
   }
+});
+
+Deno.test("an external reference must declare the requested id", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(
+      `${tmp}/child.json`,
+      JSON.stringify(
+        await toCollectionJson({
+          type: "collection",
+          name: "child",
+          nodes: [{ type: "multiscale", name: "img", id: "img" }],
+        }),
+      ),
+    );
+    const parent = new NgffCollection({
+      root: { type: "collection", name: "parent", nodes: [] },
+      base: tmp,
+    });
+    await assertRejects(
+      () =>
+        loadCollectionNode(parent, {
+          id: "missing",
+          path: { type: "json", path: "./child.json" },
+        }),
+      Error,
+      "missing",
+    );
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("relative locations keep parent traversals above a relative base", () => {
+  assertEquals(
+    resolveLocation({ type: "json", path: "../child.json" }, "."),
+    "../child.json",
+  );
+  assertEquals(
+    resolveLocation({ type: "json", path: "../../c.json" }, "a"),
+    "../c.json",
+  );
+});
+
+Deno.test("documentBase handles bare and root-level filenames", () => {
+  assertEquals(documentBase({ type: "json", path: "x" }, "child.json"), ".");
+  assertEquals(documentBase({ type: "json", path: "x" }, "/a.json"), "/");
+});
+
+Deno.test("the browser writer preserves foreign root attributes", async () => {
+  const zarr = await import("zarrita");
+  const { toCollectionZarr: toCollectionZarrBrowser } = await import(
+    "../src/io/to_collection_zarr-browser.ts"
+  );
+  const store = new Map<string, Uint8Array>();
+  await zarr.create(zarr.root(store), {
+    attributes: { "myorg:note": "kept", ome: { stale: true } },
+  });
+  await toCollectionZarrBrowser(store, {
+    type: "collection",
+    name: "c",
+    nodes: [],
+  });
+  const written = JSON.parse(
+    new TextDecoder().decode(store.get("/zarr.json")),
+  );
+  assertEquals(written.attributes["myorg:note"], "kept");
+  assertEquals(written.attributes.ome.type, "collection");
 });

--- a/ts/test/rfc8_io_test.ts
+++ b/ts/test/rfc8_io_test.ts
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * RFC-8 collection reading, writing and lazy loading, mirroring
+ * `py/test/test_rfc8_io.py` over in-memory and temporary-directory stores.
+ */
+
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { NgffMultiscales } from "../src/types/multiscales.ts";
+import {
+  fromCollectionJson,
+  fromCollectionZarr,
+  fromOmeZarr,
+  loadCollectionNode,
+  NgffCollection,
+  type OmeNode,
+  toCollectionJson,
+  toCollectionZarr,
+  toOmeZarr,
+} from "../src/mod.ts";
+import { buildRootAttributes } from "../src/io/to_ngff_zarr_ozx_common.ts";
+import type { ImageVersion } from "../src/types/supported_versions.ts";
+import type { MemoryStore } from "../src/io/from_ngff_zarr.ts";
+
+const SOURCE_IMAGE = new URL(
+  "../../py/test/data/input/v04/6001240.zarr",
+  import.meta.url,
+).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+
+function studyCollection(): OmeNode {
+  return {
+    type: "collection",
+    name: "study",
+    id: "study",
+    attributes: { "mobie:grid": "true" },
+    nodes: [
+      {
+        type: "multiscale",
+        name: "raw",
+        id: "raw",
+        path: { type: "zarr", path: "./raw" },
+      },
+      {
+        type: "collection",
+        name: "nested",
+        path: { type: "json", path: "./nested_collection.json" },
+      },
+    ],
+  };
+}
+
+function imageMultiscales(): Promise<NgffMultiscales> {
+  return fromOmeZarr(SOURCE_IMAGE, { version: "0.4" });
+}
+
+Deno.test("memory-store round trip with root attributes", async () => {
+  const store: MemoryStore = new Map();
+  await toCollectionZarr(store, studyCollection(), {
+    rootAttributes: { lab: "fideus" },
+  });
+  const document = JSON.parse(
+    new TextDecoder().decode(store.get("/zarr.json")),
+  );
+  assertEquals(document.zarr_format, 3);
+  assertEquals(document.attributes.ome.version, "0.9.dev3");
+  assertEquals(document.attributes.lab, "fideus");
+
+  const collection = await fromCollectionZarr(store, { validate: true });
+  assertEquals(collection.root, studyCollection());
+  assertEquals(collection.version, "0.9.dev3");
+  assertEquals(collection.rootAttributes, { lab: "fideus" });
+  assertEquals(collection.base, undefined);
+});
+
+Deno.test("collection writer accepts only 0.9.dev3", async () => {
+  await assertRejects(
+    () =>
+      toCollectionZarr(new Map(), studyCollection(), { version: "0.9.dev1" }),
+    Error,
+    "0.9.dev3",
+  );
+});
+
+Deno.test("collection writer validates by default", async () => {
+  const invalid: OmeNode = { type: "collection", name: "c" };
+  await assertRejects(
+    () => toCollectionZarr(new Map(), invalid),
+    Error,
+    "node-nodes-xor-path",
+  );
+  await toCollectionZarr(new Map(), invalid, { validate: false });
+});
+
+Deno.test("standalone JSON round trip", async () => {
+  const document = await toCollectionJson(studyCollection());
+  assertEquals(
+    (document.ome as Record<string, unknown>).version,
+    "0.9.dev3",
+  );
+  const collection = await fromCollectionJson(
+    document as Record<string, unknown>,
+  );
+  assertEquals(collection.root, studyCollection());
+  assertEquals(collection.base, undefined);
+});
+
+Deno.test("fromOmeZarr names the collection reader on a dev3 store", async () => {
+  const store: MemoryStore = new Map();
+  await toCollectionZarr(store, studyCollection());
+  const error = await assertRejects(() => fromOmeZarr(store), Error);
+  assertStringIncludes(String(error), "fromCollectionZarr");
+});
+
+Deno.test("the browser reader also names the collection reader", async () => {
+  const { fromOmeZarr: fromOmeZarrBrowser } = await import(
+    "../src/io/from_ngff_zarr-browser.ts"
+  );
+  const store: MemoryStore = new Map();
+  await toCollectionZarr(store, studyCollection());
+  const error = await assertRejects(() => fromOmeZarrBrowser(store), Error);
+  assertStringIncludes(String(error), "fromCollectionZarr");
+});
+
+Deno.test("fromCollectionZarr names the image reader on an image store", async () => {
+  const store: MemoryStore = new Map();
+  const multiscales = await imageMultiscales();
+  await toOmeZarr(store, multiscales, { version: "0.5" });
+  const error = await assertRejects(() => fromCollectionZarr(store), Error);
+  assertStringIncludes(String(error), "fromOmeZarr");
+});
+
+Deno.test("buildRootAttributes refuses 0.9.dev3 with guidance", async () => {
+  const multiscales = await imageMultiscales();
+  let message = "";
+  try {
+    buildRootAttributes(
+      multiscales.metadata,
+      "0.9.dev3" as unknown as ImageVersion,
+    );
+  } catch (error) {
+    message = String(error);
+  }
+  assertStringIncludes(message, "toCollectionZarr");
+});
+
+Deno.test("load resolves nodes across a temporary directory layout", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const storePath = `${tmp}/collection.ome.zarr`;
+    await toCollectionZarr(storePath, studyCollection());
+    const multiscales = await imageMultiscales();
+    await toOmeZarr(`${storePath}/raw`, multiscales, { version: "0.9.dev1" });
+    await toCollectionJson(
+      { type: "collection", name: "nested", nodes: [] },
+      { path: `${storePath}/nested_collection.json` },
+    );
+
+    const collection = await fromCollectionZarr(storePath, {
+      validate: true,
+    });
+    assertEquals(collection.base, storePath);
+
+    const image = await loadCollectionNode(collection, "raw");
+    assertEquals(image instanceof NgffMultiscales, true);
+    assertEquals((image as NgffMultiscales).metadata.version, "0.9.dev1");
+    // Loaded documents are cached per resolved location.
+    const again = await loadCollectionNode(collection, "raw");
+    assertEquals(again === image, true);
+    const byReference = await loadCollectionNode(collection, { id: "raw" });
+    assertEquals(byReference === image, true);
+
+    const nested = await loadCollectionNode(collection, "nested");
+    assertEquals(nested instanceof NgffCollection, true);
+    assertEquals((nested as NgffCollection).base, storePath);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("the external collection fixture layout loads", async () => {
+  const fixtures = new URL(
+    "../../py/test/fixtures/rfc8/external_collection/",
+    import.meta.url,
+  );
+  const tmp = await Deno.makeTempDir();
+  try {
+    for (const name of ["parent_collection.json", "child_collection.json"]) {
+      await Deno.writeTextFile(
+        `${tmp}/${name}`,
+        await Deno.readTextFile(new URL(name, fixtures)),
+      );
+    }
+    const parent = await fromCollectionJson(`${tmp}/parent_collection.json`);
+    const child = await loadCollectionNode(parent, "sub-collection");
+    assertEquals(child instanceof NgffCollection, true);
+    assertEquals((child as NgffCollection).root.name, "sub-collection");
+    assertEquals(
+      (child as NgffCollection).root.nodes?.[0].name,
+      "image-label",
+    );
+    // The child collection resolves its own relative paths from its file.
+    assertEquals((child as NgffCollection).base, tmp);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});

--- a/ts/test/rfc8_model_test.ts
+++ b/ts/test/rfc8_model_test.ts
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * RFC-8 node model: parsing and serialization round trips, mirroring
+ * `py/test/test_rfc8_model.py` over the same fixture documents.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  isCollectionNode,
+  isPrefixedIdentifier,
+  NgffCollection,
+  nodeFromOmeDict,
+  nodeToOmeDict,
+  RFC8_ID_PATTERN,
+} from "../src/mod.ts";
+
+const FIXTURES = new URL("../../py/test/fixtures/rfc8/", import.meta.url);
+
+const FIXTURE_FILES = [
+  "base_multiscale_collection.json",
+  "nested_collection.json",
+  "external_collection/parent_collection.json",
+  "external_collection/child_collection.json",
+  "external_collection/resolved_collection.json",
+  "webknossos_inline_multiscale.json",
+  "mobie_image_labels_table.json",
+];
+
+function omeValue(document: Record<string, unknown>): Record<string, unknown> {
+  if ("attributes" in document) {
+    return (document.attributes as Record<string, unknown>).ome as Record<
+      string,
+      unknown
+    >;
+  }
+  return document.ome as Record<string, unknown>;
+}
+
+Deno.test("the id pattern matches the RFC production", () => {
+  for (const accepted of ["s0", "A-1_b.2", "7fa2f064-62c5-4d55-9e6c"]) {
+    assertEquals(RFC8_ID_PATTERN.test(accepted), true, accepted);
+  }
+  for (const rejected of ["a b", "a/b", "", "é"]) {
+    assertEquals(RFC8_ID_PATTERN.test(rejected), false, rejected);
+  }
+});
+
+Deno.test("prefixed identifier detection", () => {
+  assertEquals(isPrefixedIdentifier("myorg:zip"), true);
+  assertEquals(isPrefixedIdentifier("webknossos:settings"), true);
+  assertEquals(isPrefixedIdentifier("zip"), false);
+  assertEquals(isPrefixedIdentifier(":zip"), false);
+  assertEquals(isPrefixedIdentifier("myorg:"), false);
+});
+
+Deno.test("a collection document parses and reports its version", () => {
+  const { node, version } = nodeFromOmeDict({
+    version: "0.9.dev3",
+    type: "collection",
+    name: "c",
+    nodes: [],
+  });
+  assertEquals(version, "0.9.dev3");
+  assertEquals(isCollectionNode(node), true);
+  assertEquals(node.nodes, []);
+});
+
+Deno.test("unknown keys round-trip through extra", () => {
+  const document = {
+    type: "collection",
+    name: "c",
+    nodes: [],
+    "future-key": { nested: [1, null, "x"] },
+  };
+  const { node } = nodeFromOmeDict(document);
+  assertEquals(node.extra, { "future-key": { nested: [1, null, "x"] } });
+  assertEquals(nodeToOmeDict(node), document);
+});
+
+Deno.test("attributes are opaque and deep-copied", () => {
+  const attributes = { "mobie:grid": "true", nested: { value: null } };
+  const { node } = nodeFromOmeDict({
+    type: "collection",
+    name: "c",
+    nodes: [],
+    attributes,
+  });
+  assertEquals(node.attributes, attributes);
+  (node.attributes as { nested: { value: unknown } }).nested.value = 1;
+  assertEquals(attributes.nested.value, null);
+});
+
+Deno.test("the version is not stamped on children", () => {
+  const document = nodeToOmeDict(
+    {
+      type: "collection",
+      name: "c",
+      nodes: [{ type: "collection", name: "sub", nodes: [] }],
+    },
+    "0.9.dev3",
+  );
+  assertEquals(document.version, "0.9.dev3");
+  assertEquals(
+    "version" in (document.nodes as Record<string, unknown>[])[0],
+    false,
+  );
+});
+
+Deno.test("the parser reports malformed core keys", () => {
+  assertThrows(() => nodeFromOmeDict({ name: "c" }), Error, "'type'");
+  assertThrows(() => nodeFromOmeDict({ type: "collection" }), Error, "'name'");
+  assertThrows(
+    () => nodeFromOmeDict({ type: "collection", name: "c", id: 7 }),
+    Error,
+    "'id'",
+  );
+  assertThrows(
+    () =>
+      nodeFromOmeDict({
+        type: "collection",
+        name: "c",
+        nodes: [{ name: "x" }],
+      }),
+    Error,
+    "ome.nodes[0]",
+  );
+  assertThrows(
+    () => nodeFromOmeDict({ type: "collection", name: "c", version: 9 }),
+    Error,
+    "'version'",
+  );
+});
+
+Deno.test("node lookup prefers ids", () => {
+  const collection = new NgffCollection({
+    root: {
+      type: "collection",
+      name: "c",
+      nodes: [
+        { type: "multiscale", name: "a", id: "b" },
+        { type: "multiscale", name: "b", id: "c" },
+      ],
+    },
+  });
+  assertEquals(collection.node("b").name, "a");
+  assertEquals(collection.node("a").name, "a");
+  assertThrows(() => collection.node("missing"), Error, "missing");
+});
+
+for (const fixture of FIXTURE_FILES) {
+  Deno.test(`fixture document round-trips: ${fixture}`, async () => {
+    const document = JSON.parse(
+      await Deno.readTextFile(new URL(fixture, FIXTURES)),
+    );
+    const ome = omeValue(document);
+    const { node, version } = nodeFromOmeDict(ome);
+    assertEquals(version, "0.9.dev3");
+    assertEquals(nodeToOmeDict(node, version), ome);
+  });
+}

--- a/ts/test/rfc8_validation_test.ts
+++ b/ts/test/rfc8_validation_test.ts
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * RFC-8 structural rules, driven by the shared cross-language case table.
+ *
+ * `py/test/rfc8_collection_cases.json` pins the rule, message and location
+ * bytes both ports must produce; `py/test/test_rfc8_validation.py` drives
+ * the identical file.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  validateCollection,
+  ValidationError,
+  ValidationLevel,
+} from "../src/mod.ts";
+import { isRfc8NodeModel } from "../src/types/supported_versions.ts";
+
+interface SharedCase {
+  name: string;
+  ome: Record<string, unknown>;
+  version?: string;
+  ok?: boolean;
+  rule?: string;
+  message?: string;
+  location?: string;
+}
+
+const casesUrl = new URL(
+  "../../py/test/rfc8_collection_cases.json",
+  import.meta.url,
+);
+const CASES: SharedCase[] = JSON.parse(await Deno.readTextFile(casesUrl)).cases;
+
+for (const testCase of CASES) {
+  Deno.test(`shared case: ${testCase.name}`, () => {
+    if (testCase.ok) {
+      validateCollection(testCase.ome, testCase.version);
+      return;
+    }
+    const error = assertThrows(
+      () => validateCollection(testCase.ome, testCase.version),
+      ValidationError,
+    );
+    assertEquals(error.rule, testCase.rule);
+    assertEquals(String(error.message), testCase.message);
+    assertEquals(error.location, testCase.location);
+  });
+}
+
+Deno.test("every rule is exercised by the shared cases", () => {
+  const exercised = new Set(
+    CASES.filter((testCase) => testCase.rule !== undefined).map(
+      (testCase) => testCase.rule,
+    ),
+  );
+  assertEquals(
+    exercised,
+    new Set([
+      "node-type-required",
+      "node-name-required",
+      "node-name-unique",
+      "node-id-format",
+      "node-id-unique",
+      "node-nodes-xor-path",
+      "path-type-known",
+    ]),
+  );
+});
+
+Deno.test("isRfc8NodeModel is a dispatch predicate", () => {
+  // Unlike the RFC-4 gate, no version is not node-shaped: the predicate says
+  // which document shape a version stores, and the orchestrator handles the
+  // no-version strictness default itself.
+  assertEquals(isRfc8NodeModel("0.9.dev3"), true);
+  assertEquals(isRfc8NodeModel("0.9.dev1"), false);
+  assertEquals(isRfc8NodeModel("0.6"), false);
+  assertEquals(isRfc8NodeModel(undefined), false);
+});
+
+Deno.test("validateCollection accepts a parsed node tree", () => {
+  const error = assertThrows(
+    () =>
+      validateCollection(
+        {
+          type: "collection",
+          name: "c",
+          nodes: [
+            { type: "multiscale", name: "img" },
+            { type: "multiscale", name: "img" },
+          ],
+        },
+        "0.9.dev3",
+      ),
+    ValidationError,
+  );
+  assertEquals(error.rule, "node-name-unique");
+  assertEquals(error.location, "ome.nodes[1]");
+});
+
+Deno.test("schema_only level skips the rules", () => {
+  const invalid = { type: "collection", name: "c" };
+  validateCollection(invalid, undefined, {
+    level: ValidationLevel.SchemaOnly,
+  });
+  assertThrows(() => validateCollection(invalid), ValidationError);
+});

--- a/ts/test/structural_validation_parity_test.ts
+++ b/ts/test/structural_validation_parity_test.ts
@@ -32,6 +32,7 @@
  */
 
 import { assertEquals, assertMatch, assertThrows } from "@std/assert";
+import { validateCollection } from "../src/mod.ts";
 import {
   SpecRule,
   SUPPORTED_VERSIONS,
@@ -53,8 +54,9 @@ import {
 // the two are directly comparable. The first thirteen entries are the
 // image/multiscales rules dispatched by validateStructural -- the first eleven
 // are the v0.4 rules and the next two (zarr-format, ome-namespace) are the v0.5
-// namespacing rules, inert for v0.4; the final two are the HCS plate/well rules
-// dispatched by validatePlate / validateWell.
+// namespacing rules, inert for v0.4; the next two are the HCS plate/well rules
+// dispatched by validatePlate / validateWell; the final seven are the RFC-8
+// node/collection rules dispatched by validateCollection.
 const CANONICAL_SPEC_RULE_IDS: string[] = [
   "axis-count",
   "axis-type",
@@ -71,6 +73,13 @@ const CANONICAL_SPEC_RULE_IDS: string[] = [
   "ome-namespace",
   "plate-row-index-consistency",
   "well-acquisition-missing",
+  "node-type-required",
+  "node-name-required",
+  "node-name-unique",
+  "node-id-format",
+  "node-id-unique",
+  "node-nodes-xor-path",
+  "path-type-known",
 ];
 
 // The locked RFC-3 version manifest: the versions whose axis model is
@@ -81,6 +90,7 @@ const CANONICAL_SPEC_RULE_IDS: string[] = [
 // never inert (see docs/validation/rule-reference.md).
 const CANONICAL_RFC3_VERSIONS: string[] = [
   "0.9.dev1",
+  "0.9.dev3",
 ];
 
 // Every other supported version, plus the no-version default, must enforce the
@@ -102,6 +112,7 @@ const NON_RFC3_VERSIONS: (string | undefined)[] = [
 // keeps them on, as a strictness choice (like axis-names-unique).
 const CANONICAL_RFC4_VERSIONS: string[] = [
   "0.9.dev1",
+  "0.9.dev3",
 ];
 
 // Every other supported version must leave the orientation rules inert. Read
@@ -110,6 +121,21 @@ const CANONICAL_RFC4_VERSIONS: string[] = [
 const PRE_RFC4_VERSIONS: string[] = SUPPORTED_VERSIONS
   .map((version) => version as string)
   .filter((version) => !CANONICAL_RFC4_VERSIONS.includes(version));
+
+// The locked RFC-8 version manifest: the versions that store the node model
+// under `ome`, at which the seven node/collection rules are normative. This
+// identical literal list appears in the Python twin. Like the RFC-4 rules,
+// the collection rules stay on when no version is declared.
+const CANONICAL_RFC8_VERSIONS: string[] = [
+  "0.9.dev3",
+];
+
+// Every other supported version must leave the collection rules inert. Read
+// off SUPPORTED_VERSIONS so a newly supported version has to be classified
+// here rather than silently defaulting to either side.
+const PRE_RFC8_VERSIONS: string[] = SUPPORTED_VERSIONS
+  .map((version) => version as string)
+  .filter((version) => !CANONICAL_RFC8_VERSIONS.includes(version));
 
 // The canonical fail-fast evaluation order of the image/multiscales
 // orchestrator (validateStructural). Each entry is the SpecRule the
@@ -596,5 +622,38 @@ Deno.test("RFC-4 orientation version manifest is locked", () => {
     for (const version of PRE_RFC4_VERSIONS) {
       validateStructural(orientationMetadata(buildAxes()), undefined, version);
     }
+  }
+});
+
+/**
+ * A collection whose sibling nodes share a name, and nothing else wrong.
+ *
+ * Trips `node-name-unique` exactly when the RFC-8 rules run, so the
+ * orchestrator accepts it exactly when they are inert.
+ */
+function invalidCollectionDocument(): Record<string, unknown> {
+  return {
+    type: "collection",
+    name: "c",
+    nodes: [
+      { type: "multiscale", name: "img" },
+      { type: "multiscale", name: "img" },
+    ],
+  };
+}
+
+Deno.test("RFC-8 collection version manifest is locked", () => {
+  // Enforced at the manifest versions, and when no version is given...
+  for (const version of [...CANONICAL_RFC8_VERSIONS, undefined]) {
+    const error = assertThrows(
+      () => validateCollection(invalidCollectionDocument(), version),
+      ValidationError,
+    );
+    assertEquals(error.rule, SpecRule.NodeNameUnique, String(version));
+  }
+  // ...and inert at every other supported version, 0.9.dev1 included:
+  // RFC-8 lands at 0.9.dev3.
+  for (const version of PRE_RFC8_VERSIONS) {
+    validateCollection(invalidCollectionDocument(), version);
   }
 });


### PR DESCRIPTION
Part 1 of #714, first PR of the RFC-8 stack.

Adds the opt-in OME-Zarr version 0.9.dev3: 0.9.dev1 plus RFC-8, where the root `ome` value is a typed node document rather than a `multiscales` wrapper. `LATEST` stays 0.6rc0.

The Python `ngff_zarr.rfc8` package and its TypeScript mirror provide the `OmePath`, `Reference`, `Node` and `Collection` models, collection reading and writing in both storage shapes (`zarr.json` attributes and standalone JSON documents), and a lazy `NgffCollection` for navigating members across stores. Unknown node types, prefixed attribute keys and unrecognized fields round-trip verbatim, as RFC-8 requires for extensions.

Seven structural validation rules cover the node and path constraints. Their message bytes are pinned by a shared cases fixture (`py/test/rfc8_collection_cases.json`) that both test suites drive, keeping the two ports in byte parity. RFC-8 publishes no JSON schema, so the bundled node schema is repo authored; the vendored `spec/` trees are untouched.

Fixtures are normalized copies of the examples in [normanrz/ngff-rfc8-collection-examples](https://github.com/normanrz/ngff-rfc8-collection-examples), with provenance recorded in `py/test/fixtures/rfc8/README.md`. `docs/rfc8.md` documents the feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OME-Zarr 0.9.dev3 support for RFC-8 typed nodes and collections.
  * Added collection reading, writing, serialization, traversal, lookup, references, and lazy loading for Python and TypeScript.
  * Added local, file-based, and HTTP(S) resource resolution.
  * Added collection schemas and structural validation with clear error reporting.
  * Added public APIs for collection models, I/O, schemas, and validation.

* **Documentation**
  * Documented RFC-8 collections, extensibility, validation, version behavior, and usage examples.

* **Limitations**
  * 0.9.dev3 image writing remains unsupported; images use 0.9.dev1 and are referenced by collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
