### PR TITLE
Don't force metadata consolidation

### DIFF
--- a/mcp/ngff_zarr_mcp/models.py
+++ b/mcp/ngff_zarr_mcp/models.py
@@ -82,6 +82,13 @@ class ConversionOptions(BaseModel):
     use_tensorstore: bool = Field(
         False, description="Deprecated: uses the zarrista backend for I/O"
     )
+    consolidate_metadata: bool = Field(
+        True,
+        description=(
+            "Write consolidated metadata. Set False for stores destined for a "
+            "backend that rejects it, such as Icechunk"
+        ),
+    )
 
     # Performance options
     use_local_cluster: bool = Field(
@@ -162,6 +169,13 @@ class OptimizationOptions(BaseModel):
     )
     storage_options: dict[str, str | int | bool] | None = Field(
         None, description="Storage options for remote stores"
+    )
+    consolidate_metadata: bool = Field(
+        True,
+        description=(
+            "Write consolidated metadata. Set False for stores destined for a "
+            "backend that rejects it, such as Icechunk"
+        ),
     )
 
     @model_validator(mode="after")

--- a/mcp/ngff_zarr_mcp/server.py
+++ b/mcp/ngff_zarr_mcp/server.py
@@ -52,6 +52,7 @@ async def convert_images_to_ome_zarr(
     # New RFC 4 and storage options
     anatomical_orientation: str | None = None,
     storage_options: dict[str, str] | None = None,
+    consolidate_metadata: bool = True,
 ) -> ConversionResult:
     """
     Convert images to OME-Zarr format.
@@ -80,6 +81,9 @@ async def convert_images_to_ome_zarr(
             Applies to file/array inputs only; for existing zarr-store inputs
             the orientation already in the source metadata is preserved.
         storage_options: Storage options for remote stores (S3, GCS, etc.)
+        consolidate_metadata: Write consolidated metadata (default True). Set
+            False for stores destined for a backend that rejects it, such as
+            Icechunk.
 
     Returns:
         ConversionResult with success status and store information
@@ -116,6 +120,7 @@ async def convert_images_to_ome_zarr(
         cache_dir=cache_dir,
         anatomical_orientation=anatomical_orientation,
         storage_options=storage_options,  # type: ignore[arg-type]
+        consolidate_metadata=consolidate_metadata,
     )
 
     return await convert_to_ome_zarr(input_paths, options)
@@ -177,6 +182,7 @@ async def optimize_ome_zarr_store(
     compression_level: int | None = None,
     chunks: list[int] | None = None,
     chunks_per_shard: list[int] | None = None,
+    consolidate_metadata: bool = True,
 ) -> ConversionResult:
     """
     Optimize an existing OME-Zarr store with new compression/chunking.
@@ -188,6 +194,9 @@ async def optimize_ome_zarr_store(
         compression_level: New compression level
         chunks: New chunk sizes
         chunks_per_shard: New sharding configuration
+        consolidate_metadata: Write consolidated metadata (default True). Set
+            False for stores destined for a backend that rejects it, such as
+            Icechunk.
 
     Returns:
         ConversionResult with optimization results
@@ -201,6 +210,7 @@ async def optimize_ome_zarr_store(
         chunks=chunks,
         chunks_per_shard=chunks_per_shard,
         storage_options=None,  # Add the required parameter
+        consolidate_metadata=consolidate_metadata,
     )
 
     return await optimize_zarr_store(options)

--- a/mcp/ngff_zarr_mcp/tools.py
+++ b/mcp/ngff_zarr_mcp/tools.py
@@ -234,6 +234,7 @@ async def convert_to_ome_zarr(
                     version=options.ome_zarr_version,
                     chunks_per_shard=chunks_per_shard,
                     use_tensorstore=options.use_tensorstore,
+                    consolidate_metadata=options.consolidate_metadata,
                     **kwargs,
                 )
 
@@ -481,6 +482,7 @@ async def optimize_zarr_store(options: OptimizationOptions) -> ConversionResult:
             output_store,
             optimized_multiscales,
             chunks_per_shard=chunks_per_shard,
+            consolidate_metadata=options.consolidate_metadata,
             **compression_kwargs,
         )
 

--- a/mcp/tests/test_convert_to_ome_zarr.py
+++ b/mcp/tests/test_convert_to_ome_zarr.py
@@ -282,3 +282,25 @@ async def test_convert_with_anatomical_orientation(test_input_file, temp_output_
     for dim, value in expected.items():
         assert by_name[dim]["orientation"]["type"] == "anatomical"
         assert by_name[dim]["orientation"]["value"] == value
+
+
+@pytest.mark.asyncio
+async def test_convert_without_consolidated_metadata(test_input_file, temp_output_dir):
+    """``consolidate_metadata=False`` skips the consolidated metadata."""
+    from ngff_zarr._zarrista_utils import has_consolidated_metadata
+
+    output_path = Path(temp_output_dir) / "mr_head_unconsolidated.ome.zarr"
+
+    options = ConversionOptions(
+        output_path=str(output_path),
+        ome_zarr_version="0.5",
+        method="itkwasm_gaussian",
+        scale_factors=None,
+        chunks=64,
+        consolidate_metadata=False,
+    )
+
+    result = await convert_to_ome_zarr([str(test_input_file)], options)
+    assert result.success, f"Conversion failed: {result.error}"
+
+    assert not has_consolidated_metadata(str(output_path), 3)

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -1527,6 +1527,7 @@ def to_ome_zarr(
     scale_strategy: ScaleStrategy = "pad",
     metadata_only: bool = False,
     start_level: int = 0,
+    consolidate_metadata: bool = True,
     **kwargs,
 ) -> None:
     """
@@ -1587,6 +1588,12 @@ def to_ome_zarr(
         are kept, the multiscales entry is rewritten in full, and a level at or above
         ``start_level`` that already exists is replaced.
     :type  start_level: int, optional
+
+    :param consolidate_metadata: If True (default), write consolidated metadata
+        after the arrays. Set False to skip it, e.g. when the store will be
+        uploaded to a backend that rejects consolidated metadata such as
+        Icechunk.
+    :type  consolidate_metadata: bool, optional
 
     :param **kwargs: Array-creation options: `compressor` (zarr format 2) and
         `compressors` (zarr format 3). The engine encodes with the `bytes` codec
@@ -1668,6 +1675,7 @@ def to_ome_zarr(
                 progress=progress,
                 chunks_per_shard=chunks_per_shard,
                 scale_strategy=scale_strategy,
+                consolidate_metadata=consolidate_metadata,
                 **kwargs,
             )
 
@@ -1691,6 +1699,7 @@ def to_ome_zarr(
         scale_strategy=scale_strategy,
         metadata_only=metadata_only,
         start_level=start_level,
+        consolidate_metadata=consolidate_metadata,
         **kwargs,
     )
 
@@ -1711,6 +1720,7 @@ def _to_ngff_zarr_impl(
     scale_strategy: ScaleStrategy = "pad",
     metadata_only: bool = False,
     start_level: int = 0,
+    consolidate_metadata: bool = True,
     **kwargs,
 ) -> None:
     """
@@ -1763,6 +1773,25 @@ def _to_ngff_zarr_impl(
     # Format parameters
     zarr_format = 2 if version == "0.4" else 3
 
+    # A zarr v2 store keeps consolidated metadata in a separate .zmetadata
+    # sidecar. An in-place write (overwrite=False) rewrites only the group
+    # document, so that sidecar would remain and go stale; a full overwrite
+    # recreates the store and drops it. Reject skipping consolidation for the
+    # in-place case, which start_level always is. Zarr v3 stores the block
+    # inside the root document, which the rewrite drops, so they self-clean.
+    if (
+        zarr_format == 2
+        and not consolidate_metadata
+        and not overwrite
+        and has_consolidated_metadata(store, zarr_format)
+    ):
+        raise ValueError(
+            "Cannot write into a zarr v2 store that already has consolidated "
+            "metadata with consolidate_metadata=False and overwrite=False: the "
+            "existing .zmetadata would be left stale. Recreate the store with "
+            "overwrite=True, or keep consolidate_metadata=True."
+        )
+
     # Create Zarr root
     # Appending names only the levels it keeps until the new arrays are in
     # place, so an interrupted call leaves a store that reads as those levels.
@@ -1773,7 +1802,9 @@ def _to_ngff_zarr_impl(
         kept = copy.deepcopy(metadata_dict)
         kept["datasets"] = kept["datasets"][:start_level]
         _create_zarr_root(store, version, overwrite, kept, root_attributes)
-        if was_consolidated:
+        # Restore consolidation for the kept levels only when the final write
+        # will re-consolidate; otherwise this partial block would go stale.
+        if was_consolidated and consolidate_metadata:
             _zarrista_consolidate_metadata(store, zarr_format)
     else:
         _create_zarr_root(store, version, overwrite, metadata_dict, root_attributes)
@@ -1974,5 +2005,5 @@ def _to_ngff_zarr_impl(
             callback()
         image.computed_callbacks = []
 
-    # Consolidate metadata
-    _zarrista_consolidate_metadata(store, zarr_format)
+    if consolidate_metadata:
+        _zarrista_consolidate_metadata(store, zarr_format)

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -1775,10 +1775,10 @@ def _to_ngff_zarr_impl(
 
     # A zarr v2 store keeps consolidated metadata in a separate .zmetadata
     # sidecar. An in-place write (overwrite=False) rewrites only the group
-    # document, so that sidecar would remain and go stale; a full overwrite
-    # recreates the store and drops it. Reject skipping consolidation for the
-    # in-place case, which start_level always is. Zarr v3 stores the block
-    # inside the root document, which the rewrite drops, so they self-clean.
+    # document, so without re-consolidation the sidecar would become stale.
+    # A full overwrite is ok without consolidate because it recreates the store.
+    # For zarr v3 zarrista rewrites the entire zarr.json file so we don't need
+    # to error there.
     if (
         zarr_format == 2
         and not consolidate_metadata
@@ -1788,7 +1788,7 @@ def _to_ngff_zarr_impl(
         raise ValueError(
             "Cannot write into a zarr v2 store that already has consolidated "
             "metadata with consolidate_metadata=False and overwrite=False: the "
-            "existing .zmetadata would be left stale. Recreate the store with "
+            "existing consolidated metadata would be left stale. Either use "
             "overwrite=True, or keep consolidate_metadata=True."
         )
 

--- a/py/test/test_consolidate_metadata.py
+++ b/py/test/test_consolidate_metadata.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""consolidate_metadata can skip consolidation.
+
+Consolidated metadata is incompatible with backends that run their own
+consolidation, such as Icechunk, so ``to_ome_zarr`` must be able to skip it.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import from_ome_zarr, to_multiscales, to_ngff_image, to_ome_zarr
+from ngff_zarr._zarrista_utils import has_consolidated_metadata
+from packaging import version
+
+needs_zarr_v3 = pytest.mark.skipif(
+    version.parse(zarr.__version__) < version.parse("3.0.0b1"),
+    reason="zarr version < 3.0.0b1",
+)
+VERSIONS = ["0.4", pytest.param("0.5", marks=needs_zarr_v3)]
+
+
+@pytest.mark.parametrize("ngff_version", VERSIONS)
+def test_consolidate_metadata_toggle(tmp_path, ngff_version):
+    zarr_format = 2 if ngff_version == "0.4" else 3
+    image = to_ngff_image(
+        np.arange(64 * 64, dtype=np.uint8).reshape(64, 64), dims=["y", "x"]
+    )
+    multiscales = to_multiscales(image, scale_factors=[2], cache=False)
+
+    default = str(tmp_path / "default.ome.zarr")
+    disabled = str(tmp_path / "disabled.ome.zarr")
+    to_ome_zarr(default, multiscales, version=ngff_version)
+    to_ome_zarr(disabled, multiscales, version=ngff_version, consolidate_metadata=False)
+
+    assert has_consolidated_metadata(default, zarr_format)
+    assert not has_consolidated_metadata(disabled, zarr_format)
+
+
+def _consolidated_level0(path, ngff_version):
+    data = np.random.default_rng(0).random((1, 32, 32, 32)).astype(np.float32)
+    image = to_ngff_image(data, dims=["c", "z", "y", "x"])
+    to_ome_zarr(
+        path, to_multiscales(image, scale_factors=[], cache=False), version=ngff_version
+    )
+    pyramid = to_multiscales(
+        from_ome_zarr(path).images[0], scale_factors=[2], cache=False
+    )
+    return pyramid
+
+
+# A zarr v2 in-place write cannot drop the pre-existing .zmetadata sidecar, so
+# skipping consolidation would leave it stale. This holds for an append
+# (start_level) and a plain overwrite=False rewrite alike.
+@pytest.mark.parametrize("extra", [{"start_level": 1}, {}], ids=["append", "in_place"])
+def test_disabling_on_in_place_v2_write_raises(tmp_path, extra):
+    path = str(tmp_path / "image.ome.zarr")
+    pyramid = _consolidated_level0(path, "0.4")
+    with pytest.raises(ValueError, match="would be left stale"):
+        to_ome_zarr(
+            path,
+            pyramid,
+            version="0.4",
+            overwrite=False,
+            consolidate_metadata=False,
+            **extra,
+        )
+
+
+# A zarr v3 in-place write rewrites the root document, dropping its consolidated
+# block, so the same append instead succeeds and leaves the store unconsolidated.
+@needs_zarr_v3
+def test_disabling_on_in_place_v3_append_self_cleans(tmp_path):
+    path = str(tmp_path / "image.ome.zarr")
+    pyramid = _consolidated_level0(path, "0.5")
+    to_ome_zarr(
+        path,
+        pyramid,
+        version="0.5",
+        overwrite=False,
+        start_level=1,
+        consolidate_metadata=False,
+    )
+
+    assert not has_consolidated_metadata(path, 3)
+    assert len(from_ome_zarr(path).images) == 2
+
+
+@needs_zarr_v3
+def test_zarrista_root_rewrite_drops_v3_consolidated_block(tmp_path):
+    # The v3 exemption above rests on this zarrista behavior: rewriting the root
+    # group document regenerates zarr.json without the consolidated block, so an
+    # in-place write drops it. (zarr-python instead leaves the block in place and
+    # lets it go stale.) If this ever changes, the guard must start covering v3.
+    from ngff_zarr._zarrista_utils import create_zarrista_group
+
+    path = str(tmp_path / "image.ome.zarr")
+    _consolidated_level0(path, "0.5")
+    assert has_consolidated_metadata(path, 3)
+
+    create_zarrista_group(path, {}, 3, overwrite=False)
+    assert not has_consolidated_metadata(path, 3)
+
+
+def test_v2_in_place_without_the_guard_would_be_stale(tmp_path, monkeypatch):
+    # Justifies the guard: with its check neutralized, a v2 in-place append does
+    # write scale1, but the .zmetadata sidecar still describes only scale0 --
+    # a consolidated reader would miss the appended level.
+    import sys
+
+    path = str(tmp_path / "image.ome.zarr")
+    pyramid = _consolidated_level0(path, "0.4")
+    writer = sys.modules["ngff_zarr.to_ngff_zarr"]
+    monkeypatch.setattr(writer, "has_consolidated_metadata", lambda *a, **k: False)
+    to_ome_zarr(
+        path,
+        pyramid,
+        version="0.4",
+        overwrite=False,
+        start_level=1,
+        consolidate_metadata=False,
+    )
+
+    assert (Path(path) / "scale1").exists()
+    assert len(from_ome_zarr(path).images) == 2
+    assert "scale1" not in (Path(path) / ".zmetadata").read_text()

--- a/py/test/test_consolidate_metadata.py
+++ b/py/test/test_consolidate_metadata.py
@@ -6,8 +6,6 @@ Consolidated metadata is incompatible with backends that run their own
 consolidation, such as Icechunk, so ``to_ome_zarr`` must be able to skip it.
 """
 
-from pathlib import Path
-
 import numpy as np
 import pytest
 import zarr
@@ -86,43 +84,3 @@ def test_disabling_on_in_place_v3_append_self_cleans(tmp_path):
 
     assert not has_consolidated_metadata(path, 3)
     assert len(from_ome_zarr(path).images) == 2
-
-
-@needs_zarr_v3
-def test_zarrista_root_rewrite_drops_v3_consolidated_block(tmp_path):
-    # The v3 exemption above rests on this zarrista behavior: rewriting the root
-    # group document regenerates zarr.json without the consolidated block, so an
-    # in-place write drops it. (zarr-python instead leaves the block in place and
-    # lets it go stale.) If this ever changes, the guard must start covering v3.
-    from ngff_zarr._zarrista_utils import create_zarrista_group
-
-    path = str(tmp_path / "image.ome.zarr")
-    _consolidated_level0(path, "0.5")
-    assert has_consolidated_metadata(path, 3)
-
-    create_zarrista_group(path, {}, 3, overwrite=False)
-    assert not has_consolidated_metadata(path, 3)
-
-
-def test_v2_in_place_without_the_guard_would_be_stale(tmp_path, monkeypatch):
-    # Justifies the guard: with its check neutralized, a v2 in-place append does
-    # write scale1, but the .zmetadata sidecar still describes only scale0 --
-    # a consolidated reader would miss the appended level.
-    import sys
-
-    path = str(tmp_path / "image.ome.zarr")
-    pyramid = _consolidated_level0(path, "0.4")
-    writer = sys.modules["ngff_zarr.to_ngff_zarr"]
-    monkeypatch.setattr(writer, "has_consolidated_metadata", lambda *a, **k: False)
-    to_ome_zarr(
-        path,
-        pyramid,
-        version="0.4",
-        overwrite=False,
-        start_level=1,
-        consolidate_metadata=False,
-    )
-
-    assert (Path(path) / "scale1").exists()
-    assert len(from_ome_zarr(path).images) == 2
-    assert "scale1" not in (Path(path) / ".zmetadata").read_text()


### PR DESCRIPTION
Don't force metadata consolidation. Fixes #698 

There's a little bit more complexity than I thought at first. We have to protect the user against accidentally creating a store with a stale consolidated metadata when they append. If they wrote a store with consolidated metadata, then append without consolidated metadata they could end up with stale metadata.

This is only a problem for zarr v2 as zarrista re-writes the entire zarr.json document for zarr v3. One of the tests added accounts for the dependence on that implementation detail. But happy to also throwing an error in this case if you prefer that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether metadata is consolidated when converting or optimizing OME-Zarr stores.
  * Metadata consolidation remains enabled by default.
  * Stores can now be written without consolidated metadata for compatibility with backends that reject it.
  * In-place Zarr v2 writes now report an error when disabling consolidation could leave stale metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->