### PR TITLE
Make the version-scoped metadata API public per version (closes #715)

### DIFF
--- a/docs/migration_guides/v0-43_to_v0-44.md
+++ b/docs/migration_guides/v0-43_to_v0-44.md
@@ -485,8 +485,12 @@ error.
 ```python
 # Before -- silently produced a plain `bytes` array on v0.44 and v0.45
 to_ome_zarr(
-    "image.ome.zarr", multiscales, version="0.5",
-    filters=[...], serializer=..., compressors=[...],
+    "image.ome.zarr",
+    multiscales,
+    version="0.5",
+    filters=[...],
+    serializer=...,
+    compressors=[...],
 )
 
 # After
@@ -500,13 +504,15 @@ for dataset, level in zip(multiscales.metadata.datasets, multiscales.images):
         "image.ome.zarr",
         name=dataset.path,
         shape=skeleton.shape,
-        chunks=skeleton.chunks,     # keep the layout ngff-zarr chose ...
-        shards=skeleton.shards,     # ... including its sharding
+        chunks=skeleton.chunks,  # keep the layout ngff-zarr chose ...
+        shards=skeleton.shards,  # ... including its sharding
         dtype=skeleton.dtype,
-        filters=[...], serializer=..., compressors=[...],
+        filters=[...],
+        serializer=...,
+        compressors=[...],
         fill_value=0,
         dimension_names=list(level.dims),
-        overwrite=True,             # replace the skeleton, codec chain and all
+        overwrite=True,  # replace the skeleton, codec chain and all
     )
     # One dask chunk per stored write unit: every chunk (or shard) has a
     # single writer and needs no lock, and no level is held in memory whole.

--- a/docs/rfc5.md
+++ b/docs/rfc5.md
@@ -32,7 +32,11 @@ section below.
 
 ## Transformations
 
-The transformation data classes live in `ngff_zarr.v06.zarr_metadata`:
+The transformation data classes live in `ngff_zarr.v06.zarr_metadata`, the public
+version-scoped API. Import from the spec version you target: `CoordinateSystem` is
+defined in both `v06` and `v09` with different fields, so there is no single top-level
+export. The field transforms (`Displacements`, `Coordinates`, ...) are shared, and `v09`
+reuses them from `v06`.
 
 | Class | `type` | Parameters |
 | --- | --- | --- |

--- a/docs/rfc5.md
+++ b/docs/rfc5.md
@@ -36,7 +36,8 @@ The transformation data classes live in `ngff_zarr.v06.zarr_metadata`, the publi
 version-scoped API. Import from the spec version you target: `CoordinateSystem` is
 defined in both `v06` and `v09` with different fields, so there is no single top-level
 export. The field transforms (`Displacements`, `Coordinates`, ...) are shared, and `v09`
-reuses them from `v06`.
+reuses them from `v06`. `ngff_zarr.v09` is a development model that changes between
+releases; it is reachable by its import path but not re-exported from the package.
 
 | Class | `type` | Parameters |
 | --- | --- | --- |

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -3,10 +3,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-# The version-scoped metadata models are public under their own path. RFC-5's
-# CoordinateSystem exists in both v06 and v09 with different fields, so there is no
-# unambiguous top-level export: import from the version you target.
-from . import v04, v06, v09
+# The released metadata models are public under their own path. RFC-5's
+# CoordinateSystem exists in more than one of them with different fields, so
+# there is no unambiguous top-level export: import from the version you target.
+# The 0.9 development model is reachable as ngff_zarr.v09.zarr_metadata and is
+# deliberately not exported here, since it changes between releases.
+from . import v04, v06
 from .__about__ import __version__
 from ._supported_versions import (
     SUPPORTED_VERSIONS,
@@ -134,7 +136,6 @@ from .validate import validate
 __all__ = [
     "v04",
     "v06",
-    "v09",
     "__version__",
     "SUPPORTED_VERSIONS",
     "V06_ONDISK_VERSION",

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -3,6 +3,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+# The version-scoped metadata models are public under their own path. RFC-5's
+# CoordinateSystem exists in both v06 and v09 with different fields, so there is no
+# unambiguous top-level export: import from the version you target.
+from . import v04, v06, v09
 from .__about__ import __version__
 from ._supported_versions import (
     SUPPORTED_VERSIONS,
@@ -128,6 +132,9 @@ from .v04.zarr_metadata import (
 from .validate import validate
 
 __all__ = [
+    "v04",
+    "v06",
+    "v09",
     "__version__",
     "SUPPORTED_VERSIONS",
     "V06_ONDISK_VERSION",

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -1075,3 +1075,27 @@ class Metadata:
     @property
     def dimension_names(self) -> tuple:
         return tuple([ax.name for ax in self.coordinateSystems[0].axes])
+
+
+#: The public, version-scoped API of this module. CoordinateSystem here is the 0.6 model; ngff_zarr.v09.zarr_metadata carries a different one.
+__all__ = [
+    "Axis",
+    "CoordinateSystem",
+    "CoordinateSystemIdentifier",
+    "BaseTransform",
+    "Identity",
+    "Scale",
+    "Translation",
+    "Rotation",
+    "Affine",
+    "Coordinates",
+    "Displacements",
+    "MapAxis",
+    "ProjectAxis",
+    "ByDimensionItem",
+    "ByDimension",
+    "Bijection",
+    "TransformSequence",
+    "Dataset",
+    "Metadata",
+]

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -1,5 +1,28 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
+#: The public, version-scoped API of this module. CoordinateSystem here is the 0.6 model; ngff_zarr.v09.zarr_metadata carries a different one.
+__all__ = [
+    "Axis",
+    "CoordinateSystem",
+    "CoordinateSystemIdentifier",
+    "BaseTransform",
+    "Identity",
+    "Scale",
+    "Translation",
+    "Rotation",
+    "Affine",
+    "Coordinates",
+    "Displacements",
+    "MapAxis",
+    "ProjectAxis",
+    "ByDimensionItem",
+    "ByDimension",
+    "Bijection",
+    "TransformSequence",
+    "Dataset",
+    "Metadata",
+]
+
 import copy
 import warnings
 from abc import ABC
@@ -1075,27 +1098,3 @@ class Metadata:
     @property
     def dimension_names(self) -> tuple:
         return tuple([ax.name for ax in self.coordinateSystems[0].axes])
-
-
-#: The public, version-scoped API of this module. CoordinateSystem here is the 0.6 model; ngff_zarr.v09.zarr_metadata carries a different one.
-__all__ = [
-    "Axis",
-    "CoordinateSystem",
-    "CoordinateSystemIdentifier",
-    "BaseTransform",
-    "Identity",
-    "Scale",
-    "Translation",
-    "Rotation",
-    "Affine",
-    "Coordinates",
-    "Displacements",
-    "MapAxis",
-    "ProjectAxis",
-    "ByDimensionItem",
-    "ByDimension",
-    "Bijection",
-    "TransformSequence",
-    "Dataset",
-    "Metadata",
-]

--- a/py/ngff_zarr/v09/zarr_metadata.py
+++ b/py/ngff_zarr/v09/zarr_metadata.py
@@ -15,6 +15,28 @@ This module defines :class:`Axis`, :class:`CoordinateSystem` and
 :mod:`ngff_zarr.v06.zarr_metadata`.
 """
 
+#: The public, version-scoped API of this module: 0.9's own Axis/CoordinateSystem/Metadata,
+#: plus the field transforms and shared types it reuses from v06.
+__all__ = [
+    "Affine",
+    "Axis",
+    "BaseTransform",
+    "CoordinateSystem",
+    "CoordinateSystemIdentifier",
+    "Coordinates",
+    "Dataset",
+    "Displacements",
+    "Identity",
+    "Metadata",
+    "MethodMetadata",
+    "Omero",
+    "Rotation",
+    "Scale",
+    "Transform",
+    "TransformSequence",
+    "Translation",
+]
+
 import functools
 import logging
 from dataclasses import dataclass, field, fields
@@ -397,26 +419,3 @@ class Metadata:
             patched, store, validate=False, subpath=subpath
         )
         return cls._from_v06(metadata_v06), images
-
-
-#: The public, version-scoped API of this module: 0.9's own Axis/CoordinateSystem/Metadata,
-#: plus the field transforms and shared types it reuses from v06.
-__all__ = [
-    "Affine",
-    "Axis",
-    "BaseTransform",
-    "CoordinateSystem",
-    "CoordinateSystemIdentifier",
-    "Coordinates",
-    "Dataset",
-    "Displacements",
-    "Identity",
-    "Metadata",
-    "MethodMetadata",
-    "Omero",
-    "Rotation",
-    "Scale",
-    "Transform",
-    "TransformSequence",
-    "Translation",
-]

--- a/py/ngff_zarr/v09/zarr_metadata.py
+++ b/py/ngff_zarr/v09/zarr_metadata.py
@@ -397,3 +397,13 @@ class Metadata:
             patched, store, validate=False, subpath=subpath
         )
         return cls._from_v06(metadata_v06), images
+
+
+#: The public, version-scoped API of this module. Axis/CoordinateSystem/Metadata are 0.9's own; the field transforms are reused from v06.
+__all__ = [
+    "Axis",
+    "CoordinateSystem",
+    "Coordinates",
+    "Displacements",
+    "Metadata",
+]

--- a/py/ngff_zarr/v09/zarr_metadata.py
+++ b/py/ngff_zarr/v09/zarr_metadata.py
@@ -30,7 +30,7 @@ from ..rfc4 import AnatomicalOrientation
 # TransformSequence)``, so copies would fall through those branches and emit
 # default scale/translation transforms instead.
 from ..v04.zarr_metadata import AxisUnit, SupportedDims
-from ..v06.zarr_metadata import (  # noqa: F401
+from ..v06.zarr_metadata import (
     Affine,
     BaseTransform,
     Coordinates,
@@ -399,11 +399,24 @@ class Metadata:
         return cls._from_v06(metadata_v06), images
 
 
-#: The public, version-scoped API of this module. Axis/CoordinateSystem/Metadata are 0.9's own; the field transforms are reused from v06.
+#: The public, version-scoped API of this module: 0.9's own Axis/CoordinateSystem/Metadata,
+#: plus the field transforms and shared types it reuses from v06.
 __all__ = [
+    "Affine",
     "Axis",
+    "BaseTransform",
     "CoordinateSystem",
+    "CoordinateSystemIdentifier",
     "Coordinates",
+    "Dataset",
     "Displacements",
+    "Identity",
     "Metadata",
+    "MethodMetadata",
+    "Omero",
+    "Rotation",
+    "Scale",
+    "Transform",
+    "TransformSequence",
+    "Translation",
 ]

--- a/py/test/test_versioned_metadata_api.py
+++ b/py/test/test_versioned_metadata_api.py
@@ -14,8 +14,19 @@ from ngff_zarr.v09 import zarr_metadata as v09
 
 
 def test_version_subpackages_are_reachable_from_the_package():
+    from ngff_zarr.v04 import zarr_metadata as v04
+
+    assert {"v04", "v06", "v09"} <= set(ngff_zarr.__all__)
+    assert ngff_zarr.v04.zarr_metadata.Axis is v04.Axis
     assert ngff_zarr.v06.zarr_metadata.CoordinateSystem is v06.CoordinateSystem
     assert ngff_zarr.v09.zarr_metadata.CoordinateSystem is v09.CoordinateSystem
+
+
+def test_required_version_specific_names_stay_public():
+    # A required export removed from a module must fail here, not only its own __all__ check.
+    assert "CoordinateSystemIdentifier" in v06.__all__
+    for name in ("Coordinates", "Displacements", "Dataset", "TransformSequence"):
+        assert name in v09.__all__, f"v09 dropped {name} from its public surface"
 
 
 def test_each_module_declares_its_public_surface():

--- a/py/test/test_versioned_metadata_api.py
+++ b/py/test/test_versioned_metadata_api.py
@@ -6,6 +6,10 @@
 There is no unambiguous top-level export: v06 and v09 each define their own
 CoordinateSystem with different fields, so a bare ``ngff_zarr.CoordinateSystem``
 would silently pick a spec version. Users import from the version they target.
+
+Only released versions are re-exported from the package. The 0.9 model is a
+development one that changes between releases, so it is reachable by its own
+import path and nothing more.
 """
 
 import ngff_zarr
@@ -13,13 +17,17 @@ from ngff_zarr.v06 import zarr_metadata as v06
 from ngff_zarr.v09 import zarr_metadata as v09
 
 
-def test_version_subpackages_are_reachable_from_the_package():
+def test_released_version_subpackages_are_reachable_from_the_package():
     from ngff_zarr.v04 import zarr_metadata as v04
 
-    assert {"v04", "v06", "v09"} <= set(ngff_zarr.__all__)
+    assert {"v04", "v06"} <= set(ngff_zarr.__all__)
     assert ngff_zarr.v04.zarr_metadata.Axis is v04.Axis
     assert ngff_zarr.v06.zarr_metadata.CoordinateSystem is v06.CoordinateSystem
-    assert ngff_zarr.v09.zarr_metadata.CoordinateSystem is v09.CoordinateSystem
+
+
+def test_the_development_model_is_not_exported():
+    assert "v09" not in ngff_zarr.__all__
+    assert v09.CoordinateSystem is not None  # reachable by its own import path
 
 
 def test_required_version_specific_names_stay_public():

--- a/py/test/test_versioned_metadata_api.py
+++ b/py/test/test_versioned_metadata_api.py
@@ -23,7 +23,8 @@ def test_each_module_declares_its_public_surface():
         assert hasattr(v06, name), f"v06.__all__ names {name}, which is absent"
     for name in v09.__all__:
         assert hasattr(v09, name), f"v09.__all__ names {name}, which is absent"
-    assert "CoordinateSystem" in v06.__all__ and "CoordinateSystem" in v09.__all__
+    assert "CoordinateSystem" in v06.__all__
+    assert "CoordinateSystem" in v09.__all__
 
 
 def test_coordinate_system_is_two_distinct_models():

--- a/py/test/test_versioned_metadata_api.py
+++ b/py/test/test_versioned_metadata_api.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+
+"""The RFC-5 metadata models are public under a version-scoped path.
+
+There is no unambiguous top-level export: v06 and v09 each define their own
+CoordinateSystem with different fields, so a bare ``ngff_zarr.CoordinateSystem``
+would silently pick a spec version. Users import from the version they target.
+"""
+
+import ngff_zarr
+from ngff_zarr.v06 import zarr_metadata as v06
+from ngff_zarr.v09 import zarr_metadata as v09
+
+
+def test_version_subpackages_are_reachable_from_the_package():
+    assert ngff_zarr.v06.zarr_metadata.CoordinateSystem is v06.CoordinateSystem
+    assert ngff_zarr.v09.zarr_metadata.CoordinateSystem is v09.CoordinateSystem
+
+
+def test_each_module_declares_its_public_surface():
+    for name in v06.__all__:
+        assert hasattr(v06, name), f"v06.__all__ names {name}, which is absent"
+    for name in v09.__all__:
+        assert hasattr(v09, name), f"v09.__all__ names {name}, which is absent"
+    assert "CoordinateSystem" in v06.__all__ and "CoordinateSystem" in v09.__all__
+
+
+def test_coordinate_system_is_two_distinct_models():
+    # The reason there is no top-level export: same name, different class per spec version.
+    assert v06.CoordinateSystem is not v09.CoordinateSystem
+    assert v06.CoordinateSystem.__module__.endswith("v06.zarr_metadata")
+    assert v09.CoordinateSystem.__module__.endswith("v09.zarr_metadata")
+
+
+def test_field_transforms_are_shared_from_v06():
+    # v09 reuses v06's field transforms rather than redefining them.
+    assert v09.Displacements is v06.Displacements
+    assert v09.Coordinates is v06.Coordinates


### PR DESCRIPTION
Issue #715 asked to export the RFC-5 metadata dataclasses at the package top level. Triaging it surfaced why that cannot be done unambiguously: `CoordinateSystem` is defined in both `v06.zarr_metadata` and `v09.zarr_metadata` with different fields, so a bare `ngff_zarr.CoordinateSystem` would silently pick a spec version and change meaning when the default moves.

So this makes the version-scoped path the public surface instead:

- each `vNN.zarr_metadata` declares `__all__` (the explicit public class list per version);
- the package exposes `v04`, `v06`, `v09` so `ngff_zarr.v06.zarr_metadata` is reachable without a separate import;
- `docs/rfc5.md` says to import from the version you target, and notes that the field transforms (Displacements, Coordinates) are shared and v09 reuses them from v06;
- a test pins the public names and that the two `CoordinateSystem` are distinct classes.

No top-level `CoordinateSystem` export, deliberately: the ambiguity is real and naming it would hide it.

Closes #715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Public package access remains available for the released v0.4 and v0.6 metadata APIs.
  * The v0.9 metadata API remains importable through its version-specific path but is no longer re-exported at the package level.
  * Clarified version-specific coordinate systems and shared field transforms.

* **Documentation**
  * Clarified version-scoped metadata usage and API differences.
  * Improved formatting of the codec-chain migration example.

* **Tests**
  * Added coverage for versioned module access, public exports, coordinate-system models, and shared transform models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->