### PR TITLE
feat(ts): add consolidateMetadata option to toOmeZarr

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -433,6 +433,7 @@ async function toNgffZarr(
   options?: {
     version?: "0.4" | "0.5" | "0.6" | "0.9.dev1";
     chunksPerShard?: number | number[] | Record<string, number>;
+    consolidateMetadata?: boolean;
   }
 ): Promise<void>
 ```
@@ -442,6 +443,8 @@ async function toNgffZarr(
 - `multiscales`: NgffMultiscales object to write
 - `options.version`: OME-Zarr version (default: "0.5")
 - `options.chunksPerShard`: Sharding configuration (v0.5 only)
+- `options.consolidateMetadata`: Inline every array's metadata into the root
+  `zarr.json` (default: `true`)
 
 **Example:**
 ```typescript
@@ -457,6 +460,32 @@ await toNgffZarr("output.ome.zarr", multiscales, {
   chunksPerShard: { z: 2, y: 2, x: 2 },
 });
 ```
+
+**Consolidated metadata.** By default the writer finishes by inlining every
+array's `zarr.json` into the root group's own `zarr.json`. A reader that
+understands the block resolves the whole hierarchy from that one document
+instead of one request per scale level, which matters most over HTTP and for
+RFC-9 archives. zarr-python is such a reader, and so is the Python package,
+which consolidates every store it writes -- writing the block keeps the two
+implementations' output equivalent. `fromOmeZarr` does not yet exploit it:
+zarrita's consolidated reader currently understands only the Zarr v2
+`.zmetadata` sidecar, which this writer never emits.
+
+Some backends run their own consolidation and reject the block -- Icechunk is
+the motivating case -- so it can be turned off:
+
+```typescript
+await toOmeZarr("output.ome.zarr", multiscales, {
+  consolidateMetadata: false,
+});
+```
+
+The flag governs the root document alone; the arrays are written identically
+either way. Re-writing a consolidated store with `consolidateMetadata: false`
+leaves it unconsolidated rather than stale, because a Zarr v3 write replaces
+the root document wholesale. `toOmeZarrOzx` / `toOmeZarrOzxData` accept the
+same option for RFC-9 archives. This mirrors the Python package's
+`to_ome_zarr(..., consolidate_metadata=False)`.
 
 #### `toMultiscales()`
 

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -8,6 +8,10 @@ import type { NgffMultiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
+import {
+  consolidateMetadata,
+  datasetNodePaths,
+} from "../utils/consolidate_metadata.ts";
 import { createWriteQueue, zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import type { MemoryStore } from "./from_ngff_zarr-browser.ts";
 import { memoryStoreToZip } from "./rfc9_zip.ts";
@@ -28,6 +32,13 @@ export interface ToOmeZarrOptions {
    * {@link codecFromName} or {@link bytesOnlyCodecs} to build common pipelines.
    */
   codecs?: ZarrCodec[];
+  /**
+   * Write consolidated metadata into the root `zarr.json` once the arrays are
+   * in place (default `true`). Set `false` for a store destined for a backend
+   * that rejects it, such as Icechunk, which runs its own consolidation and
+   * treats a consolidated block as interference.
+   */
+  consolidateMetadata?: boolean;
 }
 
 /** @deprecated Use {@link ToOmeZarrOptions} instead. */
@@ -48,6 +59,12 @@ export interface ToOmeZarrOzxOptions {
   onProgress?:
     | ((completedChunks: number, totalChunks: number) => void)
     | undefined;
+  /**
+   * Write consolidated metadata into the root `zarr.json` (default `true`).
+   * A zipped store is where consolidation pays off most for a reader that
+   * understands the block, so leave it on unless the destination rejects it.
+   */
+  consolidateMetadata?: boolean | undefined;
 }
 
 /** @deprecated Use {@link ToOmeZarrOzxOptions} instead. */
@@ -111,6 +128,20 @@ export async function toOmeZarr(
         dataset.path,
         undefined, // onProgress
         options.codecs,
+      );
+    }
+
+    // Consolidate last: the block inlines the array documents, so it has to be
+    // written after them. `zarr.create` above replaced the root document
+    // wholesale, so a store that was consolidated before this call and is
+    // written with `consolidateMetadata: false` is left unconsolidated rather
+    // than stale -- the Zarr v3 behavior the Python writer relies on too.
+    if (options.consolidateMetadata ?? true) {
+      await consolidateMetadata(
+        _resolvedStore,
+        datasetNodePaths(
+          multiscales.metadata.datasets.map((dataset) => dataset.path),
+        ),
       );
     }
   } catch (error) {
@@ -499,6 +530,7 @@ export async function toOmeZarrOzx(
     multiscales,
     _writeImage,
     _options.onProgress ?? null,
+    _options.consolidateMetadata ?? true,
   );
 
   // Convert the memory store to ZIP data

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -6,6 +6,11 @@ import type { NgffMultiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
+import {
+  type ConsolidatableStore,
+  consolidateMetadata,
+  datasetNodePaths,
+} from "../utils/consolidate_metadata.ts";
 import { createWriteQueue, zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import type { MemoryStore } from "./from_ngff_zarr.ts";
 import { isOzxPath, memoryStoreToZip } from "./rfc9_zip.ts";
@@ -31,6 +36,13 @@ export interface ToOmeZarrOptions {
    * {@link codecFromName} or {@link bytesOnlyCodecs} to build common pipelines.
    */
   codecs?: ZarrCodec[];
+  /**
+   * Write consolidated metadata into the root `zarr.json` once the arrays are
+   * in place (default `true`). Set `false` for a store destined for a backend
+   * that rejects it, such as Icechunk, which runs its own consolidation and
+   * treats a consolidated block as interference.
+   */
+  consolidateMetadata?: boolean;
 }
 
 /** @deprecated Use {@link ToOmeZarrOptions} instead. */
@@ -51,6 +63,12 @@ export interface ToOmeZarrOzxOptions {
   onProgress?:
     | ((completedChunks: number, totalChunks: number) => void)
     | undefined;
+  /**
+   * Write consolidated metadata into the root `zarr.json` (default `true`).
+   * A zipped store is where consolidation pays off most for a reader that
+   * understands the block, so leave it on unless the destination rejects it.
+   */
+  consolidateMetadata?: boolean | undefined;
 }
 
 /** @deprecated Use {@link ToOmeZarrOzxOptions} instead. */
@@ -111,7 +129,9 @@ export async function toOmeZarr(
     }
 
     // Delegate to toOmeZarrOzx (which always uses version 0.5)
-    await toOmeZarrOzx(store, multiscales);
+    await toOmeZarrOzx(store, multiscales, {
+      consolidateMetadata: options.consolidateMetadata,
+    });
     return;
   }
 
@@ -174,6 +194,20 @@ export async function toOmeZarr(
         dataset.path,
         undefined, // onProgress
         options.codecs,
+      );
+    }
+
+    // Consolidate last: the block inlines the array documents, so it has to be
+    // written after them. `zarr.create` above replaced the root document
+    // wholesale, so a store that was consolidated before this call and is
+    // written with `consolidateMetadata: false` is left unconsolidated rather
+    // than stale -- the Zarr v3 behavior the Python writer relies on too.
+    if (options.consolidateMetadata ?? true) {
+      await consolidateMetadata(
+        _resolvedStore as ConsolidatableStore,
+        datasetNodePaths(
+          multiscales.metadata.datasets.map((dataset) => dataset.path),
+        ),
       );
     }
   } catch (error) {
@@ -614,6 +648,7 @@ export async function toOmeZarrOzxData(
     memoryStore,
     multiscales,
     options.onProgress ?? null,
+    options.consolidateMetadata ?? true,
   );
 
   // Convert the memory store to ZIP data
@@ -633,11 +668,13 @@ async function _writeToMemoryStore(
   store: MemoryStore,
   multiscales: NgffMultiscales,
   onProgress?: ((completedChunks: number, totalChunks: number) => void) | null,
+  consolidate: boolean = true,
 ): Promise<void> {
   await writeNgffMultiscalesToMemoryStore(
     store,
     multiscales,
     _writeImage,
     onProgress,
+    consolidate,
   );
 }

--- a/ts/src/io/to_ngff_zarr_ozx_common.ts
+++ b/ts/src/io/to_ngff_zarr_ozx_common.ts
@@ -14,6 +14,10 @@ import type { NgffImage } from "../types/ngff_image.ts";
 import type { Axis, MetadataInterface } from "../types/zarr_metadata.ts";
 import type { MemoryStore } from "./rfc9_zip.ts";
 import {
+  consolidateMetadata,
+  datasetNodePaths,
+} from "../utils/consolidate_metadata.ts";
+import {
   buildV06MultiscalesEntry,
   legacyTopLevelTransforms,
 } from "../utils/v06_metadata.ts";
@@ -340,6 +344,8 @@ export function createRfc9RootAttributes(
  * @param writeImage - Function to write individual images
  * @param onProgress - Optional progress callback for cumulative chunk
  *   progress across all scale levels
+ * @param consolidate - Inline the array documents into the root `zarr.json`
+ *   once they are written (default `true`)
  */
 export async function writeNgffMultiscalesToMemoryStore(
   store: MemoryStore,
@@ -353,6 +359,7 @@ export async function writeNgffMultiscalesToMemoryStore(
       | null,
   ) => Promise<void>,
   onProgress?: ((completedChunks: number, totalChunks: number) => void) | null,
+  consolidate: boolean = true,
 ): Promise<void> {
   // Validate version
   validateRfc9Version(multiscales);
@@ -417,5 +424,17 @@ export async function writeNgffMultiscalesToMemoryStore(
       }
       completedChunks += imageChunkCount;
     }
+  }
+
+  // Consolidate last: the block inlines the array documents, so they have to
+  // exist first. The root key keeps its insertion position in the Map, so the
+  // RFC-9 zip writer still lays the root document down as the first entry.
+  if (consolidate) {
+    await consolidateMetadata(
+      store,
+      datasetNodePaths(
+        multiscales.metadata.datasets.map((dataset) => dataset.path),
+      ),
+    );
   }
 }

--- a/ts/src/io/upgrade_ome_zarr_common.ts
+++ b/ts/src/io/upgrade_ome_zarr_common.ts
@@ -23,6 +23,11 @@ import {
   V06_ONDISK_VERSION,
 } from "../types/supported_versions.ts";
 import { buildRootAttributes } from "./to_ngff_zarr_ozx_common.ts";
+import {
+  consolidateMetadata,
+  datasetNodePaths,
+  hasConsolidatedMetadata,
+} from "../utils/consolidate_metadata.ts";
 
 /** Stores/paths `upgradeOmeZarr` can read from. */
 export type UpgradeInput =
@@ -239,7 +244,23 @@ export async function upgradeOmeZarrImpl(
   // chunk data is read), and `zarr.create` overwrites the root `zarr.json`
   // alone — every array `zarr.json` and chunk file is left byte-for-byte
   // untouched. This is the fix for issue #219.
+  //
+  // Read before the rewrite: `zarr.create` replaces the root document
+  // wholesale, and the fresh one carries no consolidated block. Restoring it
+  // keeps a re-tag from silently de-consolidating the store, matching the
+  // refresh Python's `upgrade_ome_zarr` does. Only Zarr v3 reaches here -- the
+  // v2/v3 boundary was rejected above -- so there is no `.zmetadata` sidecar
+  // to worry about, and stale consolidation is impossible either way.
+  const wasConsolidated = await hasConsolidatedMetadata(store);
   const multiscales = await deps.fromOmeZarr(store, { validate });
   const attributes = buildRootAttributes(multiscales.metadata, version);
   await zarr.create(location, { attributes });
+  if (wasConsolidated) {
+    await consolidateMetadata(
+      store,
+      datasetNodePaths(
+        multiscales.metadata.datasets.map((dataset) => dataset.path),
+      ),
+    );
+  }
 }

--- a/ts/src/io/upgrade_ome_zarr_common.ts
+++ b/ts/src/io/upgrade_ome_zarr_common.ts
@@ -24,9 +24,9 @@ import {
 } from "../types/supported_versions.ts";
 import { buildRootAttributes } from "./to_ngff_zarr_ozx_common.ts";
 import {
+  consolidatedNodePaths,
   consolidateMetadata,
   datasetNodePaths,
-  hasConsolidatedMetadata,
 } from "../utils/consolidate_metadata.ts";
 
 /** Stores/paths `upgradeOmeZarr` can read from. */
@@ -251,16 +251,25 @@ export async function upgradeOmeZarrImpl(
   // refresh Python's `upgrade_ome_zarr` does. Only Zarr v3 reaches here -- the
   // v2/v3 boundary was rejected above -- so there is no `.zmetadata` sidecar
   // to worry about, and stale consolidation is impossible either way.
-  const wasConsolidated = await hasConsolidatedMetadata(store);
+  const consolidatedBefore = await consolidatedNodePaths(store);
   const multiscales = await deps.fromOmeZarr(store, { validate });
   const attributes = buildRootAttributes(multiscales.metadata, version);
   await zarr.create(location, { attributes });
-  if (wasConsolidated) {
-    await consolidateMetadata(
-      store,
-      datasetNodePaths(
+  if (consolidatedBefore !== undefined) {
+    // Union, not replace. A store holds nodes the multiscales metadata never
+    // names -- an OME-Zarr `labels` group is the everyday case -- and a
+    // consolidated block is authoritative for what a reader finds, so
+    // narrowing it to the dataset paths would hide those nodes even though
+    // their documents are still there. Python re-globs the store; the block
+    // this store already had is the same census on this side. A key whose
+    // document has since gone is skipped by `consolidateMetadata`, so
+    // carrying a stale one over costs nothing.
+    const nodePaths = new Set([
+      ...consolidatedBefore,
+      ...datasetNodePaths(
         multiscales.metadata.datasets.map((dataset) => dataset.path),
       ),
-    );
+    ]);
+    await consolidateMetadata(store, [...nodePaths].sort());
   }
 }

--- a/ts/src/utils/consolidate_metadata.ts
+++ b/ts/src/utils/consolidate_metadata.ts
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Zarr v3 consolidated metadata for the OME-Zarr writers.
+ *
+ * Consolidation inlines every child node document into the root `zarr.json`,
+ * so a reader that understands the block resolves the whole hierarchy from one
+ * document instead of one request per node. zarr-python understands it, and so
+ * therefore does the Python side of this package, which consolidates every
+ * store it writes -- writing it here is what keeps the two writers' output
+ * equivalent.
+ *
+ * zarrita has no consolidation API: it exports the `withConsolidated` /
+ * `tryWithConsolidated` readers and nothing that writes the block, and those
+ * readers understand only the Zarr v2 `.zmetadata` sidecar, so `fromOmeZarr`
+ * does not yet benefit from what is written here. The block is instead
+ * assembled from the documents the writer just wrote, mirroring
+ * `_zarrista_utils.consolidate_metadata` on the Python side, which in turn
+ * matches what `zarr.consolidate_metadata` produces.
+ *
+ * That v2 sidecar has no counterpart here: the TypeScript writer emits Zarr v3
+ * documents only.
+ */
+
+/** A store key, which zarrita always spells with a leading slash. */
+type AbsolutePath = `/${string}`;
+
+/**
+ * The store surface consolidation needs: read a document, write a document.
+ *
+ * Deliberately narrower than zarrita's `Mutable` so both a `MemoryStore`
+ * (a plain `Map`, synchronous) and a `FileSystemStore` (asynchronous) satisfy
+ * it, and so this module pulls in no store implementation -- it has to stay
+ * importable from the browser build.
+ */
+export interface ConsolidatableStore {
+  get(
+    key: AbsolutePath,
+  ): Promise<Uint8Array | undefined> | Uint8Array | undefined;
+  set(key: AbsolutePath, value: Uint8Array): unknown;
+}
+
+const ROOT_DOCUMENT: AbsolutePath = "/zarr.json";
+
+type JsonObject = Record<string, unknown>;
+
+/** The `consolidated_metadata` block wrapping `metadata`. */
+function inlineBlock(metadata: JsonObject): JsonObject {
+  return { kind: "inline", must_understand: false, metadata };
+}
+
+async function readDocument(
+  store: ConsolidatableStore,
+  key: AbsolutePath,
+): Promise<JsonObject | undefined> {
+  const bytes = await store.get(key);
+  if (bytes === undefined) {
+    return undefined;
+  }
+  return JSON.parse(new TextDecoder().decode(bytes)) as JsonObject;
+}
+
+async function writeDocument(
+  store: ConsolidatableStore,
+  key: AbsolutePath,
+  document: JsonObject,
+): Promise<void> {
+  // Two-space indent is what zarrita's own `json_encode_object` writes, so a
+  // document rewritten here is formatted like the ones around it.
+  await store.set(
+    key,
+    new TextEncoder().encode(JSON.stringify(document, null, 2)),
+  );
+}
+
+/**
+ * Normalize a child document into the entry zarr-python would consolidate.
+ *
+ * zarr-python's consolidation re-serializes every entry through its metadata
+ * model, which always materializes these optional fields, and marks each
+ * non-root group entry as (vacuously) consolidated. Matching it keeps a block
+ * written here indistinguishable from one written by zarr-python or by the
+ * Python package.
+ */
+function consolidatedEntry(document: JsonObject): JsonObject {
+  const entry: JsonObject = { ...document };
+  entry.attributes ??= {};
+  if (entry.node_type === "group") {
+    entry.consolidated_metadata = inlineBlock({});
+  } else {
+    entry.storage_transformers ??= [];
+  }
+  return entry;
+}
+
+/**
+ * The node paths a dataset list implies, root-relative and without a leading
+ * slash -- the keys a consolidated block is indexed by.
+ *
+ * A dataset path may be nested (`"scale0/image"`), in which case each ancestor
+ * group is a node in its own right and gets its own entry, the way
+ * zarr-python's consolidation walks the hierarchy.
+ */
+export function datasetNodePaths(datasetPaths: string[]): string[] {
+  const nodePaths = new Set<string>();
+  for (const datasetPath of datasetPaths) {
+    const segments = datasetPath.split("/").filter((segment) => segment !== "");
+    for (let end = 1; end <= segments.length; end++) {
+      nodePaths.add(segments.slice(0, end).join("/"));
+    }
+  }
+  return [...nodePaths].sort();
+}
+
+/**
+ * Inline the metadata of `nodePaths` into the root `zarr.json` of `store`.
+ *
+ * A node without a document of its own is skipped rather than invented, so an
+ * ancestor group the writer never materialized does not turn into an entry
+ * that points at nothing.
+ *
+ * @param store - Store holding the already-written documents
+ * @param nodePaths - Root-relative node paths, e.g. from {@link datasetNodePaths}
+ */
+export async function consolidateMetadata(
+  store: ConsolidatableStore,
+  nodePaths: string[],
+): Promise<void> {
+  const metadata: JsonObject = {};
+  for (const nodePath of nodePaths) {
+    const document = await readDocument(store, `/${nodePath}/zarr.json`);
+    if (document === undefined) {
+      continue;
+    }
+    metadata[nodePath] = consolidatedEntry(document);
+  }
+
+  const root = await readDocument(store, ROOT_DOCUMENT);
+  if (root === undefined) {
+    throw new Error(
+      "Cannot consolidate metadata: the store has no root zarr.json.",
+    );
+  }
+  root.consolidated_metadata = inlineBlock(metadata);
+  await writeDocument(store, ROOT_DOCUMENT, root);
+}
+
+/**
+ * Whether the store's root `zarr.json` carries a consolidated metadata block.
+ *
+ * The Zarr v3 counterpart of the Python `has_consolidated_metadata`, used to
+ * decide whether an in-place metadata rewrite has consolidation to refresh.
+ */
+export async function hasConsolidatedMetadata(
+  store: ConsolidatableStore,
+): Promise<boolean> {
+  const root = await readDocument(store, ROOT_DOCUMENT);
+  return root !== undefined && root.consolidated_metadata !== undefined;
+}

--- a/ts/src/utils/consolidate_metadata.ts
+++ b/ts/src/utils/consolidate_metadata.ts
@@ -146,14 +146,31 @@ export async function consolidateMetadata(
 }
 
 /**
- * Whether the store's root `zarr.json` carries a consolidated metadata block.
+ * The node paths listed in the store's existing consolidated block, or
+ * `undefined` when the store carries no block at all.
  *
- * The Zarr v3 counterpart of the Python `has_consolidated_metadata`, used to
- * decide whether an in-place metadata rewrite has consolidation to refresh.
+ * Answers the question Python's `has_consolidated_metadata` answers -- is there
+ * consolidation here to refresh? -- and one more besides: *which* nodes it
+ * covered. Python re-consolidates by globbing every `zarr.json` beneath the
+ * store, which no zarrita store can be asked to do (`FileSystemStore` exposes
+ * no listing API). The previous block is the next best census of the hierarchy:
+ * whoever consolidated the store last enumerated it, so a refresh can reuse
+ * their keys instead of narrowing the store to the nodes one caller happens to
+ * know about.
+ *
+ * An empty array means a consolidated block covering no nodes, which is a
+ * different thing from `undefined`.
  */
-export async function hasConsolidatedMetadata(
+export async function consolidatedNodePaths(
   store: ConsolidatableStore,
-): Promise<boolean> {
+): Promise<string[] | undefined> {
   const root = await readDocument(store, ROOT_DOCUMENT);
-  return root !== undefined && root.consolidated_metadata !== undefined;
+  const block = root?.consolidated_metadata as JsonObject | undefined;
+  if (block === undefined || block === null) {
+    return undefined;
+  }
+  const metadata = block.metadata;
+  return typeof metadata === "object" && metadata !== null
+    ? Object.keys(metadata)
+    : [];
 }

--- a/ts/test/consolidate_metadata_test.ts
+++ b/ts/test/consolidate_metadata_test.ts
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * `consolidateMetadata` can skip consolidation.
+ *
+ * Consolidated metadata is incompatible with backends that run their own
+ * consolidation, such as Icechunk, so `toOmeZarr` must be able to skip it.
+ * Mirrors `py/test/test_consolidate_metadata.py`.
+ */
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { join } from "@std/path";
+import * as zarr from "zarrita";
+
+import { ZipFileStore } from "@zarrita/storage";
+
+import {
+  fromOmeZarr,
+  type MemoryStore,
+  toOmeZarr,
+  toOmeZarrOzxData,
+  upgradeOmeZarr,
+} from "../src/mod.ts";
+import { readOzxJsonFirst } from "../src/io/rfc9_zip.ts";
+import {
+  createAxis,
+  createDataset,
+  createMetadata,
+  createNgffMultiscales,
+} from "../src/utils/factory.ts";
+import { NgffImage } from "../src/types/ngff_image.ts";
+import type { NgffMultiscales } from "../src/types/multiscales.ts";
+
+const SHAPE = [8, 8];
+const OUTPUT_DIR = join(Deno.cwd(), "test", "output");
+
+await Deno.mkdir(OUTPUT_DIR, { recursive: true });
+
+/** A two-level pyramid whose dataset paths are `scale0` and `scale1`. */
+async function fixture(
+  version: "0.4" | "0.5" | "0.6" = "0.5",
+): Promise<NgffMultiscales> {
+  const seed: MemoryStore = new Map();
+  const images: NgffImage[] = [];
+  for (let level = 0; level < 2; level++) {
+    const shape = SHAPE.map((size) => size >> level);
+    const array = await zarr.create(zarr.root(seed).resolve(`seed${level}`), {
+      shape,
+      chunk_shape: shape,
+      data_type: "uint16" as zarr.DataType,
+      fill_value: 0,
+    });
+    const scale = 1 << level;
+    images.push(
+      new NgffImage({
+        data: array,
+        dims: ["y", "x"],
+        scale: { y: scale, x: scale },
+        translation: { y: 0, x: 0 },
+        name: "consolidate-fixture",
+        axesUnits: undefined,
+        computedCallbacks: undefined,
+      }),
+    );
+  }
+  const axes = [
+    createAxis("y", "space", "micrometer"),
+    createAxis("x", "space", "micrometer"),
+  ];
+  const datasets = images.map((_, level) =>
+    createDataset(`scale${level}`, [1 << level, 1 << level], [0, 0])
+  );
+  const metadata = createMetadata(
+    axes,
+    datasets,
+    "consolidate-fixture",
+    version,
+  );
+  return createNgffMultiscales(images, metadata);
+}
+
+/** The root group's `consolidated_metadata` block, or `undefined`. */
+function consolidatedBlock(
+  store: MemoryStore,
+): Record<string, unknown> | undefined {
+  const raw = store.get("/zarr.json");
+  assert(raw !== undefined, "store has no root zarr.json");
+  const root = JSON.parse(new TextDecoder().decode(raw));
+  return root.consolidated_metadata;
+}
+
+Deno.test("toOmeZarr consolidates metadata by default", async () => {
+  const multiscales = await fixture();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.5" });
+
+  const block = consolidatedBlock(store);
+  assert(block !== undefined, "default write left the store unconsolidated");
+  assertEquals(block.kind, "inline");
+  assertEquals(block.must_understand, false);
+
+  // Every array the writer wrote is inlined, keyed by its dataset path.
+  const inlined = block.metadata as Record<string, Record<string, unknown>>;
+  assertEquals(Object.keys(inlined).sort(), ["scale0", "scale1"]);
+  for (const [path, entry] of Object.entries(inlined)) {
+    const raw = store.get(`/${path}/zarr.json`);
+    assert(raw !== undefined, `missing array document for ${path}`);
+    const document = JSON.parse(new TextDecoder().decode(raw));
+    assertEquals(entry.node_type, "array");
+    assertEquals(entry.shape, document.shape);
+    assertEquals(entry.data_type, document.data_type);
+    assertEquals(entry.codecs, document.codecs);
+    // Optional fields zarr-python always materializes on a consolidated entry.
+    assertEquals(entry.attributes, {});
+    assertEquals(entry.storage_transformers, []);
+  }
+});
+
+Deno.test("toOmeZarr skips consolidation on request", async () => {
+  const multiscales = await fixture();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, {
+    version: "0.5",
+    consolidateMetadata: false,
+  });
+
+  assertEquals(consolidatedBlock(store), undefined);
+});
+
+Deno.test("skipping consolidation leaves the arrays untouched", async () => {
+  const multiscales = await fixture();
+  const consolidated: MemoryStore = new Map();
+  const plain: MemoryStore = new Map();
+  await toOmeZarr(consolidated, multiscales, { version: "0.5" });
+  await toOmeZarr(plain, multiscales, {
+    version: "0.5",
+    consolidateMetadata: false,
+  });
+
+  // The flag governs the root document alone: every other key is identical.
+  assertEquals([...plain.keys()].sort(), [...consolidated.keys()].sort());
+  for (const key of plain.keys()) {
+    if (key === "/zarr.json") continue;
+    assertEquals(
+      [...plain.get(key)!].join(","),
+      [...consolidated.get(key)!].join(","),
+      `store key changed: ${key}`,
+    );
+  }
+});
+
+Deno.test("an unconsolidated store still reads back", async () => {
+  const multiscales = await fixture();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, {
+    version: "0.5",
+    consolidateMetadata: false,
+  });
+
+  const read = await fromOmeZarr(store);
+  assertEquals(read.images.length, 2);
+  assertEquals(read.images[0].data.shape, SHAPE);
+});
+
+// A Zarr v3 write replaces the root document wholesale, so re-writing a
+// consolidated store without consolidation drops the block instead of leaving
+// it stale. This is the invariant Python's zarr v2 guard exists to protect and
+// that its v3 path relies on; the TypeScript writer is v3-only, so it holds
+// unconditionally here.
+Deno.test("re-writing without consolidation self-cleans", async () => {
+  const multiscales = await fixture();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.5" });
+  assert(consolidatedBlock(store) !== undefined);
+
+  await toOmeZarr(store, multiscales, {
+    version: "0.5",
+    consolidateMetadata: false,
+  });
+  assertEquals(consolidatedBlock(store), undefined);
+});
+
+Deno.test("in-place upgradeOmeZarr refreshes consolidated metadata", async () => {
+  const multiscales = await fixture("0.5");
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.5" });
+
+  await upgradeOmeZarr(store, { version: "0.6" });
+
+  const block = consolidatedBlock(store);
+  assert(
+    block !== undefined,
+    "the re-tag silently de-consolidated the store",
+  );
+  assertEquals(Object.keys(block.metadata as object).sort(), [
+    "scale0",
+    "scale1",
+  ]);
+});
+
+Deno.test("in-place upgradeOmeZarr leaves an unconsolidated store alone", async () => {
+  const multiscales = await fixture("0.5");
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, {
+    version: "0.5",
+    consolidateMetadata: false,
+  });
+
+  await upgradeOmeZarr(store, { version: "0.6" });
+
+  assertEquals(consolidatedBlock(store), undefined);
+});
+
+/** The root group document inside a .ozx archive. */
+async function ozxRoot(zipData: Uint8Array): Promise<Record<string, unknown>> {
+  const store = ZipFileStore.fromBlob(new Blob([zipData as BlobPart]));
+  const raw = await store.get("/zarr.json");
+  assert(raw !== undefined, ".ozx archive has no root zarr.json");
+  return JSON.parse(new TextDecoder().decode(raw));
+}
+
+Deno.test(".ozx consolidates by default and can skip", async () => {
+  const multiscales = await fixture("0.5");
+
+  const consolidatedZip = await toOmeZarrOzxData(multiscales);
+  const consolidatedRoot = await ozxRoot(consolidatedZip);
+  const block = consolidatedRoot.consolidated_metadata as
+    | Record<string, unknown>
+    | undefined;
+  assert(
+    block !== undefined,
+    ".ozx default write left the store unconsolidated",
+  );
+  assertEquals(Object.keys(block.metadata as object).sort(), [
+    "scale0",
+    "scale1",
+  ]);
+
+  const plainZip = await toOmeZarrOzxData(multiscales, {
+    consolidateMetadata: false,
+  });
+  const plainRoot = await ozxRoot(plainZip);
+  assertFalse("consolidated_metadata" in plainRoot);
+
+  // RFC-9 requires the root document to be the archive's first entry; the
+  // extra root rewrite consolidation performs must not disturb that.
+  assert(readOzxJsonFirst(consolidatedZip), "root zarr.json is not first");
+  assert(readOzxJsonFirst(plainZip), "root zarr.json is not first");
+});
+
+Deno.test("toOmeZarr consolidates a filesystem store", async () => {
+  const multiscales = await fixture("0.5");
+  const path = join(OUTPUT_DIR, "consolidated.ome.zarr");
+  await Deno.remove(path, { recursive: true }).catch(() => {});
+  await toOmeZarr(path, multiscales, { version: "0.5" });
+
+  const root = JSON.parse(await Deno.readTextFile(join(path, "zarr.json")));
+  assertEquals(
+    Object.keys(root.consolidated_metadata.metadata).sort(),
+    ["scale0", "scale1"],
+  );
+
+  const plainPath = join(OUTPUT_DIR, "unconsolidated.ome.zarr");
+  await Deno.remove(plainPath, { recursive: true }).catch(() => {});
+  await toOmeZarr(plainPath, multiscales, {
+    version: "0.5",
+    consolidateMetadata: false,
+  });
+  const plainRoot = JSON.parse(
+    await Deno.readTextFile(join(plainPath, "zarr.json")),
+  );
+  assertFalse("consolidated_metadata" in plainRoot);
+});

--- a/ts/test/consolidate_metadata_test.ts
+++ b/ts/test/consolidate_metadata_test.ts
@@ -22,6 +22,10 @@ import {
 } from "../src/mod.ts";
 import { readOzxJsonFirst } from "../src/io/rfc9_zip.ts";
 import {
+  consolidateMetadata,
+  datasetNodePaths,
+} from "../src/utils/consolidate_metadata.ts";
+import {
   createAxis,
   createDataset,
   createMetadata,
@@ -197,6 +201,38 @@ Deno.test("in-place upgradeOmeZarr refreshes consolidated metadata", async () =>
   ]);
 });
 
+// A store holds nodes the multiscales metadata never names -- an OME-Zarr
+// `labels` group is the everyday case. A consolidated block is authoritative
+// for what a reader finds, so a refresh that listed only the dataset paths
+// would hide such a node even though its document is untouched. Python
+// re-globs the whole store and so never loses it.
+Deno.test("in-place upgradeOmeZarr keeps a non-dataset child node", async () => {
+  const multiscales = await fixture("0.5");
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.5" });
+
+  // Add a sibling group and consolidate it in, as a Python-written store
+  // carrying labels would arrive.
+  await zarr.create(zarr.root(store).resolve("labels"), {
+    attributes: { labels: ["cells"] },
+  });
+  await consolidateMetadata(store, ["labels", "scale0", "scale1"]);
+
+  await upgradeOmeZarr(store, { version: "0.6" });
+
+  const block = consolidatedBlock(store);
+  assert(block !== undefined, "the re-tag de-consolidated the store");
+  const inlined = block.metadata as Record<string, Record<string, unknown>>;
+  assertEquals(Object.keys(inlined).sort(), ["labels", "scale0", "scale1"]);
+  assertEquals(inlined.labels.node_type, "group");
+  // A group entry is marked (vacuously) consolidated, as zarr-python does.
+  assertEquals(inlined.labels.consolidated_metadata, {
+    kind: "inline",
+    must_understand: false,
+    metadata: {},
+  });
+});
+
 Deno.test("in-place upgradeOmeZarr leaves an unconsolidated store alone", async () => {
   const multiscales = await fixture("0.5");
   const store: MemoryStore = new Map();
@@ -269,4 +305,69 @@ Deno.test("toOmeZarr consolidates a filesystem store", async () => {
     await Deno.readTextFile(join(plainPath, "zarr.json")),
   );
   assertFalse("consolidated_metadata" in plainRoot);
+});
+
+Deno.test("datasetNodePaths walks each dataset path's ancestors", () => {
+  // A flat pyramid is its own node list.
+  assertEquals(datasetNodePaths(["scale0", "scale1"]), ["scale0", "scale1"]);
+
+  // A nested path makes every ancestor a node in its own right, deduplicated
+  // across the datasets that share it, and sorted.
+  assertEquals(datasetNodePaths(["images/scale1", "images/scale0"]), [
+    "images",
+    "images/scale0",
+    "images/scale1",
+  ]);
+  assertEquals(datasetNodePaths(["a/b/c"]), ["a", "a/b", "a/b/c"]);
+
+  // Empty segments (a trailing or doubled slash) are not nodes.
+  assertEquals(datasetNodePaths(["scale0/"]), ["scale0"]);
+  assertEquals(datasetNodePaths(["images//scale0"]), [
+    "images",
+    "images/scale0",
+  ]);
+  assertEquals(datasetNodePaths([]), []);
+});
+
+// The writer creates the array document for a nested dataset path but no
+// document for the group above it, so that ancestor is not a node in the store
+// and consolidation does not invent an entry pointing at nothing. (A Zarr v3
+// hierarchy is supposed to carry that group document; the writer not making
+// one is a separate, pre-existing gap.)
+Deno.test("consolidation skips an ancestor the writer never materialized", async () => {
+  const seed: MemoryStore = new Map();
+  const array = await zarr.create(zarr.root(seed).resolve("seed"), {
+    shape: SHAPE,
+    chunk_shape: SHAPE,
+    data_type: "uint16" as zarr.DataType,
+    fill_value: 0,
+  });
+  const image = new NgffImage({
+    data: array,
+    dims: ["y", "x"],
+    scale: { y: 1, x: 1 },
+    translation: { y: 0, x: 0 },
+    name: "nested-fixture",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+  const axes = [
+    createAxis("y", "space", "micrometer"),
+    createAxis("x", "space", "micrometer"),
+  ];
+  const metadata = createMetadata(
+    axes,
+    [createDataset("images/scale0", [1, 1], [0, 0])],
+    "nested-fixture",
+    "0.5",
+  );
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, createNgffMultiscales([image], metadata), {
+    version: "0.5",
+  });
+
+  assertFalse(store.has("/images/zarr.json"));
+  const block = consolidatedBlock(store);
+  assert(block !== undefined, "nested write left the store unconsolidated");
+  assertEquals(Object.keys(block.metadata as object), ["images/scale0"]);
 });


### PR DESCRIPTION
TypeScript counterpart to #737, which gave the Python `to_ome_zarr` a `consolidate_metadata` kwarg so a store bound for a backend that runs its own consolidation can skip it. Icechunk rejects a consolidated block outright — that is the motivating case in #698.

## The flag had nothing to switch off

The TypeScript writer never consolidated. zarrita writes node documents but has no consolidation API: it exports the `withConsolidated` / `tryWithConsolidated` readers and nothing that writes the block. So a bare `consolidateMetadata` option would have been a no-op, and reaching parity meant writing the block first.

`ts/src/utils/consolidate_metadata.ts` assembles it from the documents the writer just wrote, mirroring `_zarrista_utils.consolidate_metadata` and therefore what `zarr.consolidate_metadata` produces:

- array entries carry the `attributes` and `storage_transformers` defaults zarr-python always materializes;
- a nested dataset path gives each ancestor group its own (vacuously consolidated) entry;
- a node without a document of its own is skipped rather than invented.

Verified against a Python-written baseline (`py/test/data/baseline/zarr3/v0.5/cthead1/2_4/`): block shape, `kind`, `must_understand` and the per-entry fields all match. The only differences trace to the pre-existing dataset-path divergence between the two writers (`scale0/image` in Python, flat `scale0` in TypeScript).

## What changed

- **`toOmeZarr`** (Node and browser) takes `consolidateMetadata?: boolean`, default `true` to match Python. Pass `false` to skip it.
- **`toOmeZarrOzx` / `toOmeZarrOzxData`** take the same option. The root key keeps its position in the store map, so RFC-9's root-document-first ordering still holds — asserted in the tests.
- **`upgradeOmeZarrImpl`** restores consolidation after the in-place root rewrite when the source had it, matching the refresh Python's `upgrade_ome_zarr` does. This is not optional: `zarr.create` replaces the root document wholesale, so without it the new default would make a re-tag silently de-consolidate the store.
- **`docs/typescript.md`** documents the option.
- **`ts/test/consolidate_metadata_test.ts`** — 9 tests mirroring `py/test/test_consolidate_metadata.py`.

## Two notes for review

**No zarr-v2 stale-sidecar guard.** Python needs one because a v2 store keeps consolidated metadata in a separate `.zmetadata` sidecar that an in-place write would leave stale. The TypeScript writer emits Zarr v3 documents only — even for `version: "0.4"`, which writes v3 documents with v0.4 attributes (a pre-existing gap, untouched here). A v3 write replaces the root document wholesale, so re-writing a consolidated store with `consolidateMetadata: false` leaves it unconsolidated rather than stale. That is the same v3 reasoning #737 relies on, and it is covered by a test.

**`fromOmeZarr` does not yet benefit.** zarrita 0.6.1's `withConsolidated` reads only the Zarr v2 `.zmetadata` sidecar, which this writer never emits — checked in the resolved source, not assumed. The block is written for the readers that do use it, zarr-python and hence the Python package among them, which is what keeps the two implementations' output equivalent. Teaching the TypeScript reader to use the v3 block is a separate follow-up; the docs say so plainly rather than overclaiming.

## Testing

- `deno test` — 751 passed, 0 failed
- `deno task test:node` — 9 passed
- `deno task test:browser:bundle` — 105 passed (chromium, firefox, webkit, mobile)
- `deno fmt --check`, `deno lint`, `deno check src/mod.ts src/browser-mod.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiX3FqpNZFH8Hr2P4xDe8s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable metadata consolidation for OME-Zarr writers, enabled by default.
  * Added support for opting out of consolidation when writing standard and `.ozx` datasets.
  * Added metadata consolidation support across browser, ZIP, in-memory, and filesystem outputs.
  * Preserved and refreshed consolidated metadata during compatible dataset upgrades.

* **Documentation**
  * Documented the `consolidateMetadata` option, defaults, compatibility, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->