### PR TITLE
Store a shard as asked, and let the caller keep the axis order

### DIFF
--- a/py/ngff_zarr/to_multiscales.py
+++ b/py/ngff_zarr/to_multiscales.py
@@ -10,7 +10,7 @@ import uuid
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 from dask.array.core import Array as DaskArray
@@ -438,6 +438,7 @@ def to_multiscales(
     progress: NgffProgress | NgffProgressCallback | None = None,
     cache: bool | None = None,
     orientation: str | Mapping[str, AnatomicalOrientation] | None = None,
+    axis_order: Literal["canonical", "preserve"] = "canonical",
 ) -> NgffMultiscales:
     """
     Generate multiple resolution scales for the OME-NGFF standard data model.
@@ -471,10 +472,17 @@ def to_multiscales(
         output automatically whenever it is present; no separate opt-in is required.
     :type  orientation: str or mapping of str to AnatomicalOrientation, optional
 
+    :param axis_order: What to do with an input whose axes are not in the
+        OME-Zarr specification order. ``"canonical"``, the default, reorders
+        them to time, then channel, then space (t, c, z, y, x) with a lazy
+        transpose, which is what conversion sources need: the TIFF ``S``
+        (sample) axis, ITK component images and the 4-D/5-D default dims
+        inference all yield channel-last. ``"preserve"`` writes the axes in
+        the order given, which RFC-3 permits from OME-Zarr 0.9.dev1 on and
+        which no earlier version accepts.
+    :type  axis_order: str, optional
+
     :return: NgffImage for each resolution and NGFF multiscales metadata.
-        Axes are normalized to the OME-Zarr specification order -- time, then
-        channel, then space (t, c, z, y, x) -- with a lazy transpose when the
-        input image orders them differently.
     :rtype : NgffMultiscales
     """
     # Shallow copy, with its own computed_callbacks: the rechunk and dask
@@ -555,8 +563,14 @@ def to_multiscales(
     # OME-Zarr orders axes time, then channel, then space. Channel-last input
     # (the TIFF S axis, ITK component images, the 4-D/5-D default dims) is
     # normalized with a lazy transpose so the generated metadata and every
-    # scale are spec-ordered.
-    ngff_image = _canonical_axis_order(ngff_image)
+    # scale are spec-ordered. An order the caller chose is kept on request:
+    # RFC-3 lifts the ordering rule, and the reorder is silent otherwise
+    # (gh-issue-734).
+    if axis_order not in ("canonical", "preserve"):
+        msg = f"axis_order must be 'canonical' or 'preserve'; got {axis_order!r}"
+        raise ValueError(msg)
+    if axis_order == "canonical":
+        ngff_image = _canonical_axis_order(ngff_image)
     # Re-key the dim-keyed chunk mappings to follow the (possibly reordered)
     # dims; _ngff_image_scale_factors asserts this ordering.
     out_chunks = {dim: out_chunks[dim] for dim in ngff_image.dims}

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -1088,19 +1088,23 @@ def _resolve_scale_chunks(
         return best or shard_size
 
     if sharding_kwargs and "_shard_shape" in sharding_kwargs:
-        # Sharding: clamp the shard shape to the axis length
         shard_shape = sharding_kwargs["_shard_shape"]
         internal_chunk_shape = sharding_kwargs.get(
             "chunk_shape"
         )  # This is the inner chunk shape
 
-        # Clamp each shard dim to its axis; Zarr v3 permits a partial final shard,
-        # and the inner chunk is chosen to divide the clamped shard below.
+        # A shard may run past the axis, exactly as a chunk may: Zarr v3 permits
+        # a partial final shard. Shortening one to the axis is what dragged a
+        # requested chunk down to an axis divisor, since the inner chunk must
+        # divide the shard -- an axis of 275 (5 * 5 * 11) took a 256 chunk down
+        # to 55, and a prime axis of 271 down to the whole shard
+        # (gh-issue-733). What it is held to instead is the smallest whole
+        # number of inner chunks that covers the axis, so the shard grid is
+        # never larger than the array needs.
+        inner = internal_chunk_shape or tuple(c[0] for c in arr.chunks)
         optimized_shard_shape = tuple(
-            [
-                _find_optimal_chunk_size(s, arr.shape[i])
-                for i, s in enumerate(shard_shape)
-            ]
+            min(int(shard), -(-int(size) // int(chunk)) * int(chunk))
+            for shard, size, chunk in zip(shard_shape, arr.shape, inner)
         )
 
         # Ensure internal_chunk_shape divides evenly into optimized_shard_shape
@@ -1128,9 +1132,12 @@ def _resolve_scale_chunks(
                 ]
             )
 
-        # For region computation, use the optimized shard shape (the actual
-        # stored chunk grid); the array is created from these values.
-        zarr_chunk_shape = optimized_shard_shape
+        # The stored grid is the shard as asked for; the region planner works on
+        # it clamped to the axes, because a region cannot run past the array.
+        zarr_chunk_shape = tuple(
+            _find_optimal_chunk_size(s, arr.shape[i])
+            for i, s in enumerate(optimized_shard_shape)
+        )
         chunks = optimized_shard_shape
         shards = optimized_shard_shape
     else:

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -1521,6 +1521,10 @@ def _prepare_next_scale(
             d: f for d, f in dim_factors.items() if d in spatial_dims
         }
 
+        # The level being re-derived already has the axis order the first
+        # call settled on, canonical or kept as given; reordering it here
+        # would store the array in one order under dimension names in the
+        # other (gh-issue-734).
         next_multiscales = to_multiscales(
             source_image,
             scale_factors=[
@@ -1530,6 +1534,7 @@ def _prepare_next_scale(
             chunks=multiscales.chunks,
             progress=progress,
             cache=False,
+            axis_order="preserve",
         )
         multiscales.images[index + 1] = next_multiscales.images[1]
         return next_multiscales.images[1]

--- a/py/test/test_canonical_axis_order.py
+++ b/py/test/test_canonical_axis_order.py
@@ -109,6 +109,29 @@ def test_preserve_round_trips_through_a_0_9_dev1_store(tmp_path):
     assert np.array_equal(np.asarray(read.images[0].data), source)
 
 
+def test_preserve_survives_the_writer_regenerating_a_level(tmp_path):
+    """The writer re-derives generated levels; the order must come along."""
+    import json
+
+    from ngff_zarr import from_ome_zarr, to_ome_zarr
+
+    source = np.random.randint(0, 255, (8, 16, 16, 2), dtype=np.uint8)
+    image = to_ngff_image(
+        source, dims=("z", "y", "x", "c"), scale={"z": 0.3, "y": 0.3, "x": 0.3}
+    )
+    multiscales = to_multiscales(image, scale_factors=[2], axis_order="preserve")
+
+    store = tmp_path / "preserved.ome.zarr"
+    to_ome_zarr(str(store), multiscales, version="0.9.dev1")
+
+    level = json.loads((store / "scale1" / "image" / "zarr.json").read_text())
+    assert level["shape"] == [4, 8, 8, 2]
+    assert level["dimension_names"] == ["z", "y", "x", "c"]
+    read = from_ome_zarr(str(store))
+    assert tuple(read.images[1].dims) == ("z", "y", "x", "c")
+    assert read.images[1].data.shape == (4, 8, 8, 2)
+
+
 def test_canonical_stays_the_default():
     data = np.zeros((8, 16, 16, 2), dtype=np.uint8)
     image = to_ngff_image(data, dims=("z", "y", "x", "c"))

--- a/py/test/test_canonical_axis_order.py
+++ b/py/test/test_canonical_axis_order.py
@@ -75,3 +75,57 @@ def test_unknown_dims_are_left_untouched():
     result = _canonical_axis_order(image)
 
     assert result is image
+
+
+def test_preserve_keeps_the_order_the_caller_chose():
+    """RFC-3 lifts the ordering rule, so an order can be asked for (gh-734)."""
+    data = np.random.randint(0, 255, (8, 16, 16, 2), dtype=np.uint8)
+    image = to_ngff_image(
+        data, dims=("z", "y", "x", "c"), scale={"z": 0.3, "y": 0.3, "x": 0.3}
+    )
+
+    multiscales = to_multiscales(image, scale_factors=[2], axis_order="preserve")
+
+    assert multiscales.images[0].dims == ("z", "y", "x", "c")
+    assert [axis.name for axis in multiscales.metadata.axes] == ["z", "y", "x", "c"]
+    # The pyramid follows the axes it was given: the channel axis is not scaled.
+    assert multiscales.images[1].data.shape == (4, 8, 8, 2)
+
+
+def test_preserve_round_trips_through_a_0_9_dev1_store(tmp_path):
+    from ngff_zarr import from_ome_zarr, to_ome_zarr
+
+    source = np.random.randint(0, 255, (8, 16, 16, 2), dtype=np.uint8)
+    image = to_ngff_image(
+        source, dims=("z", "y", "x", "c"), scale={"z": 0.3, "y": 0.3, "x": 0.3}
+    )
+    multiscales = to_multiscales(image, scale_factors=[], axis_order="preserve")
+
+    store = tmp_path / "preserved.ome.zarr"
+    to_ome_zarr(str(store), multiscales, version="0.9.dev1")
+
+    read = from_ome_zarr(str(store))
+    assert tuple(read.images[0].dims) == ("z", "y", "x", "c")
+    assert np.array_equal(np.asarray(read.images[0].data), source)
+
+
+def test_canonical_stays_the_default():
+    data = np.zeros((8, 16, 16, 2), dtype=np.uint8)
+    image = to_ngff_image(data, dims=("z", "y", "x", "c"))
+
+    assert to_multiscales(image, scale_factors=[]).images[0].dims == (
+        "c",
+        "z",
+        "y",
+        "x",
+    )
+
+
+def test_an_unknown_axis_order_is_refused():
+    import pytest
+
+    data = np.zeros((8, 16, 16, 2), dtype=np.uint8)
+    image = to_ngff_image(data, dims=("z", "y", "x", "c"))
+
+    with pytest.raises(ValueError, match="axis_order must be"):
+        to_multiscales(image, scale_factors=[], axis_order="spec")

--- a/py/test/test_canonical_axis_order.py
+++ b/py/test/test_canonical_axis_order.py
@@ -130,6 +130,12 @@ def test_preserve_survives_the_writer_regenerating_a_level(tmp_path):
     read = from_ome_zarr(str(store))
     assert tuple(read.images[1].dims) == ("z", "y", "x", "c")
     assert read.images[1].data.shape == (4, 8, 8, 2)
+    # The pixels, not only the labels: level 0 is the source, level 1 is the
+    # level the writer re-derived and must equal the one computed in memory.
+    assert np.array_equal(np.asarray(read.images[0].data), source)
+    assert np.array_equal(
+        np.asarray(read.images[1].data), np.asarray(multiscales.images[1].data)
+    )
 
 
 def test_canonical_stays_the_default():

--- a/py/test/test_to_ngff_zarr_sharding.py
+++ b/py/test/test_to_ngff_zarr_sharding.py
@@ -210,7 +210,8 @@ def test_a_shard_may_run_past_the_axis(tmp_path, path):
 
     default_mem_target = config.memory_target
     if path == "large":
-        config.memory_target = 4 * 1024 * 1024
+        # Below the 1.8 MB payload, so the write takes the large-array path.
+        config.memory_target = 1024 * 1024
     try:
         to_ngff_zarr(
             str(store),

--- a/py/test/test_to_ngff_zarr_sharding.py
+++ b/py/test/test_to_ngff_zarr_sharding.py
@@ -170,3 +170,75 @@ def test_large_image_serialization_with_sharding(input_images, tmp_path):
     # verify_against_baseline(dataset_name, baseline_name, multiscales)
 
     config.memory_target = default_mem_target
+
+
+def _stored_grid(store):
+    """The stored shard shape and the inner chunk shape of one scale array."""
+    for path in sorted(store.rglob("zarr.json")):
+        metadata = json.loads(path.read_text())
+        if metadata.get("node_type") != "array":
+            continue
+        inner = next(
+            codec["configuration"]["chunk_shape"]
+            for codec in metadata["codecs"]
+            if codec["name"] == "sharding_indexed"
+        )
+        return metadata["chunk_grid"]["configuration"]["chunk_shape"], inner
+    raise AssertionError(f"no array metadata under {store}")
+
+
+@pytest.mark.parametrize("path", ["small", "large", "metadata_only"])
+def test_a_shard_may_run_past_the_axis(tmp_path, path):
+    """The requested chunk survives an axis that factors badly (gh-733).
+
+    A shard shortened to the axis has to be divided evenly by the inner chunk,
+    and 275 (5 * 5 * 11) has no divisor near 256, so the chunk collapsed to 55
+    while a prime 271 collapsed to the whole shard. Zarr v3 permits a partial
+    final shard, so the shard is stored as asked instead. Every write path
+    describes the array the same way.
+    """
+    import dask.array as da
+    import numpy as np
+
+    data = da.zeros((2, 12, 275, 271), dtype=np.uint8, chunks=(1, 1, 256, 256))
+    image = to_ngff_image(data, dims=["c", "z", "y", "x"])
+    multiscales = to_multiscales(
+        image, scale_factors=[], chunks={"c": 1, "z": 1, "y": 256, "x": 256}
+    )
+    store = tmp_path / f"{path}.ome.zarr"
+    chunks_per_shard = {"z": 10, "y": 2, "x": 2, "c": 2}
+
+    default_mem_target = config.memory_target
+    if path == "large":
+        config.memory_target = 4 * 1024 * 1024
+    try:
+        to_ngff_zarr(
+            str(store),
+            multiscales,
+            chunks_per_shard=chunks_per_shard,
+            metadata_only=path == "metadata_only",
+        )
+    finally:
+        config.memory_target = default_mem_target
+
+    assert _stored_grid(store) == ([2, 10, 512, 512], [1, 1, 256, 256])
+
+
+def test_a_shard_is_capped_at_the_chunks_that_cover_the_axis(tmp_path):
+    """No shard grid is larger than the array needs (gh-733).
+
+    Two chunks per shard on an axis one chunk long would store a shard grid
+    twice the array; the shard is held to the chunks that cover the axis.
+    """
+    import dask.array as da
+    import numpy as np
+
+    data = da.zeros((1, 3, 29, 185), dtype=np.uint8, chunks=(1, 3, 8, 8))
+    image = to_ngff_image(data, dims=["t", "c", "y", "x"])
+    multiscales = to_multiscales(image, scale_factors=[], chunks=8)
+    store = tmp_path / "capped.ome.zarr"
+    to_ngff_zarr(str(store), multiscales, chunks_per_shard=2)
+
+    shard, inner = _stored_grid(store)
+    assert shard == [1, 3, 16, 16]
+    assert inner == [1, 3, 8, 8]

--- a/ts/src/process/to_multiscales-shared.ts
+++ b/ts/src/process/to_multiscales-shared.ts
@@ -56,6 +56,16 @@ export interface ToMultiscalesOptions {
    * the compress/decompress round-trip would be wasted work.
    */
   codecs?: ZarrCodec[];
+
+  /**
+   * What to do with an input whose axes are not in the OME-Zarr specification
+   * order. `"canonical"`, the default, reorders them to time, then channel,
+   * then space (t, c, z, y, x), which is what conversion sources need: ITK
+   * component images and the 4-D/5-D default dims inference both yield
+   * channel-last. `"preserve"` writes the axes in the order given, which RFC-3
+   * permits from OME-Zarr 0.9.dev1 on and which no earlier version accepts.
+   */
+  axisOrder?: "canonical" | "preserve";
 }
 
 /**
@@ -89,13 +99,25 @@ export async function toMultiscalesCore(
     chunks: requestedChunks,
     codecs,
     orientation,
+    axisOrder = "canonical",
   } = options;
 
+  if (axisOrder !== "canonical" && axisOrder !== "preserve") {
+    throw new Error(
+      `axisOrder must be "canonical" or "preserve"; got ${
+        JSON.stringify(axisOrder)
+      }`,
+    );
+  }
   // OME-Zarr orders axes time, then channel, then space. Channel-last input
   // (ITK component images, the 4-D/5-D default dims) is normalized here so the
   // generated metadata and every scale are spec-ordered, and so a model the
-  // writer would refuse below 0.9.dev1 never reaches it.
-  const image = await canonicalAxisOrder(inputImage, codecs);
+  // writer would refuse below 0.9.dev1 never reaches it. An order the caller
+  // chose is kept on request: RFC-3 lifts the ordering rule, and the reorder is
+  // silent otherwise.
+  const image = axisOrder === "canonical"
+    ? await canonicalAxisOrder(inputImage, codecs)
+    : inputImage;
   // A positional `chunks` array indexes the caller's dims, so it follows them
   // through the reordering. The dim-keyed and scalar forms need no change.
   const _chunks = Array.isArray(requestedChunks) && image !== inputImage

--- a/ts/test/canonical_axis_order_test.ts
+++ b/ts/test/canonical_axis_order_test.ts
@@ -9,7 +9,7 @@
  * axis model outside that vocabulary alone.
  */
 
-import { assertEquals, assertNotEquals } from "@std/assert";
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
 import * as zarr from "zarrita";
 
 import {
@@ -192,5 +192,36 @@ Deno.test("canonicalAxisOrder - a 64-bit integer image transposes", async () => 
   assertEquals(
     Array.from(values as BigInt64Array).map(Number),
     [0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11],
+  );
+});
+
+Deno.test("toMultiscales - preserve keeps the order the caller chose", async () => {
+  const image = await rampImage(["z", "y", "x", "c"], [8, 16, 16, 2]);
+  const multiscales = await toMultiscales(image, {
+    scaleFactors: [2],
+    method: Methods.ITKWASM_GAUSSIAN,
+    axisOrder: "preserve",
+  });
+
+  assertEquals(
+    multiscales.metadata.axes.map((axis) => axis.name),
+    ["z", "y", "x", "c"],
+  );
+  assertEquals(multiscales.images[0].dims, ["z", "y", "x", "c"]);
+  // The pyramid follows the axes it was given: the channel axis is not scaled.
+  assertEquals(multiscales.images[1].data.shape, [4, 8, 8, 2]);
+});
+
+Deno.test("toMultiscales - an unknown axis order is refused", async () => {
+  const image = await rampImage(["z", "y", "x", "c"], [8, 16, 16, 2]);
+  await assertRejects(
+    () =>
+      toMultiscales(image, {
+        scaleFactors: [],
+        // deno-lint-ignore no-explicit-any
+        axisOrder: "spec" as any,
+      }),
+    Error,
+    "axisOrder must be",
   );
 });


### PR DESCRIPTION
Two regressions reported within a day of each other, both in how the writer reinterprets what it was given.

## A shard is stored as requested (closes #733)

A sharded write shortened every shard dimension to the axis length. The sharding codec requires the inner chunk to divide the shard, so the inner chunk was then pulled down to a divisor of that shortened shard. An axis of 275 (5 * 5 * 11) has no divisor near a requested 256, giving 55, and a prime axis of 271 leaves only the whole shard, giving 271. A store asked for 256 x 256 chunks in 512 x 512 shards came back with 1 x 1 x 55 x 271 chunks in 2 x 10 x 275 x 271 shards.

Zarr v3 permits a partial final shard exactly as it permits a partial final chunk, which is already why chunks are no longer snapped to an axis divisor (#588). The shard is now stored as requested, held only to the smallest whole number of inner chunks that covers the axis, so no shard grid is larger than the array needs and the inner chunk divides it by construction.

The region planner keeps working on the shard clamped to the axes, since a write region cannot run past the array. Conflating the two is what made the large-array path divide by zero once shards could exceed it.

Checked: the three write paths (small, large, metadata-only) describe the array identically, which was the point of the change that introduced this; the data round-trips bit for bit on the small and large paths; zarr-python reads the partial final shard and returns the same array; #588 does not reopen.

## The axis order can be kept (closes #734)

`to_multiscales` reordered any input whose axes were not in the specification order, so a `(z, y, x, c)` image came back as `(c, z, y, x)` with no way to object. RFC-3 lifts the ordering rule from 0.9.dev1 on. The guard meant to leave RFC-3 models alone only fires on an axis *name* outside `{t, c, z, y, x}`, which reordered standard names never are.

`axis_order`, `axisOrder` in the TypeScript port, chooses:

- `"canonical"`, the default and the current behaviour, reorders to time, then channel, then space. Conversion sources need it: the TIFF `S` axis, ITK component images and the 4-D/5-D default dims inference all yield channel-last.
- `"preserve"` writes the axes as given.

The writer still refuses a non-canonical order for every version before 0.9.dev1, with the message it already had, so `"preserve"` cannot produce a store an earlier version would reject.

## Note

`to_ngff_image` rejects any axis name outside `{t, c, z, y, x}`, so an RFC-3 axis model with its own names is only constructible through `NgffImage` directly, with `axes_types`. That is a separate gap and is left alone here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to preserve input axis order when converting data to multiscale OME-Zarr. Canonical OME-Zarr ordering remains the default.
  - Added validation for unsupported axis-order settings.

- **Bug Fixes**
  - Improved sharded storage resolution so requested shard dimensions are preserved, including when they extend beyond array boundaries.
  - Region planning now correctly caps chunk coverage at the relevant array dimensions.

- **Tests**
  - Added coverage for axis-order preservation, validation, round-tripping, and sharding edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->