### PR TITLE
fix(py): carry RFC-4 orientation onto the image on read

### DIFF
--- a/py/ngff_zarr/rfc4.py
+++ b/py/ngff_zarr/rfc4.py
@@ -8,6 +8,7 @@ to OME-NGFF axes, based on the LinkML schema.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Literal
@@ -330,6 +331,39 @@ def anatomical_orientation_to_itk_direction(
             col[axis_index] = -1.0
             return col
     return None
+
+
+def axes_orientations_from_axes(
+    axes: Sequence[object],
+) -> dict[str, AnatomicalOrientation] | None:
+    """Anatomical orientations declared on axes (dataclasses or raw dicts), by name.
+
+    Only an anatomical orientation with a value from the RFC 4 vocabulary is
+    returned; ``None`` when no axis declares one.
+    """
+    orientations: dict[str, AnatomicalOrientation] = {}
+    for axis in axes:
+        if isinstance(axis, dict):
+            name = axis.get("name")
+            orientation = axis.get("orientation")
+        else:
+            name = getattr(axis, "name", None)
+            orientation = getattr(axis, "orientation", None)
+        if not isinstance(name, str) or orientation is None:
+            continue
+        if isinstance(orientation, AnatomicalOrientation):
+            orientations[name] = orientation
+            continue
+        if not isinstance(orientation, dict):
+            continue
+        if orientation.get("type") != "anatomical":
+            continue
+        try:
+            value = AnatomicalOrientationValues(orientation.get("value"))
+        except (TypeError, ValueError):
+            continue
+        orientations[name] = AnatomicalOrientation(value=value)
+    return orientations or None
 
 
 def add_anatomical_orientation_to_axis(

--- a/py/ngff_zarr/v04/zarr_metadata.py
+++ b/py/ngff_zarr/v04/zarr_metadata.py
@@ -10,7 +10,7 @@ from .._store_types import StoreLike
 from .._supported_versions import NgffVersion
 
 # Import RFC 4 support
-from ..rfc4 import AnatomicalOrientation
+from ..rfc4 import AnatomicalOrientation, axes_orientations_from_axes
 
 if TYPE_CHECKING:
     from ..ngff_image import NgffImage
@@ -533,6 +533,8 @@ class Metadata:
                     if name is not None and unit is not None:
                         units[name] = unit
 
+        axes_orientations = axes_orientations_from_axes(axes)
+
         images = []
         datasets = []
         for dataset in root_attrs["datasets"]:
@@ -578,6 +580,7 @@ class Metadata:
                 translation=translation,
                 name=root_attrs.get("name", "image"),
                 axes_units=units,
+                axes_orientations=axes_orientations,
                 axes_types=non_default_axes_types(axes),
             )
             images.append(ngff_image)

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -35,7 +35,7 @@ from .._supported_versions import (
     V06_SUPERSEDED_TAGS,
     NgffVersion,
 )
-from ..rfc4 import AnatomicalOrientation
+from ..rfc4 import AnatomicalOrientation, axes_orientations_from_axes
 from ..v04.zarr_metadata import (
     AxesType as AxesTypeV04,
 )
@@ -983,6 +983,7 @@ class Metadata:
                 translation=dict(zip(dims, translation.translation)),
                 name=root_attrs.get("name", "image"),
                 axes_units=dict(zip(dims, [ax.unit for ax in cs_intrinsic.axes])),
+                axes_orientations=axes_orientations_from_axes(cs_intrinsic.axes),
                 axes_types=non_default_axes_types(cs_intrinsic.axes),
             )
             images.append(ngff_image)

--- a/py/test/test_rfc4_integration.py
+++ b/py/test/test_rfc4_integration.py
@@ -2,13 +2,21 @@
 # SPDX-License-Identifier: MIT
 """Integration test for RFC 4 anatomical orientation."""
 
+import json
 import tempfile
 from pathlib import Path
 
 import numpy as np
 import pytest
 import zarr
-from ngff_zarr import LPS, RAS, NgffImage, to_multiscales, to_ngff_zarr
+from ngff_zarr import (
+    LPS,
+    RAS,
+    NgffImage,
+    from_ngff_zarr,
+    to_multiscales,
+    to_ngff_zarr,
+)
 from ngff_zarr.rfc4 import AnatomicalOrientation, AnatomicalOrientationValues
 from packaging import version
 
@@ -316,3 +324,77 @@ def test_rfc4_legacy_enabled_rfcs_kwarg_rejected():
             to_ngff_zarr(
                 store=str(store_path), multiscales=multiscales, enabled_rfcs=[4]
             )
+
+
+def _write_oriented_store(store_path, orientations, version):
+    data = np.random.rand(4, 8, 12).astype(np.float32)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"x": 1.0, "y": 1.0, "z": 1.0},
+        translation={"x": 0.0, "y": 0.0, "z": 0.0},
+        axes_orientations=orientations,
+    )
+    multiscales = to_multiscales(ngff_image, scale_factors=[2])
+    to_ngff_zarr(store=str(store_path), multiscales=multiscales, version=version)
+
+
+@pytest.mark.parametrize("version", ["0.4", "0.5"])
+@pytest.mark.parametrize("orientations", [LPS, RAS], ids=["LPS", "RAS"])
+def test_from_ngff_zarr_reads_orientation_into_image(orientations, version):
+    """The orientation written to a store comes back on every ``NgffImage``."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+        _write_oriented_store(store_path, orientations, version)
+
+        multiscales_back = from_ngff_zarr(str(store_path), validate=True)
+
+    assert len(multiscales_back.images) == 2
+    for image in multiscales_back.images:
+        assert image.axes_orientations is not None
+        assert set(image.axes_orientations) == {"x", "y", "z"}
+        for dim, expected in orientations.items():
+            orientation = image.axes_orientations[dim]
+            assert isinstance(orientation, AnatomicalOrientation)
+            assert orientation.type == "anatomical"
+            assert orientation.value == expected.value
+
+
+def test_from_ngff_zarr_leaves_orientation_unset_when_absent():
+    """No orientation on disk means ``axes_orientations`` stays ``None``."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+        _write_oriented_store(store_path, None, "0.4")
+
+        multiscales_back = from_ngff_zarr(str(store_path))
+
+    for image in multiscales_back.images:
+        assert image.axes_orientations is None
+
+
+def test_from_ngff_zarr_skips_malformed_orientation_without_validation():
+    """Only well-formed anatomical orientations reach the image; the raw entry stays on ``metadata.axes``."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+        _write_oriented_store(store_path, LPS, "0.4")
+
+        zattrs_path = store_path / ".zattrs"
+        attrs = json.loads(zattrs_path.read_text())
+        axes = attrs["multiscales"][0]["axes"]
+        for axis in axes:
+            if axis["name"] == "x":
+                axis["orientation"]["value"] = "not-an-orientation"
+            elif axis["name"] == "y":
+                axis["orientation"]["type"] = "cardinal"
+        zattrs_path.write_text(json.dumps(attrs))
+
+        multiscales_back = from_ngff_zarr(str(store_path), validate=False)
+
+    image = multiscales_back.images[0]
+    assert image.axes_orientations == {
+        "z": AnatomicalOrientation(
+            value=AnatomicalOrientationValues.inferior_to_superior
+        )
+    }
+    raw_x = next(a for a in multiscales_back.metadata.axes if a.name == "x")
+    assert raw_x.orientation == {"type": "anatomical", "value": "not-an-orientation"}


### PR DESCRIPTION
`from_ome_zarr` left `NgffImage.axes_orientations` unset and only kept the raw axis entry on `metadata.axes`, so `ngff_image_to_itk_image` built an identity direction for a store that declares its orientation. The TypeScript reader already fills `axesOrientations`.

- `rfc4.axes_orientations_from_axes` derives the orientations from the parsed axes; only an anatomical orientation with a value from the RFC 4 vocabulary is carried, the raw entry stays on `metadata.axes` for validation.
- The v0.4 and v0.6 readers pass it to every `NgffImage`.
- Tests: LPS and RAS read back at 0.4 and 0.5, the absent case, and a malformed orientation read without validation.

Full Python suite: 1549 passed, 5 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reading RFC 4 anatomical axis orientations from OME-Zarr 0.4 and 0.5 metadata.
  - Propagated recognized axis orientations to associated images during metadata loading.
  - Supports orientation data provided in standard axis metadata formats.

- **Bug Fixes**
  - Invalid, unsupported, or incomplete orientation entries are safely ignored during non-validating reads.
  - Images remain without orientation data when no valid orientations are present.

- **Tests**
  - Added integration coverage for orientation round-tripping and malformed metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->