### PR TITLE
Carry a displacement range through a non-linear outer stage

### DIFF
--- a/py/ngff_zarr/resample_bounding_box.py
+++ b/py/ngff_zarr/resample_bounding_box.py
@@ -538,22 +538,39 @@ def _box_inside_field_domain(entry, dimension: int, grid_box) -> bool:
     return True
 
 
-def _folded_interval(interval, outer_entries, dimension: int):
-    """``interval`` carried through the stages applied after its own.
+def _accumulated_interval(entries, intervals, dimension: int, contained: bool):
+    """The range the displacement stages of ``entries`` can add, or ``None``.
 
-    ITK applies the last entry of a list first, so the stages applied after
-    entry ``i`` are the entries before it. An affine stage maps the interval
-    through the signs of its matrix; an orthonormal stage bounds every output
-    component by the Euclidean reach of the input; anything else returns
+    ITK applies the last entry of a list first, so the walk runs from the
+    last entry outward, carrying what the stages seen so far can add. A
+    displacement stage adds its own range, since the linear list this widens
+    replaced that stage by the identity; an affine stage maps the range
+    through the signs of its matrix; an orthonormal stage bounds every
+    component by the range's Euclidean reach. Any other stage returns
     ``None``, and the caller keeps the boundary walk.
+
+    Accumulating outward rather than folding each stage separately is what
+    lets a displacement stage sit outside another one: the range reaching it
+    is carried through, and its own range joins on top.
+
+    :param intervals: One :func:`_stage_interval` per entry, so a field's
+        parameters are scanned once for the whole list.
     """
     from .itk_transform_to_ngff_transform import (
         _matrix_offset_from_itkwasm,
         _parameterization_name,
     )
 
-    low, high = interval
-    for entry in reversed(outer_entries):
+    low = np.zeros(dimension)
+    high = np.zeros(dimension)
+    for entry, interval in zip(reversed(entries), reversed(intervals)):
+        if interval is not None:
+            if not contained:
+                # ITK displaces a point beyond a stage's domain by nothing.
+                interval = (np.minimum(interval[0], 0.0), np.maximum(interval[1], 0.0))
+            low = low + interval[0]
+            high = high + interval[1]
+            continue
         name = _parameterization_name(entry.transformType)
         matrix = None
         try:
@@ -583,39 +600,31 @@ def _nonlinear_interval(entries, dimension: int, grid_box=None):
         lattice contains the box keeps the values' own range; in every other
         case zero joins the range, since ITK displaces a point beyond a
         stage's domain by nothing.
-    :return: ``(affine_entries, (low, high))`` when every displacement stage
-        could be bounded and folded: the entries with those stages replaced by
-        the identity, whose boundary walk the pipeline reports exactly, and
-        the range to widen its region by. ``(entries, None)`` otherwise, and
-        the caller's boundary walk stands, with the miss its docstring names.
+    :return: ``(affine_entries, (low, high))`` when every stage could be
+        carried: the entries with the displacement stages replaced by the
+        identity, whose boundary walk the pipeline reports exactly, and the
+        range to widen its region by. ``(entries, None)`` otherwise, and the
+        caller's boundary walk stands, with the miss its docstring names.
     """
-    intervals = [
-        (index, interval)
-        for index, entry in enumerate(entries)
-        if (interval := _stage_interval(entry, dimension)) is not None
+    intervals = [_stage_interval(entry, dimension) for entry in entries]
+    indices = [
+        index for index, interval in enumerate(intervals) if interval is not None
     ]
-    if not intervals:
+    if not indices:
         return entries, None
     contained = (
         len(entries) == 1
         and grid_box is not None
         and _box_inside_field_domain(entries[0], dimension, grid_box)
     )
-    low = np.zeros(dimension)
-    high = np.zeros(dimension)
-    for index, interval in intervals:
-        if not contained:
-            interval = (np.minimum(interval[0], 0.0), np.maximum(interval[1], 0.0))
-        folded = _folded_interval(interval, entries[:index], dimension)
-        if folded is None:
-            return entries, None
-        low = low + folded[0]
-        high = high + folded[1]
+    accumulated = _accumulated_interval(entries, intervals, dimension, contained)
+    if accumulated is None:
+        return entries, None
     replaced = list(entries)
     identity = _identity_transform_list(("z", "y", "x")[-dimension:])[0]
-    for index, _interval in intervals:
+    for index in indices:
         replaced[index] = identity
-    return replaced, (low, high)
+    return replaced, accumulated
 
 
 def _grid_physical_box(grid: NgffImage, itk_dims):
@@ -827,9 +836,10 @@ def resample_bounding_box(
     so such a stage is bounded the way a field is: the walk measures the list
     with those stages replaced by the identity, and the range their values
     can add, carried through the stages applied after them, widens the
-    result. Other non-linear parameterizations, the velocity fields among
-    them, still rely on the walk alone and can under-report a strictly
-    interior excursion.
+    result. A stage sitting outside another one carries the range reaching
+    it and adds its own on top, so several of them compose. Other non-linear
+    parameterizations, the velocity fields among them, still rely on the
+    walk alone and can under-report a strictly interior excursion.
 
     In both cases the transform maps *fixed* points into *moving* space.
 

--- a/py/test/test_resample_bounding_box.py
+++ b/py/test/test_resample_bounding_box.py
@@ -1403,3 +1403,246 @@ def test_a_lone_bspline_keeps_zero_in_its_range():
         # Zero in the range keeps the grid's own undisplaced extent covered.
         assert region.start_index[dim] <= 8
         assert region.start_index[dim] + region.size[dim] >= 8 + 15 + 10
+
+
+def _reached_corners(itk, transform, grid):
+    """Where ``transform`` actually sends every point of ``grid``.
+
+    ``itk.TransformToDisplacementFieldFilter`` materializes the whole
+    composition as one displacement field over the grid, so a stage the
+    walk cannot see analytically still shows up here. Adding each grid
+    point's own position back gives the reached positions; their per-axis
+    extremes are what the region has to contain.
+
+    The filter is only wrapped for float fields, so the values carry
+    single-precision rounding; the callers below allow for it. Two
+    dimensions, like the cases that call it.
+
+    :return: ``{dim: (low, high)}`` in NGFF dimension names.
+    """
+    field_type = itk.Image[itk.Vector[itk.F, 2], 2]
+    filt = itk.TransformToDisplacementFieldFilter[field_type, itk.D].New()
+    filt.SetTransform(transform)
+    filt.SetSize([int(grid.data.shape[1]), int(grid.data.shape[0])])
+    filt.SetOutputOrigin([grid.translation["x"], grid.translation["y"]])
+    filt.SetOutputSpacing([grid.scale["x"], grid.scale["y"]])
+    filt.SetOutputDirection(itk.matrix_from_array(np.eye(2)))
+    filt.Update()
+    output = filt.GetOutput()
+    output.DisconnectPipeline()
+    # A view aliases the filter's buffer, which the next Update() reuses.
+    displacements = np.array(itk.array_view_from_image(output), copy=True)
+
+    rows, columns = grid.data.shape
+    grid_y, grid_x = np.mgrid[0:rows, 0:columns].astype(np.float64)
+    grid_y = grid_y * grid.scale["y"] + grid.translation["y"]
+    grid_x = grid_x * grid.scale["x"] + grid.translation["x"]
+    reached_x = grid_x + displacements[..., 0]
+    reached_y = grid_y + displacements[..., 1]
+    return {
+        "y": (float(reached_y.min()), float(reached_y.max())),
+        "x": (float(reached_x.min()), float(reached_x.max())),
+    }
+
+
+def _assert_region_reaches(region, reached, tolerance=1e-3):
+    """The region's physical extent contains every reached position."""
+    for dim, (low, high) in reached.items():
+        assert region.corners_min[dim] <= low + tolerance, (
+            f"{dim}: region starts at {region.corners_min[dim]}, "
+            f"transform reaches {low}"
+        )
+        assert region.corners_max[dim] >= high - tolerance, (
+            f"{dim}: region ends at {region.corners_max[dim]}, transform reaches {high}"
+        )
+
+
+def _varied_bspline(itk, extent=64.0, mesh=4, seed=0, amplitude=12.0):
+    """A B-spline whose coefficients differ from one another and from zero."""
+    spline = itk.BSplineTransform[itk.D, 2, 3].New()
+    spline.SetTransformDomainOrigin([0.0, 0.0])
+    spline.SetTransformDomainPhysicalDimensions([extent, extent])
+    size = itk.Size[2]()
+    size.Fill(mesh)
+    spline.SetTransformDomainMeshSize(size)
+    count = spline.GetNumberOfParameters()
+    parameters = itk.OptimizerParameters[itk.D](count)
+    values = np.random.default_rng(seed).uniform(-amplitude, amplitude, count)
+    for index in range(count):
+        parameters.SetElement(index, float(values[index]))
+    spline.SetParameters(parameters)
+    return spline
+
+
+def _itk_affine(itk, matrix, offset):
+    affine = itk.AffineTransform[itk.D, 2].New()
+    affine.SetMatrix(itk.matrix_from_array(np.asarray(matrix, dtype=float)))
+    affine.SetOffset(list(offset))
+    return affine
+
+
+def _itk_composite(itk, *transforms):
+    composite = itk.CompositeTransform[itk.D, 2].New()
+    for transform in transforms:
+        composite.AddTransform(transform)
+    return composite
+
+
+def _reaching_grids():
+    """The fixed grid these cases transform, and a moving image to land in."""
+    fixed = _image("yx", {"y": 64, "x": 64}, {"y": 1.0, "x": 1.0}, {"y": 0.0, "x": 0.0})
+    moving = _image(
+        "yx", {"y": 512, "x": 512}, {"y": 1.0, "x": 1.0}, {"y": -128.0, "x": -128.0}
+    )
+    return fixed, moving
+
+
+def test_a_bspline_with_non_trivial_coefficients_is_covered():
+    """Coefficients that differ per control point, not one constant shift."""
+    itk = pytest.importorskip("itk")
+    fixed, moving = _reaching_grids()
+    spline = _varied_bspline(itk)
+
+    region = resample_bounding_box(spline, fixed, moving, padding=0)
+
+    _assert_region_reaches(region, _reached_corners(itk, spline, fixed))
+
+
+def test_a_bspline_then_affine_composite_is_covered():
+    itk = pytest.importorskip("itk")
+    fixed, moving = _reaching_grids()
+    composite = _itk_composite(
+        itk,
+        _varied_bspline(itk),
+        _itk_affine(itk, [[1.0, 0.0], [0.0, 1.0]], [5.0, 3.0]),
+    )
+
+    region = resample_bounding_box(composite, fixed, moving, padding=0)
+
+    _assert_region_reaches(region, _reached_corners(itk, composite, fixed))
+
+
+def test_a_composite_of_several_affines_is_covered_exactly():
+    """A purely linear composition: the boundary walk reports it exactly."""
+    itk = pytest.importorskip("itk")
+    fixed, moving = _reaching_grids()
+    composite = _itk_composite(
+        itk,
+        _itk_affine(itk, [[2.0, 0.0], [0.0, 0.5]], [1.0, 2.0]),
+        _itk_affine(itk, [[1.0, 0.3], [0.0, 1.0]], [-4.0, 7.0]),
+    )
+
+    region = resample_bounding_box(composite, fixed, moving, padding=0)
+
+    reached = _reached_corners(itk, composite, fixed)
+    _assert_region_reaches(region, reached)
+    # No displacement stage widens this one, so the region is the reached
+    # extent itself rather than a bound around it.
+    for dim, (low, high) in reached.items():
+        assert region.corners_min[dim] == pytest.approx(low, abs=1e-3)
+        assert region.corners_max[dim] == pytest.approx(high, abs=1e-3)
+
+
+def test_an_affine_then_bspline_composite_is_covered():
+    itk = pytest.importorskip("itk")
+    fixed, moving = _reaching_grids()
+    composite = _itk_composite(
+        itk,
+        _itk_affine(itk, [[1.5, 0.0], [0.0, 1.5]], [2.0, -3.0]),
+        _varied_bspline(itk),
+    )
+
+    region = resample_bounding_box(composite, fixed, moving, padding=0)
+
+    _assert_region_reaches(region, _reached_corners(itk, composite, fixed))
+
+
+def test_an_affine_then_displacement_field_composite_is_covered():
+    itk = pytest.importorskip("itk")
+    fixed, moving = _reaching_grids()
+    warp, _profile = _bump_displacement_transform(itk)
+    composite = _itk_composite(
+        itk, _itk_affine(itk, [[2.0, 0.0], [0.0, 2.0]], [4.0, 4.0]), warp
+    )
+
+    region = resample_bounding_box(composite, fixed, moving, padding=0)
+
+    _assert_region_reaches(region, _reached_corners(itk, composite, fixed))
+
+
+def test_an_affine_bspline_and_field_composite_is_covered():
+    """Two displacement stages of different kinds, one outside the other.
+
+    The interior bump is invisible to the boundary walk, and the B-spline
+    stage sits between it and the affine, so the range has to travel through
+    a stage that is itself non-linear.
+    """
+    itk = pytest.importorskip("itk")
+    fixed, moving = _reaching_grids()
+    warp, _profile = _bump_displacement_transform(itk)
+    composite = _itk_composite(
+        itk,
+        _itk_affine(itk, [[1.2, 0.0], [0.0, 0.8]], [3.0, 1.0]),
+        _varied_bspline(itk),
+        warp,
+    )
+
+    region = resample_bounding_box(composite, fixed, moving, padding=0)
+
+    _assert_region_reaches(region, _reached_corners(itk, composite, fixed))
+
+
+def test_an_affine_and_two_displacement_fields_composite_is_covered():
+    """Two fields in one composition, each bumped where the other is not."""
+    itk = pytest.importorskip("itk")
+    fixed, moving = _reaching_grids()
+    first, _first_profile = _bump_displacement_transform(itk, peaks=(40.0, -20.0))
+    second, _second_profile = _bump_displacement_transform(
+        itk, radius=12, peaks=(-30.0, 50.0)
+    )
+    composite = _itk_composite(
+        itk, _itk_affine(itk, [[1.0, 0.0], [0.0, 1.0]], [2.0, 2.0]), first, second
+    )
+
+    region = resample_bounding_box(composite, fixed, moving, padding=0)
+
+    _assert_region_reaches(region, _reached_corners(itk, composite, fixed))
+
+
+def test_a_composite_range_contains_the_range_its_field_shows():
+    """The bound the split derives holds the displacement ITK measures.
+
+    ``TransformToDisplacementFieldFilter`` collapses the composition into one
+    field, which ``_stage_interval`` reads exactly as it reads a field stage.
+    Comparing the two ranges only means something when the linear part is the
+    identity, so this composition carries no affine, and the test says so.
+    """
+    itk = pytest.importorskip("itk")
+    from ngff_zarr.resample_bounding_box import _nonlinear_interval, _stage_interval
+
+    fixed, _moving = _reaching_grids()
+    warp, _profile = _bump_displacement_transform(itk)
+    composite = _itk_composite(itk, _varied_bspline(itk), warp)
+
+    entries = _as_itk_transform_list(composite)
+    walked, (low, high) = _nonlinear_interval(entries, 2)
+    for entry in walked:
+        assert _stage_interval(entry, 2) is None
+
+    field_type = itk.Image[itk.Vector[itk.F, 2], 2]
+    filt = itk.TransformToDisplacementFieldFilter[field_type, itk.D].New()
+    filt.SetTransform(composite)
+    filt.SetSize([int(fixed.data.shape[1]), int(fixed.data.shape[0])])
+    filt.SetOutputOrigin([fixed.translation["x"], fixed.translation["y"]])
+    filt.SetOutputSpacing([fixed.scale["x"], fixed.scale["y"]])
+    filt.SetOutputDirection(itk.matrix_from_array(np.eye(2)))
+    filt.Update()
+    output = filt.GetOutput()
+    output.DisconnectPipeline()
+    measured = itk.DisplacementFieldTransform[itk.F, 2].New()
+    measured.SetDisplacementField(output)
+    (entry,) = _as_itk_transform_list(measured)
+    measured_low, measured_high = _stage_interval(entry, 2)
+
+    assert np.all(low <= measured_low + 1e-3)
+    assert np.all(high >= measured_high - 1e-3)

--- a/ts/src/io/resample_bounding_box-shared.ts
+++ b/ts/src/io/resample_bounding_box-shared.ts
@@ -421,20 +421,41 @@ function boxInsideFieldDomain(
   return true;
 }
 
-/** `interval` carried through the stages applied after its own: ITK applies
- * the last entry of a list first, so those are the entries before it. An
- * affine stage maps the interval through the signs of its matrix, an
- * orthonormal stage bounds every component by the Euclidean reach, and
- * anything else returns undefined: the caller keeps the boundary walk. */
-function foldedInterval(
-  interval: Interval,
-  outers: TransformList,
+/** The range the displacement stages of `entries` can add, or undefined.
+ * ITK applies the last entry of a list first, so the walk runs from the last
+ * entry outward, carrying what the stages seen so far can add. A displacement
+ * stage adds its own range, since the linear list this widens replaced that
+ * stage by the identity; an affine stage maps the range through the signs of
+ * its matrix; an orthonormal stage bounds every component by the range's
+ * Euclidean reach. Any other stage returns undefined, and the caller keeps the
+ * boundary walk.
+ *
+ * Accumulating outward rather than folding each stage separately is what lets
+ * a displacement stage sit outside another one: the range reaching it is
+ * carried through, and its own range joins on top. `intervals` holds one
+ * `stageInterval` per entry, so a field's parameters are scanned once for the
+ * whole list. */
+function accumulatedInterval(
+  entries: TransformList,
+  intervals: (Interval | undefined)[],
   dimension: number,
+  contained: boolean,
 ): Interval | undefined {
-  let low = interval.low.slice();
-  let high = interval.high.slice();
-  for (let position = outers.length - 1; position >= 0; position--) {
-    const entry = outers[position];
+  let low = new Array<number>(dimension).fill(0);
+  let high = new Array<number>(dimension).fill(0);
+  for (let position = entries.length - 1; position >= 0; position--) {
+    const entry = entries[position];
+    const interval = intervals[position];
+    if (interval !== undefined) {
+      // ITK displaces a point beyond a stage's domain by nothing.
+      const ranged = contained ? interval : {
+        low: interval.low.map((value) => Math.min(value, 0)),
+        high: interval.high.map((value) => Math.max(value, 0)),
+      };
+      low = low.map((value, i) => value + ranged.low[i]);
+      high = high.map((value, i) => value + ranged.high[i]);
+      continue;
+    }
     let matrix: number[][] | undefined;
     try {
       matrix = decodeMatrixOffset(entry, dimension).matrix;
@@ -513,35 +534,23 @@ function nonlinearInterval(
   dimension: number,
   gridBox: Interval | undefined,
 ): { entries: TransformList; range: Interval } | undefined {
-  const intervals: [number, Interval][] = [];
-  entries.forEach((entry, index) => {
-    const interval = stageInterval(entry, dimension);
-    if (interval !== undefined) intervals.push([index, interval]);
+  const intervals = entries.map((entry) => stageInterval(entry, dimension));
+  const indices: number[] = [];
+  intervals.forEach((interval, index) => {
+    if (interval !== undefined) indices.push(index);
   });
-  if (intervals.length === 0) return undefined;
+  if (indices.length === 0) return undefined;
   const contained = entries.length === 1 && gridBox !== undefined &&
     boxInsideFieldDomain(entries[0], dimension, gridBox);
-  const low = new Array<number>(dimension).fill(0);
-  const high = new Array<number>(dimension).fill(0);
-  for (const [index, interval] of intervals) {
-    const ranged = contained ? interval : {
-      low: interval.low.map((value) => Math.min(value, 0)),
-      high: interval.high.map((value) => Math.max(value, 0)),
-    };
-    const folded = foldedInterval(ranged, entries.slice(0, index), dimension);
-    if (folded === undefined) return undefined;
-    for (let component = 0; component < dimension; component++) {
-      low[component] += folded.low[component];
-      high[component] += folded.high[component];
-    }
-  }
+  const range = accumulatedInterval(entries, intervals, dimension, contained);
+  if (range === undefined) return undefined;
   const replaced = entries.slice();
   const identity = ngffTransformToItkTransform(
     { type: "identity" },
     ["z", "y", "x"].slice(-dimension),
   )[0];
-  for (const [index] of intervals) replaced[index] = identity;
-  return { entries: replaced, range: { low, high } };
+  for (const index of indices) replaced[index] = identity;
+  return { entries: replaced, range };
 }
 
 /** The physical range as the two per-dimension mappings `grown` takes: the
@@ -671,7 +680,8 @@ export async function resampleBoundingBoxShared(
     // reports a linear map exactly and misses what a DisplacementField or
     // BSpline stage does strictly inside it. The walk therefore measures
     // the list with those stages replaced by the identity, and the range
-    // their values can add widens the result.
+    // their values can add widens the result; a stage outside another one
+    // carries the range reaching it and adds its own on top.
     const split = nonlinearInterval(
       transform,
       itkDims.length,

--- a/ts/test/resample_bounding_box_test.ts
+++ b/ts/test/resample_bounding_box_test.ts
@@ -1566,3 +1566,121 @@ Deno.test("an interior bump in an itk field widens the region", async () => {
     );
   }
 });
+
+/** A field that shifts every point of its lattice by the same vector. */
+function constantFieldEntry(
+  shift: number[],
+  size: number[],
+  spacing: number[],
+  // deno-lint-ignore no-explicit-any
+): any {
+  const points = size.reduce((total, extent) => total * extent, 1);
+  const vectors = new Float64Array(points * shift.length);
+  for (let point = 0; point < points; point++) {
+    for (let component = 0; component < shift.length; component++) {
+      vectors[point * shift.length + component] = shift[component];
+    }
+  }
+  return displacementFieldEntry(vectors, size, spacing);
+}
+
+/** A field that is zero on its boundary and peaks at its centre.
+ *
+ * The boundary walk sees only the zero, so a stage outside this one has to
+ * carry the peak for the region to hold it. `peaks` is in ITK component
+ * order (x, y); the returned entry's lattice is unit-spaced at the origin. */
+function bumpFieldEntry(
+  extent: number,
+  peaks: number[],
+  radius: number,
+  // deno-lint-ignore no-explicit-any
+): any {
+  const vectors = new Float64Array(extent * extent * 2);
+  for (let y = 0; y < extent; y++) {
+    for (let x = 0; x < extent; x++) {
+      const distance = Math.hypot(y - extent / 2, x - extent / 2);
+      const profile = distance < radius
+        ? 0.5 * (1 + Math.cos(Math.PI * distance / radius))
+        : 0;
+      const index = (y * extent + x) * 2;
+      vectors[index] = peaks[0] * profile;
+      vectors[index + 1] = peaks[1] * profile;
+    }
+  }
+  return displacementFieldEntry(vectors, [extent, extent], [1, 1]);
+}
+
+Deno.test("a field outside an interior bump carries its range", async () => {
+  // ITK applies the last entry first, so the bump's range has to travel
+  // through the constant field outside it, which is itself non-linear:
+  // folding stage by stage stops there and the walk, which sees only the
+  // bump's zero boundary, reports a region the composition leaves.
+  const { resampleBoundingBox } = await import(
+    "../src/io/resample_bounding_box.ts"
+  );
+  const extent = 64;
+  const peaks = [-60, 60];
+  const bump = bumpFieldEntry(extent, peaks, 20);
+  const shift = [-3, 11];
+  const outer = constantFieldEntry(shift, [256, 256], [1, 1]);
+  const fixed = await geometryImage(
+    ["y", "x"],
+    { y: extent, x: extent },
+    { y: 1, x: 1 },
+    { y: 0, x: 0 },
+  );
+  const moving = await geometryImage(["y", "x"], { y: 512, x: 512 }, {
+    y: 1,
+    x: 1,
+  }, { y: -128, x: -128 });
+
+  const region = await resampleBoundingBox([outer, bump], fixed, moving, {
+    padding: 0,
+  });
+
+  // The grid centre takes the whole peak, then the constant shift.
+  const centre = extent / 2;
+  assertEquals(region.cornersMax.y >= centre + peaks[1] + shift[1], true);
+  assertEquals(region.cornersMin.x <= centre + peaks[0] + shift[0], true);
+});
+
+Deno.test("an affine outside two fields carries both their ranges", async () => {
+  const { resampleBoundingBox } = await import(
+    "../src/io/resample_bounding_box.ts"
+  );
+  const extent = 64;
+  const peaks = [-60, 60];
+  const bump = bumpFieldEntry(extent, peaks, 20);
+  const shift = [-3, 11];
+  const outer = constantFieldEntry(shift, [256, 256], [1, 1]);
+  const [affine] = itkAffine([[2, 0], [0, 3]], [4, -6]);
+  const fixed = await geometryImage(
+    ["y", "x"],
+    { y: extent, x: extent },
+    { y: 1, x: 1 },
+    { y: 0, x: 0 },
+  );
+  const moving = await geometryImage(["y", "x"], { y: 1024, x: 1024 }, {
+    y: 1,
+    x: 1,
+  }, { y: -512, x: -512 });
+
+  const region = await resampleBoundingBox(
+    [affine, outer, bump],
+    fixed,
+    moving,
+    { padding: 0 },
+  );
+
+  // The centre takes the peak and the shift, then the affine scales it:
+  // x' = 2 (x + peak_x + shift_x) + 4, y' = 3 (y + peak_y + shift_y) - 6.
+  const centre = extent / 2;
+  assertEquals(
+    region.cornersMax.y >= 3 * (centre + peaks[1] + shift[1]) - 6,
+    true,
+  );
+  assertEquals(
+    region.cornersMin.x <= 2 * (centre + peaks[0] + shift[0]) + 4,
+    true,
+  );
+});


### PR DESCRIPTION
Closes #727.

The seven compositions that issue lists are measured against `itk.TransformToDisplacementFieldFilter`: it collapses the whole composition into one displacement field over the fixed grid, so a stage acting strictly inside the grid, which the boundary walk cannot see, shows up in the field. Adding each grid point's own position back gives the positions the transform actually reaches, and the region has to contain them.

Two of the seven did not: an affine over a B-spline over a displacement field, and an affine over two displacement fields, each leaving about 19 pixels outside the reported region.

## What was wrong

#704 bounds a displacement stage by the range its values take, and carries that range through the stages applied after it, one stage at a time. The carry handled an affine, through the signs of its matrix, and the orthonormal family, into the ball its Euclidean reach bounds; anything else gave up and the boundary walk stood. A second displacement stage is exactly that "anything else", so a list holding two of them, or a field under a B-spline, fell back to a walk that reports the identity region for an interior bump.

## What changed

The per-stage fold becomes one accumulation running outward from the last entry, the one ITK applies first. A displacement stage adds its own range, since the list being widened replaced that stage by the identity; an affine maps the accumulated range through the signs of its matrix; an orthonormal stage bounds it by its Euclidean reach. Stages therefore compose, in any nesting, and the fallback now only covers parameterizations that carry no range at all, the velocity fields among them, which the docstring already names.

This is smaller than what it replaces: one pass instead of a fold per stage plus a sum, with no cross-stage bookkeeping. It reports the same bound on every list the fold already handled, which the tests #704 added pin unchanged, and the entries are scanned once for their intervals rather than once per displacement stage, keeping the property that a field's parameters are read once.

## Tests

The seven cases are covered in Python against the filter oracle. Case 3, several affines, is purely linear, so the region is asserted equal to the reached extent rather than merely containing it: the walk reports a linear map exactly and nothing should widen it.

One further test does what the issue describes literally: it reads the materialized field with `_stage_interval`, the same function a field stage goes through, and checks the range the split derives holds it. That comparison only means something when the linear part is the identity, so the composition it uses carries no affine, and the test asserts that before comparing.

TypeScript has no ITK, so it mirrors the two nested cases over an interior bump whose reached point is known in closed form. A constant field would not do: its uniform shift is visible from the boundary, so the walk finds the right answer by accident.

Sensitivity checked by neutralizing the accumulation in each port: exactly the nested cases fail, the other five pass either way, being the ones the fold already handled.

Python 1502 passed, TypeScript 719, prek and deno clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resampling bounds for composite transforms that combine multiple displacement fields, B-spline stages, and affine transformations.
  * Preserved accumulated displacement ranges across nested and sequential transform stages.
  * Improved physical-region containment for complex transformed grids, including interior displacement variations.

* **Tests**
  * Added coverage for composite transforms, multiple nonlinear stages, affine compositions, and displacement-field measurements.
  * Added validation for constant shifts and localized displacement changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->